### PR TITLE
feat: 알림 템플릿 & 약관 관리 페이지 추가

### DIFF
--- a/apps/hammer-system/src/apps/ui/AppRouter.tsx
+++ b/apps/hammer-system/src/apps/ui/AppRouter.tsx
@@ -12,12 +12,16 @@ const pageImports = {
   notFound: () => import("@/pages/not-found"),
   overview: () => import("@/pages/overview"),
   logExplorer: () => import("@/pages/log-explorer"),
+  notificationTemplates: () => import("@/pages/notification-templates"),
+  legalDocuments: () => import("@/pages/legal-documents"),
 };
 
 const AuthLoginPage = lazy(pageImports.authLogin);
 const NotFoundPage = lazy(pageImports.notFound);
 const OverviewPage = lazy(pageImports.overview);
 const LogExplorerPage = lazy(pageImports.logExplorer);
+const NotificationTemplatesPage = lazy(pageImports.notificationTemplates);
+const LegalDocumentsPage = lazy(pageImports.legalDocuments);
 
 const GuestOnly = ({ children }: { children: React.ReactNode }) => {
   if (getAccessToken()) {
@@ -110,6 +114,22 @@ export const AppRouter = () => {
           element={
             <Shell>
               <LogExplorerPage />
+            </Shell>
+          }
+        />
+        <Route
+          path={RoutesConfig.NOTIFICATION_TEMPLATE.LIST}
+          element={
+            <Shell>
+              <NotificationTemplatesPage />
+            </Shell>
+          }
+        />
+        <Route
+          path={RoutesConfig.LEGAL_DOCUMENT.LIST}
+          element={
+            <Shell>
+              <LegalDocumentsPage />
             </Shell>
           }
         />

--- a/apps/hammer-system/src/apps/ui/NavItems.tsx
+++ b/apps/hammer-system/src/apps/ui/NavItems.tsx
@@ -1,4 +1,9 @@
-import { DashboardOutlined, SearchOutlined } from "hobom-design-system/icons";
+import {
+  DashboardOutlined,
+  SearchOutlined,
+  NotificationsNoneOutlined,
+  GavelOutlined,
+} from "hobom-design-system/icons";
 import { RoutesConfig } from "@/shared/config";
 import type { NavEntry } from "@/shared/ui";
 
@@ -14,5 +19,17 @@ export const NAV_ITEMS: NavEntry[] = [
     label: "Log Explorer",
     path: RoutesConfig.DASHBOARD.LOG_EXPLORER,
     icon: <SearchOutlined fontSize="small" />,
+  },
+  {
+    value: "NOTIFICATION_TEMPLATES",
+    label: "Notification Templates",
+    path: RoutesConfig.NOTIFICATION_TEMPLATE.LIST,
+    icon: <NotificationsNoneOutlined fontSize="small" />,
+  },
+  {
+    value: "LEGAL_DOCUMENTS",
+    label: "Legal Documents",
+    path: RoutesConfig.LEGAL_DOCUMENT.LIST,
+    icon: <GavelOutlined fontSize="small" />,
   },
 ];

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.api.spec.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.api.spec.ts
@@ -1,0 +1,42 @@
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock("@/shared/api", () => ({
+  userHttpClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+const { fetchTerms, fetchPrivacy, postCreateLegalDocument } = await import("./legal-document.api");
+
+describe("legal-document API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetchTerms calls GET /legal/terms", () => {
+    fetchTerms();
+
+    expect(mockGet).toHaveBeenCalledWith("/legal/terms");
+  });
+
+  it("fetchPrivacy calls GET /legal/privacy", () => {
+    fetchPrivacy();
+
+    expect(mockGet).toHaveBeenCalledWith("/legal/privacy");
+  });
+
+  it("postCreateLegalDocument calls POST /internal/legal with body", () => {
+    const data = {
+      type: 1 as const,
+      version: "1.0",
+      effectiveDate: "2026-04-01",
+      content: "# Terms of Service",
+    };
+
+    postCreateLegalDocument(data);
+
+    expect(mockPost).toHaveBeenCalledWith("/internal/legal", data);
+  });
+});

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.api.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.api.ts
@@ -1,0 +1,11 @@
+import { userHttpClient } from "@/shared/api";
+import type { LegalDocumentResponse, CreateLegalDocumentRequest } from "./legal-document.type";
+
+export const fetchTerms = () =>
+  userHttpClient.get<LegalDocumentResponse>("/legal/terms");
+
+export const fetchPrivacy = () =>
+  userHttpClient.get<LegalDocumentResponse>("/legal/privacy");
+
+export const postCreateLegalDocument = (data: CreateLegalDocumentRequest) =>
+  userHttpClient.post<LegalDocumentResponse>("/internal/legal", data);

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.mutations.spec.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.mutations.spec.ts
@@ -1,0 +1,37 @@
+const postCreateMock = vi.fn();
+
+vi.mock("./legal-document.api", () => ({
+  postCreateLegalDocument: (...args: unknown[]) => postCreateMock(...args),
+}));
+
+const { legalDocumentMutations } = await import("./legal-document.mutations");
+
+describe("legalDocumentMutations", () => {
+  describe("mutationKey structure", () => {
+    it("all() returns base key", () => {
+      expect(legalDocumentMutations.all()).toEqual(["legal-documents"]);
+    });
+
+    it("create() key extends base", () => {
+      expect(legalDocumentMutations.create().mutationKey).toEqual([
+        "legal-documents",
+        "create",
+      ]);
+    });
+  });
+
+  describe("mutationFn delegation", () => {
+    it("create delegates to postCreateLegalDocument", () => {
+      const data = {
+        type: 2 as const,
+        version: "2.0",
+        effectiveDate: "2026-05-01",
+        content: "# Privacy Policy",
+      };
+
+      legalDocumentMutations.create().mutationFn(data);
+
+      expect(postCreateMock).toHaveBeenCalledWith(data);
+    });
+  });
+});

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.mutations.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.mutations.ts
@@ -1,0 +1,12 @@
+import { mutationOptions } from "hobom-data";
+import { postCreateLegalDocument } from "./legal-document.api";
+
+export const legalDocumentMutations = {
+  all: () => ["legal-documents"] as const,
+
+  create: () =>
+    mutationOptions({
+      mutationKey: [...legalDocumentMutations.all(), "create"] as const,
+      mutationFn: postCreateLegalDocument,
+    }),
+} as const;

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.queries.spec.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.queries.spec.ts
@@ -1,0 +1,61 @@
+const fetchTermsMock = vi.fn();
+const fetchPrivacyMock = vi.fn();
+
+vi.mock("./legal-document.api", () => ({
+  fetchTerms: (...args: unknown[]) => fetchTermsMock(...args),
+  fetchPrivacy: (...args: unknown[]) => fetchPrivacyMock(...args),
+}));
+
+const { legalDocumentQueries } = await import("./legal-document.queries");
+
+describe("legalDocumentQueries", () => {
+  describe("queryKey structure", () => {
+    it("all() returns base key", () => {
+      expect(legalDocumentQueries.all()).toEqual(["legal-documents"]);
+    });
+
+    it("terms() includes 'terms' in key", () => {
+      expect(legalDocumentQueries.terms().queryKey).toEqual(["legal-documents", "terms"]);
+    });
+
+    it("privacy() includes 'privacy' in key", () => {
+      expect(legalDocumentQueries.privacy().queryKey).toEqual(["legal-documents", "privacy"]);
+    });
+  });
+
+  describe("queryFn delegation", () => {
+    it("terms queryFn calls fetchTerms", () => {
+      const opts = legalDocumentQueries.terms();
+
+      opts.queryFn({
+        queryKey: opts.queryKey,
+        signal: new AbortController().signal,
+        meta: undefined,
+      });
+
+      expect(fetchTermsMock).toHaveBeenCalled();
+    });
+
+    it("privacy queryFn calls fetchPrivacy", () => {
+      const opts = legalDocumentQueries.privacy();
+
+      opts.queryFn({
+        queryKey: opts.queryKey,
+        signal: new AbortController().signal,
+        meta: undefined,
+      });
+
+      expect(fetchPrivacyMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("staleTime configuration", () => {
+    it("terms has 5min staleTime (SLOW)", () => {
+      expect(legalDocumentQueries.terms().staleTime).toBe(300_000);
+    });
+
+    it("privacy has 5min staleTime (SLOW)", () => {
+      expect(legalDocumentQueries.privacy().staleTime).toBe(300_000);
+    });
+  });
+});

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.queries.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.queries.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from "hobom-data";
+import { CACHE_PROFILE } from "@/shared/config";
+import { fetchTerms, fetchPrivacy } from "./legal-document.api";
+
+export const legalDocumentQueries = {
+  all: () => ["legal-documents"],
+
+  terms: () =>
+    queryOptions({
+      queryKey: ["legal-documents", "terms"],
+      queryFn: fetchTerms,
+      ...CACHE_PROFILE.SLOW,
+    }),
+
+  privacy: () =>
+    queryOptions({
+      queryKey: ["legal-documents", "privacy"],
+      queryFn: fetchPrivacy,
+      ...CACHE_PROFILE.SLOW,
+    }),
+} as const;

--- a/apps/hammer-system/src/entities/legal-document/api/legal-document.type.ts
+++ b/apps/hammer-system/src/entities/legal-document/api/legal-document.type.ts
@@ -1,0 +1,18 @@
+/**
+ * 1 = TermsOfService (이용약관)
+ * 2 = PrivacyPolicy (개인정보처리방침)
+ */
+export type LegalDocumentKind = 1 | 2;
+
+export interface LegalDocumentResponse {
+  version: string;
+  effectiveDate: string;
+  content: string;
+}
+
+export interface CreateLegalDocumentRequest {
+  type: LegalDocumentKind;
+  version: string;
+  effectiveDate: string;
+  content: string;
+}

--- a/apps/hammer-system/src/entities/legal-document/index.ts
+++ b/apps/hammer-system/src/entities/legal-document/index.ts
@@ -1,0 +1,8 @@
+export { legalDocumentQueries } from "./api/legal-document.queries";
+export { legalDocumentMutations } from "./api/legal-document.mutations";
+
+export type {
+  LegalDocumentKind,
+  LegalDocumentResponse,
+  CreateLegalDocumentRequest,
+} from "./api/legal-document.type";

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.api.spec.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.api.spec.ts
@@ -1,0 +1,77 @@
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/shared/api", () => ({
+  supportHttpClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+const {
+  fetchNotificationTemplates,
+  fetchNotificationTemplate,
+  postCreateNotificationTemplate,
+  putUpdateNotificationTemplate,
+  deleteNotificationTemplate,
+} = await import("./notification-template.api");
+
+describe("notification-template API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetchNotificationTemplates calls GET /api/notification-templates", () => {
+    fetchNotificationTemplates();
+
+    expect(mockGet).toHaveBeenCalledWith("/api/notification-templates");
+  });
+
+  it("fetchNotificationTemplate calls GET /api/notification-templates/:id", () => {
+    fetchNotificationTemplate("tmpl-123");
+
+    expect(mockGet).toHaveBeenCalledWith("/api/notification-templates/tmpl-123");
+  });
+
+  it("postCreateNotificationTemplate calls POST /api/notification-templates with body", () => {
+    const data = {
+      templateKey: "auction_new",
+      titleTemplate: "New Auction",
+      bodyTemplate: "Body",
+      channel: "Push" as const,
+    };
+
+    postCreateNotificationTemplate(data);
+
+    expect(mockPost).toHaveBeenCalledWith("/api/notification-templates", data);
+  });
+
+  it("putUpdateNotificationTemplate calls PUT /api/notification-templates/:id with body", () => {
+    const payload = {
+      id: "tmpl-456",
+      templateKey: "auction_updated",
+      titleTemplate: "Updated",
+      bodyTemplate: "Updated Body",
+      channel: "Both" as const,
+    };
+
+    putUpdateNotificationTemplate(payload);
+
+    expect(mockPut).toHaveBeenCalledWith("/api/notification-templates/tmpl-456", {
+      templateKey: "auction_updated",
+      titleTemplate: "Updated",
+      bodyTemplate: "Updated Body",
+      channel: "Both",
+    });
+  });
+
+  it("deleteNotificationTemplate calls DELETE /api/notification-templates/:id", () => {
+    deleteNotificationTemplate("tmpl-789");
+
+    expect(mockDelete).toHaveBeenCalledWith("/api/notification-templates/tmpl-789");
+  });
+});

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.api.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.api.ts
@@ -1,0 +1,24 @@
+import { supportHttpClient } from "@/shared/api";
+import type {
+  NotificationTemplateType,
+  CreateNotificationTemplateRequest,
+  UpdateNotificationTemplateRequest,
+} from "./notification-template.type";
+
+export const fetchNotificationTemplates = () =>
+  supportHttpClient.get<NotificationTemplateType[]>("/api/notification-templates");
+
+export const fetchNotificationTemplate = (id: string) =>
+  supportHttpClient.get<NotificationTemplateType>(`/api/notification-templates/${id}`);
+
+export const postCreateNotificationTemplate = (data: CreateNotificationTemplateRequest) =>
+  supportHttpClient.post<NotificationTemplateType>("/api/notification-templates", data);
+
+export const putUpdateNotificationTemplate = ({
+  id,
+  ...data
+}: UpdateNotificationTemplateRequest & { id: string }) =>
+  supportHttpClient.put<NotificationTemplateType>(`/api/notification-templates/${id}`, data);
+
+export const deleteNotificationTemplate = (id: string) =>
+  supportHttpClient.delete<void>(`/api/notification-templates/${id}`);

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.mutations.spec.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.mutations.spec.ts
@@ -1,0 +1,75 @@
+const postCreateMock = vi.fn();
+const putUpdateMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock("./notification-template.api", () => ({
+  postCreateNotificationTemplate: (...args: unknown[]) => postCreateMock(...args),
+  putUpdateNotificationTemplate: (...args: unknown[]) => putUpdateMock(...args),
+  deleteNotificationTemplate: (...args: unknown[]) => deleteMock(...args),
+}));
+
+const { notificationTemplateMutations } = await import("./notification-template.mutations");
+
+describe("notificationTemplateMutations", () => {
+  describe("mutationKey structure", () => {
+    it("all() returns base key", () => {
+      expect(notificationTemplateMutations.all()).toEqual(["notification-templates"]);
+    });
+
+    it("create() key extends base", () => {
+      expect(notificationTemplateMutations.create().mutationKey).toEqual([
+        "notification-templates",
+        "create",
+      ]);
+    });
+
+    it("update() key extends base", () => {
+      expect(notificationTemplateMutations.update().mutationKey).toEqual([
+        "notification-templates",
+        "update",
+      ]);
+    });
+
+    it("delete() key extends base", () => {
+      expect(notificationTemplateMutations.delete().mutationKey).toEqual([
+        "notification-templates",
+        "delete",
+      ]);
+    });
+  });
+
+  describe("mutationFn delegation", () => {
+    it("create delegates to postCreateNotificationTemplate", () => {
+      const data = {
+        templateKey: "test",
+        titleTemplate: "title",
+        bodyTemplate: "body",
+        channel: "Push" as const,
+      };
+
+      notificationTemplateMutations.create().mutationFn(data);
+
+      expect(postCreateMock).toHaveBeenCalledWith(data);
+    });
+
+    it("update delegates to putUpdateNotificationTemplate", () => {
+      const data = {
+        id: "123",
+        templateKey: "test",
+        titleTemplate: "title",
+        bodyTemplate: "body",
+        channel: "InApp" as const,
+      };
+
+      notificationTemplateMutations.update().mutationFn(data);
+
+      expect(putUpdateMock).toHaveBeenCalledWith(data);
+    });
+
+    it("delete delegates to deleteNotificationTemplate", () => {
+      notificationTemplateMutations.delete().mutationFn("id-to-delete");
+
+      expect(deleteMock).toHaveBeenCalledWith("id-to-delete");
+    });
+  });
+});

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.mutations.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.mutations.ts
@@ -1,0 +1,28 @@
+import { mutationOptions } from "hobom-data";
+import {
+  postCreateNotificationTemplate,
+  putUpdateNotificationTemplate,
+  deleteNotificationTemplate,
+} from "./notification-template.api";
+
+export const notificationTemplateMutations = {
+  all: () => ["notification-templates"] as const,
+
+  create: () =>
+    mutationOptions({
+      mutationKey: [...notificationTemplateMutations.all(), "create"] as const,
+      mutationFn: postCreateNotificationTemplate,
+    }),
+
+  update: () =>
+    mutationOptions({
+      mutationKey: [...notificationTemplateMutations.all(), "update"] as const,
+      mutationFn: putUpdateNotificationTemplate,
+    }),
+
+  delete: () =>
+    mutationOptions({
+      mutationKey: [...notificationTemplateMutations.all(), "delete"] as const,
+      mutationFn: deleteNotificationTemplate,
+    }),
+} as const;

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.queries.spec.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.queries.spec.ts
@@ -1,0 +1,41 @@
+const fetchNotificationTemplatesMock = vi.fn();
+
+vi.mock("./notification-template.api", () => ({
+  fetchNotificationTemplates: (...args: unknown[]) => fetchNotificationTemplatesMock(...args),
+}));
+
+const { notificationTemplateQueries } = await import("./notification-template.queries");
+
+describe("notificationTemplateQueries", () => {
+  describe("queryKey structure", () => {
+    it("all() returns base key", () => {
+      expect(notificationTemplateQueries.all()).toEqual(["notification-templates"]);
+    });
+
+    it("list() includes 'list' in key", () => {
+      const opts = notificationTemplateQueries.list();
+
+      expect(opts.queryKey).toEqual(["notification-templates", "list"]);
+    });
+  });
+
+  describe("queryFn delegation", () => {
+    it("list queryFn calls fetchNotificationTemplates", () => {
+      const opts = notificationTemplateQueries.list();
+
+      opts.queryFn({
+        queryKey: opts.queryKey,
+        signal: new AbortController().signal,
+        meta: undefined,
+      });
+
+      expect(fetchNotificationTemplatesMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("staleTime configuration", () => {
+    it("list has 5min staleTime (SLOW)", () => {
+      expect(notificationTemplateQueries.list().staleTime).toBe(300_000);
+    });
+  });
+});

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.queries.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.queries.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from "hobom-data";
+import { CACHE_PROFILE } from "@/shared/config";
+import { fetchNotificationTemplates } from "./notification-template.api";
+
+export const notificationTemplateQueries = {
+  all: () => ["notification-templates"],
+
+  list: () =>
+    queryOptions({
+      queryKey: ["notification-templates", "list"],
+      queryFn: fetchNotificationTemplates,
+      ...CACHE_PROFILE.SLOW,
+    }),
+} as const;

--- a/apps/hammer-system/src/entities/notification-template/api/notification-template.type.ts
+++ b/apps/hammer-system/src/entities/notification-template/api/notification-template.type.ts
@@ -1,0 +1,20 @@
+export type NotificationChannel = "Push" | "InApp" | "Both";
+
+export interface NotificationTemplateType {
+  id: string;
+  templateKey: string;
+  titleTemplate: string;
+  bodyTemplate: string;
+  channel: NotificationChannel;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateNotificationTemplateRequest {
+  templateKey: string;
+  titleTemplate: string;
+  bodyTemplate: string;
+  channel: NotificationChannel;
+}
+
+export type UpdateNotificationTemplateRequest = CreateNotificationTemplateRequest;

--- a/apps/hammer-system/src/entities/notification-template/index.ts
+++ b/apps/hammer-system/src/entities/notification-template/index.ts
@@ -1,0 +1,9 @@
+export { notificationTemplateQueries } from "./api/notification-template.queries";
+export { notificationTemplateMutations } from "./api/notification-template.mutations";
+
+export type {
+  NotificationChannel,
+  NotificationTemplateType,
+  CreateNotificationTemplateRequest,
+  UpdateNotificationTemplateRequest,
+} from "./api/notification-template.type";

--- a/apps/hammer-system/src/features/manage-legal-documents/index.ts
+++ b/apps/hammer-system/src/features/manage-legal-documents/index.ts
@@ -1,0 +1,1 @@
+export { LegalDocumentContent } from "./ui/LegalDocumentContent";

--- a/apps/hammer-system/src/features/manage-legal-documents/model/useLegalDocumentForm.ts
+++ b/apps/hammer-system/src/features/manage-legal-documents/model/useLegalDocumentForm.ts
@@ -1,0 +1,44 @@
+import { useForm } from "react-hook-form";
+import { useMutation, useDataLot } from "hobom-data";
+import { useToast } from "@/shared/model";
+import { legalDocumentQueries, legalDocumentMutations } from "@/entities/legal-document";
+import type { CreateLegalDocumentRequest } from "@/entities/legal-document";
+
+interface UseLegalDocumentFormParams {
+  onSuccess: () => void;
+}
+
+const DEFAULT_VALUES: CreateLegalDocumentRequest = {
+  type: 1,
+  version: "",
+  effectiveDate: "",
+  content: "",
+};
+
+export const useLegalDocumentForm = ({ onSuccess }: UseLegalDocumentFormParams) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const formMethods = useForm<CreateLegalDocumentRequest>({
+    mode: "onChange",
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  const createMutation = useMutation(legalDocumentMutations.create());
+
+  const handleSubmit = formMethods.handleSubmit((data) => {
+    createMutation.mutate(data, {
+      onSuccess: () => {
+        dataLot.invalidateQueries({ queryKey: legalDocumentQueries.all() });
+        openSuccessToast({ message: "새 문서 버전이 등록되었어요." });
+        formMethods.reset(DEFAULT_VALUES);
+        onSuccess();
+      },
+      onError: () => {
+        openErrorToast({ message: "문서 등록에 실패했어요." });
+      },
+    });
+  });
+
+  return { formMethods, handleSubmit, isPending: createMutation.isPending };
+};

--- a/apps/hammer-system/src/features/manage-legal-documents/model/useLegalDocumentList.ts
+++ b/apps/hammer-system/src/features/manage-legal-documents/model/useLegalDocumentList.ts
@@ -1,0 +1,13 @@
+import { useSuspenseQueries } from "hobom-data";
+import { legalDocumentQueries } from "@/entities/legal-document";
+
+export const useLegalDocumentList = () => {
+  const [termsResult, privacyResult] = useSuspenseQueries({
+    queries: [legalDocumentQueries.terms(), legalDocumentQueries.privacy()],
+  });
+
+  return {
+    terms: termsResult.data,
+    privacy: privacyResult.data,
+  };
+};

--- a/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentCard.tsx
+++ b/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentCard.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { ExpandMore, ExpandLess } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import type { LegalDocumentResponse } from "@/entities/legal-document";
+
+interface LegalDocumentCardProps {
+  title: string;
+  document: LegalDocumentResponse | null;
+}
+
+export const LegalDocumentCard = ({ title, document }: LegalDocumentCardProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!document) {
+    return (
+      <Hb.Card.Root>
+        <Hb.Card.Content>
+          <Hb.Text variant="h6" sx={{ mb: 1 }}>
+            {title}
+          </Hb.Text>
+          <Hb.Text variant="body2" sx={{ color: "text.secondary" }}>
+            등록된 문서가 없어요.
+          </Hb.Text>
+        </Hb.Card.Content>
+      </Hb.Card.Root>
+    );
+  }
+
+  return (
+    <Hb.Card.Root>
+      <Hb.Card.Content>
+        <Hb.Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+          <Hb.Text variant="h6">{title}</Hb.Text>
+          <Hb.Stack direction="row" spacing={1} alignItems="center">
+            <Hb.Chip label={`v${document.version}`} size="small" color="primary" />
+            <Hb.Chip label={document.effectiveDate} size="small" variant="outlined" />
+            <Hb.Button.Icon size="small" onClick={() => setExpanded((prev) => !prev)}>
+              {expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+            </Hb.Button.Icon>
+          </Hb.Stack>
+        </Hb.Box>
+        <Hb.Box
+          sx={{
+            maxHeight: expanded ? "none" : 200,
+            overflow: "auto",
+            p: 2,
+            bgcolor: "action.hover",
+            borderRadius: 1,
+            whiteSpace: "pre-wrap",
+            fontFamily: "monospace",
+            fontSize: 13,
+            transition: "max-height 0.2s ease",
+          }}
+        >
+          {document.content}
+        </Hb.Box>
+      </Hb.Card.Content>
+    </Hb.Card.Root>
+  );
+};

--- a/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentContent.tsx
+++ b/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentContent.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { AddOutlined } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import { useLegalDocumentList } from "../model/useLegalDocumentList";
+import { LegalDocumentCard } from "./LegalDocumentCard";
+import { LegalDocumentFormDialog } from "./LegalDocumentFormDialog";
+
+export const LegalDocumentContent = () => {
+  const { terms, privacy } = useLegalDocumentList();
+  const [formDialogOpen, setFormDialogOpen] = useState(false);
+
+  return (
+    <>
+      <Hb.Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+        <Hb.Button
+          variant="primary"
+          startIcon={<AddOutlined />}
+          onClick={() => setFormDialogOpen(true)}
+        >
+          새 버전 등록
+        </Hb.Button>
+      </Hb.Box>
+
+      <Hb.Stack spacing={3}>
+        <LegalDocumentCard title="이용약관 (Terms of Service)" document={terms} />
+        <LegalDocumentCard title="개인정보처리방침 (Privacy Policy)" document={privacy} />
+      </Hb.Stack>
+
+      <LegalDocumentFormDialog open={formDialogOpen} onClose={() => setFormDialogOpen(false)} />
+    </>
+  );
+};

--- a/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentFormDialog.tsx
+++ b/apps/hammer-system/src/features/manage-legal-documents/ui/LegalDocumentFormDialog.tsx
@@ -1,0 +1,109 @@
+import { FormProvider, Controller } from "react-hook-form";
+import { Hb } from "@/shared/ui";
+import { useLegalDocumentForm } from "../model/useLegalDocumentForm";
+
+interface LegalDocumentFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const DOCUMENT_TYPE_OPTIONS = [
+  { value: 1, label: "이용약관 (Terms of Service)" },
+  { value: 2, label: "개인정보처리방침 (Privacy Policy)" },
+] as const;
+
+export const LegalDocumentFormDialog = ({ open, onClose }: LegalDocumentFormDialogProps) => {
+  const { formMethods, handleSubmit, isPending } = useLegalDocumentForm({
+    onSuccess: onClose,
+  });
+
+  return (
+    <Hb.Dialog.Root open={open} onClose={onClose} size="md">
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit}>
+          <Hb.Dialog.Title>새 문서 버전 등록</Hb.Dialog.Title>
+          <Hb.Dialog.Content>
+            <Hb.Stack spacing={2.5} sx={{ mt: 1 }}>
+              <Controller
+                name="type"
+                render={({ field }) => (
+                  <Hb.TextField
+                    {...field}
+                    select
+                    label="문서 유형"
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  >
+                    {DOCUMENT_TYPE_OPTIONS.map((opt) => (
+                      <Hb.Menu.Item key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </Hb.Menu.Item>
+                    ))}
+                  </Hb.TextField>
+                )}
+              />
+              <Controller
+                name="version"
+                rules={{ required: "버전을 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    label="버전"
+                    placeholder="1.0"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  />
+                )}
+              />
+              <Controller
+                name="effectiveDate"
+                rules={{ required: "시행일을 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    type="date"
+                    label="시행일"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  />
+                )}
+              />
+              <Controller
+                name="content"
+                rules={{ required: "내용을 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    label="내용 (Markdown)"
+                    placeholder="# 이용약관..."
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    multiline
+                    minRows={8}
+                    slotProps={{
+                      inputLabel: { shrink: true },
+                      input: { sx: { fontFamily: "monospace", fontSize: 13 } },
+                    }}
+                  />
+                )}
+              />
+            </Hb.Stack>
+          </Hb.Dialog.Content>
+          <Hb.Dialog.Actions>
+            <Hb.Button variant="ghost" onClick={onClose} disabled={isPending}>
+              취소
+            </Hb.Button>
+            <Hb.Button type="submit" variant="primary" disabled={isPending}>
+              {isPending ? <Hb.Progress.Circular size={20} /> : "등록"}
+            </Hb.Button>
+          </Hb.Dialog.Actions>
+        </form>
+      </FormProvider>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hammer-system/src/features/manage-notification-templates/index.ts
+++ b/apps/hammer-system/src/features/manage-notification-templates/index.ts
@@ -1,0 +1,1 @@
+export { NotificationTemplateContent } from "./ui/NotificationTemplateContent";

--- a/apps/hammer-system/src/features/manage-notification-templates/model/useNotificationTemplateForm.ts
+++ b/apps/hammer-system/src/features/manage-notification-templates/model/useNotificationTemplateForm.ts
@@ -1,0 +1,83 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useMutation, useDataLot } from "hobom-data";
+import { useToast } from "@/shared/model";
+import {
+  notificationTemplateQueries,
+  notificationTemplateMutations,
+} from "@/entities/notification-template";
+import type {
+  NotificationTemplateType,
+  CreateNotificationTemplateRequest,
+} from "@/entities/notification-template";
+
+interface UseNotificationTemplateFormParams {
+  editingTemplate: NotificationTemplateType | null;
+  onSuccess: () => void;
+}
+
+const DEFAULT_VALUES: CreateNotificationTemplateRequest = {
+  templateKey: "",
+  titleTemplate: "",
+  bodyTemplate: "",
+  channel: "Both",
+};
+
+export const useNotificationTemplateForm = ({
+  editingTemplate,
+  onSuccess,
+}: UseNotificationTemplateFormParams) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const formMethods = useForm<CreateNotificationTemplateRequest>({
+    mode: "onChange",
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  useEffect(() => {
+    if (editingTemplate) {
+      formMethods.reset({
+        templateKey: editingTemplate.templateKey,
+        titleTemplate: editingTemplate.titleTemplate,
+        bodyTemplate: editingTemplate.bodyTemplate,
+        channel: editingTemplate.channel,
+      });
+    } else {
+      formMethods.reset(DEFAULT_VALUES);
+    }
+  }, [editingTemplate, formMethods]);
+
+  const createMutation = useMutation(notificationTemplateMutations.create());
+  const updateMutation = useMutation(notificationTemplateMutations.update());
+
+  const isEditing = editingTemplate !== null;
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const handleSubmit = formMethods.handleSubmit((data) => {
+    if (isEditing) {
+      updateMutation.mutate(
+        { id: editingTemplate.id, ...data },
+        {
+          onSuccess: () => {
+            dataLot.invalidateQueries({ queryKey: notificationTemplateQueries.all() });
+            openSuccessToast({ message: "템플릿이 수정되었어요." });
+            onSuccess();
+          },
+          onError: () => openErrorToast({ message: "수정에 실패했어요." }),
+        },
+      );
+    } else {
+      createMutation.mutate(data, {
+        onSuccess: () => {
+          dataLot.invalidateQueries({ queryKey: notificationTemplateQueries.all() });
+          openSuccessToast({ message: "템플릿이 생성되었어요." });
+          onSuccess();
+        },
+        onError: () => openErrorToast({ message: "생성에 실패했어요." }),
+      });
+    }
+  });
+
+  return { formMethods, handleSubmit, isEditing, isPending };
+};

--- a/apps/hammer-system/src/features/manage-notification-templates/model/useNotificationTemplateList.ts
+++ b/apps/hammer-system/src/features/manage-notification-templates/model/useNotificationTemplateList.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useSuspenseQuery, useMutation, useDataLot } from "hobom-data";
+import { useToast } from "@/shared/model";
+import {
+  notificationTemplateQueries,
+  notificationTemplateMutations,
+} from "@/entities/notification-template";
+import type { NotificationTemplateType } from "@/entities/notification-template";
+
+export const useNotificationTemplateList = () => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const { data: templates } = useSuspenseQuery(notificationTemplateQueries.list());
+
+  const [editingTemplate, setEditingTemplate] = useState<NotificationTemplateType | null>(null);
+  const [formDialogOpen, setFormDialogOpen] = useState(false);
+
+  const deleteMutation = useMutation(notificationTemplateMutations.delete());
+
+  const handleDelete = (id: string) => {
+    deleteMutation.mutate(id, {
+      onSuccess: () => {
+        dataLot.invalidateQueries({ queryKey: notificationTemplateQueries.all() });
+        openSuccessToast({ message: "템플릿이 삭제되었어요." });
+      },
+      onError: () => {
+        openErrorToast({ message: "삭제에 실패했어요." });
+      },
+    });
+  };
+
+  const openCreateDialog = () => {
+    setEditingTemplate(null);
+    setFormDialogOpen(true);
+  };
+
+  const openEditDialog = (template: NotificationTemplateType) => {
+    setEditingTemplate(template);
+    setFormDialogOpen(true);
+  };
+
+  const closeFormDialog = () => {
+    setFormDialogOpen(false);
+    setEditingTemplate(null);
+  };
+
+  return {
+    templates,
+    editingTemplate,
+    formDialogOpen,
+    isDeleting: deleteMutation.isPending,
+    handleDelete,
+    openCreateDialog,
+    openEditDialog,
+    closeFormDialog,
+  };
+};

--- a/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateContent.tsx
+++ b/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateContent.tsx
@@ -1,0 +1,44 @@
+import { AddOutlined } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import { DashboardPaper } from "@/entities/analytics";
+import { useNotificationTemplateList } from "../model/useNotificationTemplateList";
+import { NotificationTemplateTable } from "./NotificationTemplateTable";
+import { NotificationTemplateFormDialog } from "./NotificationTemplateFormDialog";
+
+export const NotificationTemplateContent = () => {
+  const {
+    templates,
+    editingTemplate,
+    formDialogOpen,
+    isDeleting,
+    handleDelete,
+    openCreateDialog,
+    openEditDialog,
+    closeFormDialog,
+  } = useNotificationTemplateList();
+
+  return (
+    <>
+      <DashboardPaper>
+        <Hb.Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+          <Hb.Button variant="primary" startIcon={<AddOutlined />} onClick={openCreateDialog}>
+            템플릿 추가
+          </Hb.Button>
+        </Hb.Box>
+
+        <NotificationTemplateTable
+          templates={templates}
+          isDeleting={isDeleting}
+          onEdit={openEditDialog}
+          onDelete={handleDelete}
+        />
+      </DashboardPaper>
+
+      <NotificationTemplateFormDialog
+        open={formDialogOpen}
+        editingTemplate={editingTemplate}
+        onClose={closeFormDialog}
+      />
+    </>
+  );
+};

--- a/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateFormDialog.tsx
+++ b/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateFormDialog.tsx
@@ -1,0 +1,115 @@
+import { FormProvider, Controller } from "react-hook-form";
+import { Hb } from "@/shared/ui";
+import type { NotificationTemplateType } from "@/entities/notification-template";
+import { useNotificationTemplateForm } from "../model/useNotificationTemplateForm";
+
+interface NotificationTemplateFormDialogProps {
+  open: boolean;
+  editingTemplate: NotificationTemplateType | null;
+  onClose: () => void;
+}
+
+const CHANNEL_OPTIONS = [
+  { value: "Both", label: "Push + In-App" },
+  { value: "Push", label: "Push" },
+  { value: "InApp", label: "In-App" },
+] as const;
+
+export const NotificationTemplateFormDialog = ({
+  open,
+  editingTemplate,
+  onClose,
+}: NotificationTemplateFormDialogProps) => {
+  const { formMethods, handleSubmit, isEditing, isPending } = useNotificationTemplateForm({
+    editingTemplate,
+    onSuccess: onClose,
+  });
+
+  return (
+    <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit}>
+          <Hb.Dialog.Title>{isEditing ? "템플릿 수정" : "템플릿 생성"}</Hb.Dialog.Title>
+          <Hb.Dialog.Content>
+            <Hb.Stack spacing={2.5} sx={{ mt: 1 }}>
+              <Controller
+                name="templateKey"
+                rules={{ required: "Template Key를 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    label="Template Key"
+                    placeholder="auction_new_item"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  />
+                )}
+              />
+              <Controller
+                name="titleTemplate"
+                rules={{ required: "Title Template을 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    label="Title Template"
+                    placeholder="새로운 경매 상품: {itemName}"
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message ?? "플레이스홀더: {변수명}"}
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  />
+                )}
+              />
+              <Controller
+                name="bodyTemplate"
+                rules={{ required: "Body Template을 입력해주세요." }}
+                render={({ field, fieldState }) => (
+                  <Hb.TextField
+                    {...field}
+                    label="Body Template"
+                    placeholder="{itemName}에 대한 새로운 경매가 시작되었습니다."
+                    error={!!fieldState.error}
+                    helperText={fieldState.error?.message}
+                    fullWidth
+                    multiline
+                    minRows={3}
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  />
+                )}
+              />
+              <Controller
+                name="channel"
+                render={({ field }) => (
+                  <Hb.TextField
+                    {...field}
+                    select
+                    label="Channel"
+                    fullWidth
+                    slotProps={{ inputLabel: { shrink: true } }}
+                  >
+                    {CHANNEL_OPTIONS.map((opt) => (
+                      <Hb.Menu.Item key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </Hb.Menu.Item>
+                    ))}
+                  </Hb.TextField>
+                )}
+              />
+            </Hb.Stack>
+          </Hb.Dialog.Content>
+          <Hb.Dialog.Actions>
+            <Hb.Button variant="ghost" onClick={onClose} disabled={isPending}>
+              취소
+            </Hb.Button>
+            <Hb.Button type="submit" variant="primary" disabled={isPending}>
+              {isPending && <Hb.Progress.Circular size={20} />}
+              {!isPending && (isEditing ? "수정" : "생성")}
+            </Hb.Button>
+          </Hb.Dialog.Actions>
+        </form>
+      </FormProvider>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateTable.tsx
+++ b/apps/hammer-system/src/features/manage-notification-templates/ui/NotificationTemplateTable.tsx
@@ -1,0 +1,87 @@
+import { EditOutlined, DeleteOutlined } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import type { NotificationTemplateType } from "@/entities/notification-template";
+
+interface NotificationTemplateTableProps {
+  templates: NotificationTemplateType[];
+  isDeleting: boolean;
+  onEdit: (template: NotificationTemplateType) => void;
+  onDelete: (id: string) => void;
+}
+
+const CHANNEL_LABEL: Record<string, string> = {
+  Push: "Push",
+  InApp: "In-App",
+  Both: "Push + In-App",
+};
+
+export const NotificationTemplateTable = ({
+  templates,
+  isDeleting,
+  onEdit,
+  onDelete,
+}: NotificationTemplateTableProps) => {
+  if (templates.length === 0) {
+    return (
+      <Hb.Box sx={{ py: 6, textAlign: "center" }}>
+        <Hb.Text variant="body2" sx={{ color: "text.secondary" }}>
+          등록된 알림 템플릿이 없어요.
+        </Hb.Text>
+      </Hb.Box>
+    );
+  }
+
+  return (
+    <Hb.Table.Container>
+      <Hb.Table.Root size="small">
+        <Hb.Table.Head>
+          <Hb.Table.Row>
+            <Hb.Table.Cell>Template Key</Hb.Table.Cell>
+            <Hb.Table.Cell>Title Template</Hb.Table.Cell>
+            <Hb.Table.Cell>Channel</Hb.Table.Cell>
+            <Hb.Table.Cell>Updated</Hb.Table.Cell>
+            <Hb.Table.Cell align="right">Actions</Hb.Table.Cell>
+          </Hb.Table.Row>
+        </Hb.Table.Head>
+        <Hb.Table.Body>
+          {templates.map((template) => (
+            <Hb.Table.Row key={template.id}>
+              <Hb.Table.Cell>
+                <Hb.Text variant="body2" sx={{ fontWeight: 600, fontFamily: "monospace" }}>
+                  {template.templateKey}
+                </Hb.Text>
+              </Hb.Table.Cell>
+              <Hb.Table.Cell>
+                <Hb.Text variant="body2" sx={{ maxWidth: 300 }} noWrap>
+                  {template.titleTemplate}
+                </Hb.Text>
+              </Hb.Table.Cell>
+              <Hb.Table.Cell>
+                <Hb.Chip label={CHANNEL_LABEL[template.channel] ?? template.channel} size="small" />
+              </Hb.Table.Cell>
+              <Hb.Table.Cell>
+                <Hb.Text variant="body2" sx={{ color: "text.secondary" }}>
+                  {new Date(template.updatedAt).toLocaleDateString("ko-KR")}
+                </Hb.Text>
+              </Hb.Table.Cell>
+              <Hb.Table.Cell align="right">
+                <Hb.Stack direction="row" spacing={0.5} justifyContent="flex-end">
+                  <Hb.Button.Icon size="small" onClick={() => onEdit(template)}>
+                    <EditOutlined fontSize="small" />
+                  </Hb.Button.Icon>
+                  <Hb.Button.Icon
+                    size="small"
+                    disabled={isDeleting}
+                    onClick={() => onDelete(template.id)}
+                  >
+                    <DeleteOutlined fontSize="small" />
+                  </Hb.Button.Icon>
+                </Hb.Stack>
+              </Hb.Table.Cell>
+            </Hb.Table.Row>
+          ))}
+        </Hb.Table.Body>
+      </Hb.Table.Root>
+    </Hb.Table.Container>
+  );
+};

--- a/apps/hammer-system/src/pages/legal-documents/index.ts
+++ b/apps/hammer-system/src/pages/legal-documents/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ui/LegalDocumentsPage";

--- a/apps/hammer-system/src/pages/legal-documents/ui/LegalDocumentsPage.tsx
+++ b/apps/hammer-system/src/pages/legal-documents/ui/LegalDocumentsPage.tsx
@@ -1,0 +1,5 @@
+import { LegalDocumentWorkspace } from "@/widgets/legal-document-workspace";
+
+export default function LegalDocumentsPage() {
+  return <LegalDocumentWorkspace />;
+}

--- a/apps/hammer-system/src/pages/notification-templates/index.ts
+++ b/apps/hammer-system/src/pages/notification-templates/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ui/NotificationTemplatesPage";

--- a/apps/hammer-system/src/pages/notification-templates/ui/NotificationTemplatesPage.tsx
+++ b/apps/hammer-system/src/pages/notification-templates/ui/NotificationTemplatesPage.tsx
@@ -1,0 +1,5 @@
+import { NotificationTemplateWorkspace } from "@/widgets/notification-template-workspace";
+
+export default function NotificationTemplatesPage() {
+  return <NotificationTemplateWorkspace />;
+}

--- a/apps/hammer-system/src/shared/api/http.api.ts
+++ b/apps/hammer-system/src/shared/api/http.api.ts
@@ -20,10 +20,12 @@ const createConfiguredClient = (baseUrl: string) => {
 
 const httpClient = createConfiguredClient(env.VITE_APP_HAMMER_API_GATEWAY_URL);
 const userHttpClient = createConfiguredClient(env.VITE_APP_HAMMER_USER_URL);
+const supportHttpClient = createConfiguredClient(env.VITE_APP_HAMMER_SUPPORT_URL);
 
 export {
   httpClient,
   userHttpClient,
+  supportHttpClient,
   setAccessToken,
   getAccessToken,
   UNAUTHORIZED_EVENT,

--- a/apps/hammer-system/src/shared/api/index.ts
+++ b/apps/hammer-system/src/shared/api/index.ts
@@ -1,6 +1,7 @@
 export {
   httpClient,
   userHttpClient,
+  supportHttpClient,
   setAccessToken,
   getAccessToken,
   UNAUTHORIZED_EVENT,

--- a/apps/hammer-system/src/shared/config/env.ts
+++ b/apps/hammer-system/src/shared/config/env.ts
@@ -2,4 +2,5 @@ export const env = {
   VITE_APP_HAMMER_API_GATEWAY_URL:
     import.meta.env.VITE_APP_HAMMER_API_GATEWAY_URL ?? "/hammer-collectors",
   VITE_APP_HAMMER_USER_URL: import.meta.env.VITE_APP_HAMMER_USER_URL ?? "/hammer-users",
+  VITE_APP_HAMMER_SUPPORT_URL: import.meta.env.VITE_APP_HAMMER_SUPPORT_URL ?? "/hammer-supports",
 };

--- a/apps/hammer-system/src/shared/config/routes.ts
+++ b/apps/hammer-system/src/shared/config/routes.ts
@@ -6,6 +6,12 @@ export const RoutesConfig = {
     OVERVIEW: "/",
     LOG_EXPLORER: "/logs",
   },
+  NOTIFICATION_TEMPLATE: {
+    LIST: "/notification-templates",
+  },
+  LEGAL_DOCUMENT: {
+    LIST: "/legal-documents",
+  },
   NOT_FOUND: {
     ALL: "*",
   },

--- a/apps/hammer-system/src/widgets/legal-document-workspace/index.ts
+++ b/apps/hammer-system/src/widgets/legal-document-workspace/index.ts
@@ -1,0 +1,1 @@
+export { LegalDocumentWorkspace } from "./ui/LegalDocumentWorkspace";

--- a/apps/hammer-system/src/widgets/legal-document-workspace/ui/LegalDocumentWorkspace.tsx
+++ b/apps/hammer-system/src/widgets/legal-document-workspace/ui/LegalDocumentWorkspace.tsx
@@ -1,0 +1,35 @@
+import { GavelOutlined } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import { LegalDocumentContent } from "@/features/manage-legal-documents";
+
+export const LegalDocumentWorkspace = () => {
+  return (
+    <Hb.Box sx={{ p: 3 }}>
+      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 3 }}>
+        <Hb.Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            bgcolor: "primary.main",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <GavelOutlined sx={{ color: "#fff", fontSize: 22 }} />
+        </Hb.Box>
+        <Hb.Box>
+          <Hb.Text variant="h5" sx={{ fontWeight: 700, lineHeight: 1.3 }}>
+            Legal Documents
+          </Hb.Text>
+          <Hb.Text variant="body2" sx={{ color: "text.secondary", mt: 0.25 }}>
+            이용약관과 개인정보처리방침을 관리할 수 있어요.
+          </Hb.Text>
+        </Hb.Box>
+      </Hb.Box>
+
+      <LegalDocumentContent />
+    </Hb.Box>
+  );
+};

--- a/apps/hammer-system/src/widgets/notification-template-workspace/index.ts
+++ b/apps/hammer-system/src/widgets/notification-template-workspace/index.ts
@@ -1,0 +1,1 @@
+export { NotificationTemplateWorkspace } from "./ui/NotificationTemplateWorkspace";

--- a/apps/hammer-system/src/widgets/notification-template-workspace/ui/NotificationTemplateWorkspace.tsx
+++ b/apps/hammer-system/src/widgets/notification-template-workspace/ui/NotificationTemplateWorkspace.tsx
@@ -1,0 +1,35 @@
+import { NotificationsNoneOutlined } from "hobom-design-system/icons";
+import { Hb } from "@/shared/ui";
+import { NotificationTemplateContent } from "@/features/manage-notification-templates";
+
+export const NotificationTemplateWorkspace = () => {
+  return (
+    <Hb.Box sx={{ p: 3 }}>
+      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 3 }}>
+        <Hb.Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            bgcolor: "primary.main",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <NotificationsNoneOutlined sx={{ color: "#fff", fontSize: 22 }} />
+        </Hb.Box>
+        <Hb.Box>
+          <Hb.Text variant="h5" sx={{ fontWeight: 700, lineHeight: 1.3 }}>
+            Notification Templates
+          </Hb.Text>
+          <Hb.Text variant="body2" sx={{ color: "text.secondary", mt: 0.25 }}>
+            알림 템플릿을 관리할 수 있어요.
+          </Hb.Text>
+        </Hb.Box>
+      </Hb.Box>
+
+      <NotificationTemplateContent />
+    </Hb.Box>
+  );
+};

--- a/apps/hammer-system/vite.config.ts
+++ b/apps/hammer-system/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    port: 3001,
     proxy: {
       "/hammer-collectors": {
         target: "https://hobom-system.com/hammers/hammer-collectors",

--- a/apps/hammer-system/vite.config.ts
+++ b/apps/hammer-system/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3001,
+    port: 3000,
     proxy: {
       "/hammer-collectors": {
         target: "https://hobom-system.com/hammers/hammer-collectors",
@@ -50,6 +50,12 @@ export default defineConfig({
         changeOrigin: true,
         secure: true,
         rewrite: (p) => p.replace(/^\/hammer-users/, ""),
+      },
+      "/hammer-supports": {
+        target: "https://hobom-system.com/hammers/hammer-supports",
+        changeOrigin: true,
+        secure: true,
+        rewrite: (p) => p.replace(/^\/hammer-supports/, ""),
       },
     },
   },


### PR DESCRIPTION
## Summary

- **알림 템플릿 관리**: hammer-support 백엔드 연동, CRUD UI (테이블 + 폼 다이얼로그)
- **약관 관리**: hammer-user 백엔드 연동, 이용약관/개인정보처리방침 조회 + 새 버전 등록
- FSD 아키텍처 준수 (entities → features → widgets → pages), 테스트 29개 통과

## Changes

### Shared layer
- `supportHttpClient` 추가 (hammer-supports 서비스용)
- 라우트 설정: `/notification-templates`, `/legal-documents`
- Vite dev 프록시: `/hammer-supports`

### Entities
- `notification-template` — API, queries(SLOW), mutations(create/update/delete) + 테스트
- `legal-document` — API, queries(terms/privacy, SLOW), mutations(create) + 테스트

### Features
- `manage-notification-templates` — 목록 조회/생성/수정/삭제 UI
- `manage-legal-documents` — 약관/개인정보 카드(펼치기/접기) + 새 버전 등록 폼

### Widgets / Pages / App
- 각 기능별 workspace 위젯 + 페이지 + AppRouter/NavItems 등록

## Test plan
- [x] `vitest run` — 29 tests passed (6 spec files)
- [ ] `/hammer/notification-templates` 페이지 접근 확인
- [ ] `/hammer/legal-documents` 페이지 접근 확인
- [ ] 사이드바 네비게이션 항목 렌더링 확인