### PR TITLE
feat: HoBom Studio 라우트 추가

### DIFF
--- a/apps/hobom-system/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-system/src/apps/ui/AppRouter.tsx
@@ -34,6 +34,7 @@ const pageImports = {
   projectDashboard: () => import("@/pages/project-dashboard"),
   projectSettings: () => import("@/pages/project-settings"),
   adminUsers: () => import("@/pages/admin-users"),
+  studio: () => import("@/pages/studio"),
   wikiSpaces: () => import("@/pages/wiki-spaces"),
   wikiSpaceLayout: () => import("@/pages/wiki-space-layout"),
   wikiSpaceHome: () => import("@/pages/wiki-space-home"),
@@ -73,6 +74,7 @@ const ProjectIssuesPage = lazy(pageImports.projectIssues);
 const ProjectDashboardPage = lazy(pageImports.projectDashboard);
 const ProjectSettingsPage = lazy(pageImports.projectSettings);
 const AdminUsersPage = lazy(pageImports.adminUsers);
+const StudioPage = lazy(pageImports.studio);
 const WikiSpacesPage = lazy(pageImports.wikiSpaces);
 const WikiSpaceLayoutPage = lazy(pageImports.wikiSpaceLayout);
 const WikiSpaceHomePage = lazy(pageImports.wikiSpaceHome);
@@ -291,6 +293,14 @@ export const AppRouter = () => {
           element={
             <Shell>
               <AdminUsersPage />
+            </Shell>
+          }
+        />
+        <Route
+          path={RoutesConfig.STUDIO.HOME}
+          element={
+            <Shell>
+              <StudioPage />
             </Shell>
           }
         />

--- a/apps/hobom-system/src/apps/ui/NavItems.tsx
+++ b/apps/hobom-system/src/apps/ui/NavItems.tsx
@@ -5,6 +5,7 @@ import {
   BugReportOutlined,
   Replay,
   CompareArrowsOutlined,
+  BrushOutlined,
   DashboardOutlined,
   FolderOutlined,
   GavelOutlined,
@@ -29,6 +30,12 @@ export const NAV_ITEMS: NavEntry[] = [
     label: "대시보드",
     path: RoutesConfig.DASHBOARD.HOME,
     icon: <DashboardOutlined fontSize="small" />,
+  },
+  {
+    value: "STUDIO",
+    label: "스튜디오",
+    path: RoutesConfig.STUDIO.HOME,
+    icon: <BrushOutlined fontSize="small" />,
   },
   {
     section: "DAILY",

--- a/apps/hobom-system/src/pages/studio/index.ts
+++ b/apps/hobom-system/src/pages/studio/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ui/StudioPage";

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,0 +1,67 @@
+import { Hb } from "@/shared/ui";
+
+/**
+ * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
+ * 좌: 컴포넌트 팔레트 / 중앙: 캔버스 / 우: 인스펙터+코드.
+ * 현재는 3-pane 레이아웃 골격만.
+ */
+export default function StudioPage() {
+  return (
+    <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
+      <Pane label="컴포넌트" width={240} border="right">
+        <Hb.Text variant="body2" color="text.secondary">
+          매니페스트 기반 Insert 팔레트 (예정)
+        </Hb.Text>
+      </Pane>
+
+      <Hb.Box
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          bgcolor: "background.default",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Hb.Text variant="body2" color="text.secondary">
+          캔버스 (Document Model 렌더러)
+        </Hb.Text>
+      </Hb.Box>
+
+      <Pane label="속성 · 코드" width={320} border="left">
+        <Hb.Text variant="body2" color="text.secondary">
+          Inspector + 코드 스니펫 (예정)
+        </Hb.Text>
+      </Pane>
+    </Hb.Stack>
+  );
+}
+
+interface PaneProps {
+  label: string;
+  width: number;
+  border: "left" | "right";
+  children: React.ReactNode;
+}
+
+function Pane({ label, width, border, children }: PaneProps) {
+  return (
+    <Hb.Stack
+      sx={{
+        width,
+        flexShrink: 0,
+        bgcolor: "background.paper",
+        [`border${border === "right" ? "Right" : "Left"}`]: 1,
+        borderColor: "divider",
+        p: 2,
+        gap: 1,
+      }}
+    >
+      <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+        {label}
+      </Hb.Text>
+      {children}
+    </Hb.Stack>
+  );
+}

--- a/apps/hobom-system/src/shared/config/routes.ts
+++ b/apps/hobom-system/src/shared/config/routes.ts
@@ -46,6 +46,9 @@ export const RoutesConfig = {
     EXAMS: "/privacy-law/exams",
     EXAM_DETAIL: "/privacy-law/exams/:examId",
   },
+  STUDIO: {
+    HOME: "/studio",
+  },
   ADMIN: {
     USERS: "/admin/users",
   },


### PR DESCRIPTION
## 개요
디자인 시스템(`hobom-design-system`) 기반 웹 캔버스 **HoBom Studio**의 진입점 PR입니다.

## 변경 사항
- `/studio` 라우트 추가 (`RoutesConfig.STUDIO.HOME`)
- 좌측 네비게이션 최상위 '스튜디오' 항목 추가 (`BrushOutlined`)
- 3-pane 골격 `StudioPage` (팔레트 / 캔버스 / 인스펙터·코드) — 현재는 placeholder

## 이후 작업 (PR 분할)
1. `entities/manifest` — 컴포넌트 매니페스트
2. `entities/document` — Document Model
3. `widgets/canvas` — 재귀 렌더러
4. `widgets/inspector` — 노드 편집
5. `widgets/code-panel` — JSX 코드 생성

## 비고
- `tsc` 에 기존 타입 에러가 있으나(daily-todo/issue/note entities) 본 PR 변경과 무관합니다.