### PR TITLE
feat: Studio 컴포넌트 매니페스트(entities/manifest) 추가

### DIFF
--- a/apps/hobom-system/src/entities/manifest/index.ts
+++ b/apps/hobom-system/src/entities/manifest/index.ts
@@ -1,0 +1,8 @@
+export type {
+  ComponentKey,
+  ComponentManifest,
+  NodeKind,
+  PropSpec,
+} from "./model/manifest.model";
+export { getManifest, listManifests, MANIFEST_REGISTRY } from "./model/manifest.registry";
+export { buttonManifest } from "./model/button.manifest";

--- a/apps/hobom-system/src/entities/manifest/model/button.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/button.manifest.ts
@@ -1,0 +1,20 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/**
+ * `Hb.Button` 매니페스트.
+ * 실제 계약 출처: packages/hobom-design-system/src/hb/Button.tsx
+ */
+export const buttonManifest: ComponentManifest = {
+  name: "Hb.Button",
+  import: { source: "hobom-design-system", access: "Hb.Button" },
+  category: "actions",
+  props: {
+    variant: {
+      kind: "enum",
+      values: ["primary", "secondary", "danger", "ghost"],
+      default: "primary",
+    },
+    disabled: { kind: "boolean", default: false },
+    children: { kind: "slot", accepts: ["text"] },
+  },
+};

--- a/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
@@ -1,0 +1,32 @@
+/**
+ * 컴포넌트 매니페스트 — 디자인 시스템 컴포넌트(`Hb.*`)의 "기계가 읽는 계약".
+ *
+ * 하나의 매니페스트가 Studio의 여러 레이어를 동시에 구동한다:
+ *  - Insert 팔레트  : 무엇을 놓을 수 있는가(`category`)
+ *  - Inspector      : 어떤 prop을 어떤 컨트롤로 편집하는가(`PropSpec.kind`)
+ *  - 코드 생성       : 어떤 prop이 default라 생략 가능한가(`default`)
+ *  - 유효성 검증     : slot이 어떤 자식을 허용하는가(`accepts`)
+ */
+
+/** prop 한 개의 편집/생성 스펙. `kind`로 구분되는 discriminated union. */
+export type PropSpec =
+  | { kind: "enum"; values: readonly string[]; default: string }
+  | { kind: "boolean"; default: boolean }
+  | { kind: "slot"; accepts: readonly NodeKind[] };
+
+/** Document 노드가 가질 수 있는 종류. 컴포넌트 키이거나 원시 텍스트. */
+export type NodeKind = ComponentKey | "text";
+
+/** 매니페스트가 식별하는 컴포넌트 키. 예: `"Hb.Button"`. */
+export type ComponentKey = string;
+
+export interface ComponentManifest {
+  /** Document 노드·레지스트리가 참조하는 고유 키. 예: `"Hb.Button"`. */
+  name: ComponentKey;
+  /** 코드 생성 시 사용할 import 정보. */
+  import: { source: string; access: string };
+  /** Insert 팔레트 분류. */
+  category: string;
+  /** prop 이름 → 스펙. `children`는 slot으로 표현한다. */
+  props: Record<string, PropSpec>;
+}

--- a/apps/hobom-system/src/entities/manifest/model/manifest.registry.spec.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.registry.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getManifest, listManifests, MANIFEST_REGISTRY } from "./manifest.registry";
+
+describe("manifest.registry", () => {
+  it("등록된 키로 매니페스트를 조회한다", () => {
+    expect(getManifest("Hb.Button")?.name).toBe("Hb.Button");
+  });
+
+  it("미등록 키는 undefined를 반환한다", () => {
+    expect(getManifest("Hb.Unknown")).toBeUndefined();
+  });
+
+  it("listManifests는 레지스트리의 모든 매니페스트를 반환한다", () => {
+    expect(listManifests()).toEqual(Object.values(MANIFEST_REGISTRY));
+  });
+
+  it("레지스트리 키는 매니페스트의 name과 일치한다", () => {
+    for (const [key, manifest] of Object.entries(MANIFEST_REGISTRY)) {
+      expect(key).toBe(manifest.name);
+    }
+  });
+});

--- a/apps/hobom-system/src/entities/manifest/model/manifest.registry.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.registry.ts
@@ -1,0 +1,14 @@
+import { buttonManifest } from "./button.manifest";
+import type { ComponentKey, ComponentManifest } from "./manifest.model";
+
+/** 컴포넌트 키 → 매니페스트. 새 컴포넌트는 여기 등록한다. */
+export const MANIFEST_REGISTRY: Readonly<Record<ComponentKey, ComponentManifest>> = {
+  [buttonManifest.name]: buttonManifest,
+};
+
+/** 등록된 매니페스트를 조회한다. 미등록 키는 `undefined`. */
+export const getManifest = (name: ComponentKey): ComponentManifest | undefined =>
+  MANIFEST_REGISTRY[name];
+
+/** 팔레트 노출용 — 등록된 모든 매니페스트. */
+export const listManifests = (): ComponentManifest[] => Object.values(MANIFEST_REGISTRY);


### PR DESCRIPTION
## 개요
HoBom Studio가 디자인 시스템 컴포넌트를 '기계가 읽을 수 있게' 다루기 위한 계약 레이어입니다. 이 매니페스트 하나가 이후 **팔레트 / 인스펙터 / 코드 생성 / 유효성 검증**을 모두 구동합니다.

## 변경 사항
- `ComponentManifest` 타입 — 컴포넌트의 import 정보·분류·prop 스펙
- `PropSpec` discriminated union — `enum` / `boolean` / `slot`
- `Hb.Button` 매니페스트 (variant·disabled·children)
- 레지스트리 `getManifest` / `listManifests` + 단위 테스트

## 검증
- 타입체크 통과 / 테스트 4건 통과 / eslint 통과

## 다음 PR
`entities/document`(Document Model) → `widgets/canvas`(렌더러)에서 이 매니페스트를 소비합니다.