### PR TITLE
feat: Studio Document Model(entities/document) 추가

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -1,0 +1,11 @@
+export type {
+  ComponentKey,
+  ComponentNode,
+  DocumentNode,
+  NodeId,
+  NodeProps,
+  PropValue,
+  StudioDocument,
+  TextNode,
+} from "./model/document.model";
+export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";

--- a/apps/hobom-system/src/entities/document/model/document.model.spec.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSampleDocument,
+  isComponentNode,
+  isTextNode,
+  type DocumentNode,
+} from "./document.model";
+
+const textNode: DocumentNode = { id: "t", type: "text", value: "x" };
+const componentNode: DocumentNode = {
+  id: "c",
+  type: "Hb.Button",
+  props: {},
+  children: [],
+};
+
+describe("document.model 타입 가드", () => {
+  it("isTextNode는 텍스트 노드만 참", () => {
+    expect(isTextNode(textNode)).toBe(true);
+    expect(isTextNode(componentNode)).toBe(false);
+  });
+
+  it("isComponentNode는 컴포넌트 노드만 참", () => {
+    expect(isComponentNode(componentNode)).toBe(true);
+    expect(isComponentNode(textNode)).toBe(false);
+  });
+});
+
+describe("createSampleDocument", () => {
+  it("primary 버튼 1개와 텍스트 자식을 가진다", () => {
+    const doc = createSampleDocument();
+
+    expect(doc.children).toHaveLength(1);
+
+    const [button] = doc.children;
+
+    expect(isComponentNode(button)).toBe(true);
+    if (!isComponentNode(button)) return;
+
+    expect(button.type).toBe("Hb.Button");
+    expect(button.props.variant).toBe("primary");
+    expect(button.children).toHaveLength(1);
+    expect(isTextNode(button.children[0])).toBe(true);
+  });
+
+  it("호출마다 동일한 트리를 반환한다(결정론적 id)", () => {
+    expect(createSampleDocument()).toEqual(createSampleDocument());
+  });
+});

--- a/apps/hobom-system/src/entities/document/model/document.model.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.ts
@@ -1,0 +1,62 @@
+/**
+ * Document Model — Studio 캔버스가 편집하는 직렬화 가능한 노드 트리(scene graph).
+ *
+ * 이 트리 하나가 캔버스 렌더링과 코드 생성의 **공통 입력**이다.
+ * "보이는 것 = 생성되는 코드"는, 두 렌더러가 같은 트리를 읽기 때문에 성립한다.
+ *
+ * 주의(FSD): 이 엔티티는 동일 레이어인 `entities/manifest`를 import할 수 없다.
+ * 따라서 컴포넌트 키는 여기서 `string`(ComponentKey)으로만 다루고,
+ * 매니페스트와 엮는 로직(렌더/검증)은 상위 레이어(widgets)에 둔다.
+ */
+
+export type NodeId = string;
+
+/** 매니페스트의 ComponentKey와 같은 의미. 동일 레이어 의존 금지로 string 별칭만 둔다. */
+export type ComponentKey = string;
+
+/** prop 값으로 허용되는 원시 타입. (토큰 참조 등은 추후 확장) */
+export type PropValue = string | boolean | number;
+
+export type NodeProps = Record<string, PropValue>;
+
+/** 원시 텍스트 노드. */
+export interface TextNode {
+  id: NodeId;
+  type: "text";
+  value: string;
+}
+
+/** 디자인 시스템 컴포넌트 노드. */
+export interface ComponentNode {
+  id: NodeId;
+  type: ComponentKey;
+  props: NodeProps;
+  children: DocumentNode[];
+}
+
+export type DocumentNode = TextNode | ComponentNode;
+
+/** 캔버스 한 장. v0 스켈레톤은 최상위에 단일 노드만 두지만, 구조상 여러 개를 허용한다. */
+export interface StudioDocument {
+  children: DocumentNode[];
+}
+
+export const isTextNode = (node: DocumentNode): node is TextNode => node.type === "text";
+
+export const isComponentNode = (node: DocumentNode): node is ComponentNode =>
+  node.type !== "text";
+
+/**
+ * 스켈레톤 검증용 샘플 문서: "저장" 라벨을 가진 primary 버튼 1개.
+ * id는 결정론적으로 고정한다(테스트·스냅샷 안정성).
+ */
+export const createSampleDocument = (): StudioDocument => ({
+  children: [
+    {
+      id: "n_btn",
+      type: "Hb.Button",
+      props: { variant: "primary", disabled: false },
+      children: [{ id: "n_btn_label", type: "text", value: "저장" }],
+    },
+  ],
+});


### PR DESCRIPTION
## 개요
캔버스가 편집하는 **직렬화 가능한 노드 트리**입니다. 이 트리 하나가 캔버스 렌더링과 코드 생성의 공통 입력이 되어, "보이는 것 = 생성되는 코드"를 구조적으로 보장합니다.

## 변경 사항
- `StudioDocument` / `DocumentNode` — 노드 트리(scene graph)
- `TextNode` / `ComponentNode` discriminated union + 타입 가드(`isTextNode`/`isComponentNode`)
- `createSampleDocument` — 스켈레톤 검증용 샘플(저장 버튼 1개)

## 설계 노트
- **FSD 경계 준수**: `entities/document`는 동일 레이어인 `entities/manifest`를 import하지 않음. 컴포넌트 키는 `string`(ComponentKey)으로만 다루고, 둘을 엮는 로직은 상위 레이어(widgets)에 둠.

## 검증
- 타입체크 통과 / 테스트 4건 통과 / eslint 통과

## 다음 PR
`widgets/canvas` — 이 문서를 재귀로 순회하며 매니페스트 기반으로 실제 `Hb.*`를 렌더(눈에 보이는 첫 결과).