### PR TITLE
feat: Studio 캔버스 렌더러(widgets/canvas) 추가

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -1,11 +1,2 @@
-export type {
-  ComponentKey,
-  ComponentNode,
-  DocumentNode,
-  NodeId,
-  NodeProps,
-  PropValue,
-  StudioDocument,
-  TextNode,
-} from "./model/document.model";
-export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
+export type { DocumentNode, StudioDocument } from "./model/document.model";
+export { createSampleDocument, isTextNode } from "./model/document.model";

--- a/apps/hobom-system/src/entities/document/model/document.model.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.ts
@@ -9,15 +9,15 @@
  * 매니페스트와 엮는 로직(렌더/검증)은 상위 레이어(widgets)에 둔다.
  */
 
-export type NodeId = string;
+type NodeId = string;
 
 /** 매니페스트의 ComponentKey와 같은 의미. 동일 레이어 의존 금지로 string 별칭만 둔다. */
-export type ComponentKey = string;
+type ComponentKey = string;
 
 /** prop 값으로 허용되는 원시 타입. (토큰 참조 등은 추후 확장) */
-export type PropValue = string | boolean | number;
+type PropValue = string | boolean | number;
 
-export type NodeProps = Record<string, PropValue>;
+type NodeProps = Record<string, PropValue>;
 
 /** 원시 텍스트 노드. */
 export interface TextNode {

--- a/apps/hobom-system/src/entities/manifest/index.ts
+++ b/apps/hobom-system/src/entities/manifest/index.ts
@@ -1,8 +1,1 @@
-export type {
-  ComponentKey,
-  ComponentManifest,
-  NodeKind,
-  PropSpec,
-} from "./model/manifest.model";
-export { getManifest, listManifests, MANIFEST_REGISTRY } from "./model/manifest.registry";
-export { buttonManifest } from "./model/button.manifest";
+export { getManifest } from "./model/manifest.registry";

--- a/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
@@ -15,7 +15,7 @@ export type PropSpec =
   | { kind: "slot"; accepts: readonly NodeKind[] };
 
 /** Document 노드가 가질 수 있는 종류. 컴포넌트 키이거나 원시 텍스트. */
-export type NodeKind = ComponentKey | "text";
+type NodeKind = ComponentKey | "text";
 
 /** 매니페스트가 식별하는 컴포넌트 키. 예: `"Hb.Button"`. */
 export type ComponentKey = string;

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,11 +1,15 @@
+import { useState } from "react";
 import { Hb } from "@/shared/ui";
+import { createSampleDocument } from "@/entities/document";
+import { Canvas } from "@/widgets/canvas";
 
 /**
  * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
  * 좌: 컴포넌트 팔레트 / 중앙: 캔버스 / 우: 인스펙터+코드.
- * 현재는 3-pane 레이아웃 골격만.
  */
 export default function StudioPage() {
+  const [document] = useState(createSampleDocument);
+
   return (
     <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
       <Pane label="컴포넌트" width={240} border="right">
@@ -24,9 +28,7 @@ export default function StudioPage() {
           justifyContent: "center",
         }}
       >
-        <Hb.Text variant="body2" color="text.secondary">
-          캔버스 (Document Model 렌더러)
-        </Hb.Text>
+        <Canvas document={document} />
       </Hb.Box>
 
       <Pane label="속성 · 코드" width={320} border="left">

--- a/apps/hobom-system/src/widgets/canvas/index.ts
+++ b/apps/hobom-system/src/widgets/canvas/index.ts
@@ -1,0 +1,1 @@
+export { Canvas } from "./ui/Canvas";

--- a/apps/hobom-system/src/widgets/canvas/lib/resolve-component.lib.spec.ts
+++ b/apps/hobom-system/src/widgets/canvas/lib/resolve-component.lib.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolvePath } from "./resolve-component.lib";
+
+describe("resolvePath", () => {
+  const root = { Hb: { Button: "BUTTON", Card: { Root: "CARD_ROOT" } } };
+
+  it("단일 깊이 경로를 해석한다", () => {
+    expect(resolvePath(root, "Hb.Button")).toBe("BUTTON");
+  });
+
+  it("중첩(compound) 경로를 해석한다", () => {
+    expect(resolvePath(root, "Hb.Card.Root")).toBe("CARD_ROOT");
+  });
+
+  it("끊긴 경로는 undefined", () => {
+    expect(resolvePath(root, "Hb.Nope")).toBeUndefined();
+    expect(resolvePath(root, "Bad.Path")).toBeUndefined();
+  });
+});

--- a/apps/hobom-system/src/widgets/canvas/lib/resolve-component.lib.ts
+++ b/apps/hobom-system/src/widgets/canvas/lib/resolve-component.lib.ts
@@ -1,0 +1,13 @@
+/**
+ * 점(.)으로 구분된 접근 경로를 root 객체에서 따라가 값을 얻는다.
+ * 매니페스트의 `import.access`(예: "Hb.Button", "Hb.Card.Root")를
+ * 실제 컴포넌트 참조로 해석하는 데 쓴다. 경로가 끊기면 undefined.
+ */
+export const resolvePath = (root: unknown, dottedPath: string): unknown =>
+  dottedPath.split(".").reduce<unknown>((acc, segment) => {
+    if (acc && typeof acc === "object" && segment in acc) {
+      return (acc as Record<string, unknown>)[segment];
+    }
+
+    return undefined;
+  }, root);

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.spec.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.spec.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createSampleDocument, type StudioDocument } from "@/entities/document";
+import { Canvas } from "./Canvas";
+
+describe("Canvas", () => {
+  it("샘플 문서를 실제 Hb.Button으로 렌더한다", () => {
+    render(<Canvas document={createSampleDocument()} />);
+
+    const button = screen.getByRole("button", { name: "저장" });
+
+    expect(button).toBeDefined();
+  });
+
+  it("variant 등 props가 실제 컴포넌트에 반영된다(MUI primary 클래스)", () => {
+    render(<Canvas document={createSampleDocument()} />);
+
+    const button = screen.getByRole("button", { name: "저장" });
+
+    expect(button.className).toContain("MuiButton-containedPrimary");
+  });
+
+  it("미등록 컴포넌트는 경고 플레이스홀더로 렌더한다", () => {
+    const doc: StudioDocument = {
+      children: [{ id: "x", type: "Hb.Unknown", props: {}, children: [] }],
+    };
+
+    render(<Canvas document={doc} />);
+
+    expect(screen.getByText(/미등록 컴포넌트/)).toBeDefined();
+  });
+});

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
@@ -1,0 +1,61 @@
+import type { ComponentType } from "react";
+import { Hb } from "@/shared/ui";
+import { getManifest } from "@/entities/manifest";
+import { isTextNode, type DocumentNode, type StudioDocument } from "@/entities/document";
+import { resolvePath } from "../lib/resolve-component.lib";
+
+/** 매니페스트 `import.access` 경로 해석의 시작점. */
+const COMPONENT_ROOT = { Hb };
+
+interface NodeViewProps {
+  node: DocumentNode;
+}
+
+/** Document 노드 하나를 실제 컴포넌트(또는 텍스트)로 렌더한다. 재귀적. */
+function NodeView({ node }: NodeViewProps) {
+  if (isTextNode(node)) {
+    return <>{node.value}</>;
+  }
+
+  const manifest = getManifest(node.type);
+  const Component = manifest
+    ? (resolvePath(COMPONENT_ROOT, manifest.import.access) as
+        | ComponentType<Record<string, unknown>>
+        | undefined)
+    : undefined;
+
+  if (!Component) {
+    return <UnknownNode type={node.type} />;
+  }
+
+  return (
+    <Component {...node.props}>
+      {node.children.map((child) => (
+        <NodeView key={child.id} node={child} />
+      ))}
+    </Component>
+  );
+}
+
+function UnknownNode({ type }: { type: string }) {
+  return (
+    <Hb.Text variant="caption" color="error">
+      ⚠ 미등록 컴포넌트: {type}
+    </Hb.Text>
+  );
+}
+
+interface CanvasProps {
+  document: StudioDocument;
+}
+
+/** Document Model을 실제 `Hb.*` 컴포넌트 트리로 렌더하는 캔버스. */
+export function Canvas({ document }: CanvasProps) {
+  return (
+    <>
+      {document.children.map((node) => (
+        <NodeView key={node.id} node={node} />
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## 개요
**눈에 보이는 첫 결과** PR입니다. `/studio` 중앙 캔버스가 Document Model을 재귀로 순회하며 매니페스트 기반으로 **실제 `Hb.*` 컴포넌트**를 렌더합니다.

매니페스트(entities/manifest)와 문서(entities/document)를 엮는 지점이 바로 이 widget입니다(FSD상 동일 레이어 엔티티 결합은 상위 레이어에서).

## 변경 사항
- `Canvas` — `StudioDocument`를 받아 노드 트리를 재귀 렌더(`NodeView`)
- `resolvePath` — 매니페스트 `import.access`("Hb.Button") → 실제 컴포넌트 참조 해석(순수 함수, 단위 테스트)
- 미등록 컴포넌트 fallback 플레이스홀더
- `StudioPage` 중앙 pane에 캔버스 연결(샘플 문서: 저장 버튼)
- 공개 배럴(index.ts)을 현재 소비 표면으로 정리 — speculative export 제거

## 검증
- 타입체크 통과 / 테스트 14건 통과 / eslint 통과 / **knip 통과**(앞선 PR들의 미사용 export까지 모두 해소)
- Canvas render 테스트: 실제 `MuiButton-containedPrimary`에 "저장"이 렌더됨을 검증

## 다음 PR
`widgets/inspector` — 노드 선택 + variant 편집(캔버스와 상태 공유).