### PR TITLE
feat: Studio 인스펙터 & 노드 선택(widgets/inspector) 추가

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -1,2 +1,8 @@
-export type { DocumentNode, StudioDocument } from "./model/document.model";
-export { createSampleDocument, isTextNode } from "./model/document.model";
+export type {
+  DocumentNode,
+  NodeId,
+  PropValue,
+  StudioDocument,
+} from "./model/document.model";
+export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
+export { findNode, updateNodeProps } from "./lib/document-tree.lib";

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createSampleDocument, isComponentNode } from "../model/document.model";
+import { findNode, updateNodeProps } from "./document-tree.lib";
+
+describe("findNode", () => {
+  const doc = createSampleDocument();
+
+  it("최상위 노드를 찾는다", () => {
+    expect(findNode(doc, "n_btn")?.id).toBe("n_btn");
+  });
+
+  it("중첩된 자식 노드를 찾는다", () => {
+    expect(findNode(doc, "n_btn_label")?.id).toBe("n_btn_label");
+  });
+
+  it("없는 id는 undefined", () => {
+    expect(findNode(doc, "nope")).toBeUndefined();
+  });
+});
+
+describe("updateNodeProps", () => {
+  const doc = createSampleDocument();
+
+  it("대상 노드의 prop을 바꾼다", () => {
+    const next = updateNodeProps(doc, "n_btn", "variant", "danger");
+    const button = findNode(next, "n_btn");
+
+    expect(button && isComponentNode(button) && button.props.variant).toBe("danger");
+  });
+
+  it("원본 문서는 불변(immutable)", () => {
+    updateNodeProps(doc, "n_btn", "variant", "danger");
+    const original = findNode(doc, "n_btn");
+
+    expect(original && isComponentNode(original) && original.props.variant).toBe("primary");
+  });
+
+  it("없는 대상이면 값 변화 없이 새 트리를 반환한다", () => {
+    const next = updateNodeProps(doc, "nope", "variant", "danger");
+
+    expect(next).toEqual(doc);
+    expect(next).not.toBe(doc);
+  });
+});

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -1,0 +1,54 @@
+import {
+  isComponentNode,
+  type ComponentNode,
+  type DocumentNode,
+  type NodeId,
+  type PropValue,
+  type StudioDocument,
+} from "../model/document.model";
+
+/** 문서 트리에서 id로 노드를 찾는다(깊이 우선). 없으면 undefined. */
+export const findNode = (doc: StudioDocument, id: NodeId): DocumentNode | undefined => {
+  const visit = (nodes: DocumentNode[]): DocumentNode | undefined => {
+    for (const node of nodes) {
+      if (node.id === id) {
+        return node;
+      }
+
+      if (isComponentNode(node)) {
+        const found = visit(node.children);
+
+        if (found) {
+          return found;
+        }
+      }
+    }
+
+    return undefined;
+  };
+
+  return visit(doc.children);
+};
+
+/**
+ * 특정 노드의 prop 하나를 바꾼 새 문서를 반환한다(불변 업데이트).
+ * 대상이 없으면 원본과 동일한 구조의 새 트리를 반환한다.
+ */
+export const updateNodeProps = (
+  doc: StudioDocument,
+  id: NodeId,
+  prop: string,
+  value: PropValue,
+): StudioDocument => {
+  const mapNode = (node: DocumentNode): DocumentNode => {
+    if (!isComponentNode(node)) {
+      return node;
+    }
+
+    const next: ComponentNode = { ...node, children: node.children.map(mapNode) };
+
+    return node.id === id ? { ...next, props: { ...node.props, [prop]: value } } : next;
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
+};

--- a/apps/hobom-system/src/entities/document/model/document.model.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.ts
@@ -9,13 +9,13 @@
  * 매니페스트와 엮는 로직(렌더/검증)은 상위 레이어(widgets)에 둔다.
  */
 
-type NodeId = string;
+export type NodeId = string;
 
 /** 매니페스트의 ComponentKey와 같은 의미. 동일 레이어 의존 금지로 string 별칭만 둔다. */
 type ComponentKey = string;
 
 /** prop 값으로 허용되는 원시 타입. (토큰 참조 등은 추후 확장) */
-type PropValue = string | boolean | number;
+export type PropValue = string | boolean | number;
 
 type NodeProps = Record<string, PropValue>;
 

--- a/apps/hobom-system/src/entities/manifest/index.ts
+++ b/apps/hobom-system/src/entities/manifest/index.ts
@@ -1,1 +1,2 @@
+export type { PropSpec } from "./model/manifest.model";
 export { getManifest } from "./model/manifest.registry";

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  createSampleDocument,
+  findNode,
+  updateNodeProps,
+  type DocumentNode,
+  type NodeId,
+  type PropValue,
+} from "@/entities/document";
+
+/**
+ * Studio 에디터 상태 오케스트레이션 — 문서·선택·prop 편집을 한 곳에서 소유한다.
+ * 캔버스와 인스펙터가 이 훅의 상태를 공유한다(컴포넌트는 순수 렌더).
+ */
+export function useStudioEditor() {
+  const [document, setDocument] = useState(createSampleDocument);
+  const [selectedId, setSelectedId] = useState<NodeId | undefined>(undefined);
+
+  const selectNode = useCallback((id: NodeId) => setSelectedId(id), []);
+
+  const updateProp = useCallback(
+    (prop: string, value: PropValue) => {
+      if (!selectedId) {
+        return;
+      }
+
+      setDocument((doc) => updateNodeProps(doc, selectedId, prop, value));
+    },
+    [selectedId],
+  );
+
+  const selectedNode: DocumentNode | undefined = useMemo(
+    () => (selectedId ? findNode(document, selectedId) : undefined),
+    [document, selectedId],
+  );
+
+  return { document, selectedId, selectedNode, selectNode, updateProp };
+}

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,14 +1,14 @@
-import { useState } from "react";
 import { Hb } from "@/shared/ui";
-import { createSampleDocument } from "@/entities/document";
 import { Canvas } from "@/widgets/canvas";
+import { Inspector } from "@/widgets/inspector";
+import { useStudioEditor } from "../model/useStudioEditor";
 
 /**
  * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
  * 좌: 컴포넌트 팔레트 / 중앙: 캔버스 / 우: 인스펙터+코드.
  */
 export default function StudioPage() {
-  const [document] = useState(createSampleDocument);
+  const { document, selectedId, selectedNode, selectNode, updateProp } = useStudioEditor();
 
   return (
     <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
@@ -28,13 +28,11 @@ export default function StudioPage() {
           justifyContent: "center",
         }}
       >
-        <Canvas document={document} />
+        <Canvas document={document} selectedId={selectedId} onSelect={selectNode} />
       </Hb.Box>
 
       <Pane label="속성 · 코드" width={320} border="left">
-        <Hb.Text variant="body2" color="text.secondary">
-          Inspector + 코드 스니펫 (예정)
-        </Hb.Text>
+        <Inspector node={selectedNode} onChange={updateProp} />
       </Pane>
     </Hb.Stack>
   );

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
@@ -1,7 +1,12 @@
-import type { ComponentType } from "react";
+import type { ComponentType, MouseEvent } from "react";
 import { Hb } from "@/shared/ui";
 import { getManifest } from "@/entities/manifest";
-import { isTextNode, type DocumentNode, type StudioDocument } from "@/entities/document";
+import {
+  isTextNode,
+  type DocumentNode,
+  type NodeId,
+  type StudioDocument,
+} from "@/entities/document";
 import { resolvePath } from "../lib/resolve-component.lib";
 
 /** 매니페스트 `import.access` 경로 해석의 시작점. */
@@ -9,10 +14,12 @@ const COMPONENT_ROOT = { Hb };
 
 interface NodeViewProps {
   node: DocumentNode;
+  selectedId?: NodeId;
+  onSelect?: (id: NodeId) => void;
 }
 
 /** Document 노드 하나를 실제 컴포넌트(또는 텍스트)로 렌더한다. 재귀적. */
-function NodeView({ node }: NodeViewProps) {
+function NodeView({ node, selectedId, onSelect }: NodeViewProps) {
   if (isTextNode(node)) {
     return <>{node.value}</>;
   }
@@ -28,12 +35,30 @@ function NodeView({ node }: NodeViewProps) {
     return <UnknownNode type={node.type} />;
   }
 
+  const handleSelect = (event: MouseEvent) => {
+    event.stopPropagation();
+    onSelect?.(node.id);
+  };
+
   return (
-    <Component {...node.props}>
-      {node.children.map((child) => (
-        <NodeView key={child.id} node={child} />
-      ))}
-    </Component>
+    <Hb.Box
+      component="span"
+      onClick={handleSelect}
+      sx={{
+        display: "inline-flex",
+        cursor: "pointer",
+        borderRadius: 1,
+        outline: "2px solid",
+        outlineColor: node.id === selectedId ? "primary.main" : "transparent",
+        outlineOffset: 2,
+      }}
+    >
+      <Component {...node.props}>
+        {node.children.map((child) => (
+          <NodeView key={child.id} node={child} selectedId={selectedId} onSelect={onSelect} />
+        ))}
+      </Component>
+    </Hb.Box>
   );
 }
 
@@ -47,14 +72,16 @@ function UnknownNode({ type }: { type: string }) {
 
 interface CanvasProps {
   document: StudioDocument;
+  selectedId?: NodeId;
+  onSelect?: (id: NodeId) => void;
 }
 
 /** Document Model을 실제 `Hb.*` 컴포넌트 트리로 렌더하는 캔버스. */
-export function Canvas({ document }: CanvasProps) {
+export function Canvas({ document, selectedId, onSelect }: CanvasProps) {
   return (
     <>
       {document.children.map((node) => (
-        <NodeView key={node.id} node={node} />
+        <NodeView key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} />
       ))}
     </>
   );

--- a/apps/hobom-system/src/widgets/inspector/index.ts
+++ b/apps/hobom-system/src/widgets/inspector/index.ts
@@ -1,0 +1,1 @@
+export { Inspector } from "./ui/Inspector";

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createSampleDocument } from "@/entities/document";
+import { Inspector } from "./Inspector";
+
+const buttonNode = createSampleDocument().children[0];
+
+describe("Inspector", () => {
+  it("선택된 노드가 없으면 안내 문구를 보여준다", () => {
+    render(<Inspector node={undefined} onChange={vi.fn()} />);
+
+    expect(screen.getByText("노드를 선택하세요")).toBeDefined();
+  });
+
+  it("매니페스트의 enum 옵션을 버튼으로 렌더한다", () => {
+    render(<Inspector node={buttonNode} onChange={vi.fn()} />);
+
+    for (const variant of ["primary", "secondary", "danger", "ghost"]) {
+      expect(screen.getByRole("button", { name: variant })).toBeDefined();
+    }
+  });
+
+  it("enum 옵션 클릭 시 onChange(prop, value)를 호출한다", () => {
+    const onChange = vi.fn();
+
+    render(<Inspector node={buttonNode} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "danger" }));
+
+    expect(onChange).toHaveBeenCalledWith("variant", "danger");
+  });
+
+  it("boolean prop은 체크박스로 렌더한다", () => {
+    render(<Inspector node={buttonNode} onChange={vi.fn()} />);
+
+    expect(screen.getByRole("checkbox")).toBeDefined();
+  });
+});

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -1,0 +1,90 @@
+import { Hb } from "@/shared/ui";
+import { getManifest, type PropSpec } from "@/entities/manifest";
+import { isComponentNode, type DocumentNode, type PropValue } from "@/entities/document";
+
+interface InspectorProps {
+  node: DocumentNode | undefined;
+  onChange: (prop: string, value: PropValue) => void;
+}
+
+/** 선택된 노드의 prop을 매니페스트 기반 컨트롤로 편집한다. */
+export function Inspector({ node, onChange }: InspectorProps) {
+  if (!node || !isComponentNode(node)) {
+    return (
+      <Hb.Text variant="body2" color="text.secondary">
+        노드를 선택하세요
+      </Hb.Text>
+    );
+  }
+
+  const manifest = getManifest(node.type);
+
+  if (!manifest) {
+    return (
+      <Hb.Text variant="caption" color="error">
+        ⚠ 미등록 컴포넌트: {node.type}
+      </Hb.Text>
+    );
+  }
+
+  return (
+    <Hb.Stack gap={2}>
+      <Hb.Text variant="body2" sx={{ fontWeight: 600 }}>
+        {node.type}
+      </Hb.Text>
+      {Object.entries(manifest.props).map(([name, spec]) => (
+        <PropField
+          key={name}
+          name={name}
+          spec={spec}
+          value={node.props[name]}
+          onChange={onChange}
+        />
+      ))}
+    </Hb.Stack>
+  );
+}
+
+interface PropFieldProps {
+  name: string;
+  spec: PropSpec;
+  value: PropValue | undefined;
+  onChange: (prop: string, value: PropValue) => void;
+}
+
+/** prop 한 개를 spec.kind에 맞는 컨트롤로 렌더한다. slot은 편집 대상이 아니다. */
+function PropField({ name, spec, value, onChange }: PropFieldProps) {
+  if (spec.kind === "slot") {
+    return null;
+  }
+
+  return (
+    <Hb.Stack gap={0.5}>
+      <Hb.Text variant="caption" color="text.secondary">
+        {name}
+      </Hb.Text>
+
+      {spec.kind === "enum" && (
+        <Hb.Stack direction="row" gap={0.5} sx={{ flexWrap: "wrap" }}>
+          {spec.values.map((option) => (
+            <Hb.Button
+              key={option}
+              size="small"
+              variant={value === option ? "primary" : "ghost"}
+              onClick={() => onChange(name, option)}
+            >
+              {option}
+            </Hb.Button>
+          ))}
+        </Hb.Stack>
+      )}
+
+      {spec.kind === "boolean" && (
+        <Hb.Checkbox
+          checked={Boolean(value)}
+          onChange={(event) => onChange(name, event.target.checked)}
+        />
+      )}
+    </Hb.Stack>
+  );
+}


### PR DESCRIPTION
## 개요
캔버스에서 노드를 선택하고, 인스펙터에서 그 노드의 prop을 매니페스트 기반 컨트롤로 편집합니다. **편집하면 캔버스가 즉시 반영**됩니다(척추의 나머지 절반).

## 변경 사항
- **노드 선택**: 캔버스 클릭 시 outline 하이라이트(`selectedId`/`onSelect`)
- **Inspector**: 선택 노드의 prop을 `PropSpec.kind`별 컨트롤로 렌더/편집(enum→버튼 그룹, boolean→체크박스)
- **순수 트리 연산**(`entities/document/lib`): `findNode` / `updateNodeProps`(불변 업데이트) + 단위 테스트
- **에디터 훅**(`pages/studio/model/useStudioEditor`): 문서·선택·편집 상태를 한 곳에서 소유 → 캔버스/인스펙터가 공유(컴포넌트는 순수 렌더)
- 배럴(index.ts)을 실제 소비 표면으로 재정리

## 설계 노트
- 비즈니스 로직은 커스텀 훅, 순수 함수는 `lib/`로 분리·테스트 (프로젝트 컨벤션)
- 동일 레이어 엔티티 결합은 상위 레이어(widget/page)에서만

## 검증
- 타입체크 통과 / 테스트 20건 통과 / eslint 통과 / **knip 통과**
- Inspector 테스트: enum 옵션 클릭 → `onChange("variant", "danger")` 호출 검증

## 다음 PR (마지막)
`widgets/code-panel` — Document Model → JSX 문자열 생성. **편집하면 코드가 바뀌는 데모 완성.**