### PR TITLE
feat: Studio 코드 패널(widgets/code-panel) 추가

### DIFF
--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,5 +1,6 @@
 import { Hb } from "@/shared/ui";
 import { Canvas } from "@/widgets/canvas";
+import { CodePanel } from "@/widgets/code-panel";
 import { Inspector } from "@/widgets/inspector";
 import { useStudioEditor } from "../model/useStudioEditor";
 
@@ -31,8 +32,13 @@ export default function StudioPage() {
         <Canvas document={document} selectedId={selectedId} onSelect={selectNode} />
       </Hb.Box>
 
-      <Pane label="속성 · 코드" width={320} border="left">
+      <Pane label="속성 · 코드" width={360} border="left">
         <Inspector node={selectedNode} onChange={updateProp} />
+        <Hb.Divider sx={{ my: 1 }} />
+        <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+          코드
+        </Hb.Text>
+        <CodePanel document={document} />
       </Pane>
     </Hb.Stack>
   );

--- a/apps/hobom-system/src/widgets/code-panel/index.ts
+++ b/apps/hobom-system/src/widgets/code-panel/index.ts
@@ -1,0 +1,1 @@
+export { CodePanel } from "./ui/CodePanel";

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { createSampleDocument, updateNodeProps, type StudioDocument } from "@/entities/document";
+import { generateJsx } from "./generate-jsx.lib";
+
+describe("generateJsx", () => {
+  it("default와 같은 prop은 생략한다", () => {
+    // 샘플: variant=primary(default), disabled=false(default) → 둘 다 생략
+    const code = generateJsx(createSampleDocument());
+
+    expect(code).toContain('import { Hb } from "hobom-design-system";');
+    expect(code).toContain("<Hb.Button>저장</Hb.Button>");
+    expect(code).not.toContain("variant");
+    expect(code).not.toContain("disabled");
+  });
+
+  it("default와 다른 enum 값은 속성으로 출력한다", () => {
+    const doc = updateNodeProps(createSampleDocument(), "n_btn", "variant", "danger");
+
+    expect(generateJsx(doc)).toContain('<Hb.Button variant="danger">저장</Hb.Button>');
+  });
+
+  it("true boolean은 단축 속성으로 출력한다", () => {
+    const doc = updateNodeProps(createSampleDocument(), "n_btn", "disabled", true);
+
+    expect(generateJsx(doc)).toContain("<Hb.Button disabled>저장</Hb.Button>");
+  });
+
+  it("자식이 없으면 self-closing 태그", () => {
+    const doc: StudioDocument = {
+      children: [{ id: "b", type: "Hb.Button", props: { variant: "danger" }, children: [] }],
+    };
+
+    expect(generateJsx(doc)).toContain('<Hb.Button variant="danger" />');
+  });
+
+  it("미등록 컴포넌트는 주석으로 표시한다", () => {
+    const doc: StudioDocument = {
+      children: [{ id: "x", type: "Hb.Unknown", props: {}, children: [] }],
+    };
+
+    expect(generateJsx(doc)).toContain("{/* 미등록 컴포넌트: Hb.Unknown */}");
+  });
+});

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
@@ -1,0 +1,109 @@
+import { getManifest, type PropSpec } from "@/entities/manifest";
+import {
+  isComponentNode,
+  isTextNode,
+  type DocumentNode,
+  type PropValue,
+  type StudioDocument,
+} from "@/entities/document";
+
+const INDENT = "  ";
+
+/**
+ * prop 하나를 JSX 속성 문자열로 직렬화한다.
+ * 매니페스트 default와 같은 값은 생략한다(null 반환) — 깔끔한 코드를 위해.
+ */
+const serializeProp = (
+  name: string,
+  value: PropValue | undefined,
+  spec: PropSpec,
+): string | null => {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (spec.kind !== "slot" && value === spec.default) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return `${name}="${value}"`;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? name : `${name}={false}`;
+  }
+
+  return `${name}={${value}}`;
+};
+
+/** 노드 하나를 JSX 문자열로 직렬화한다. 재귀적. */
+const serializeNode = (node: DocumentNode, indent: string): string => {
+  if (isTextNode(node)) {
+    return indent + node.value;
+  }
+
+  const manifest = getManifest(node.type);
+
+  if (!manifest) {
+    return `${indent}{/* 미등록 컴포넌트: ${node.type} */}`;
+  }
+
+  const tag = manifest.import.access;
+  const attrs = Object.entries(manifest.props)
+    .filter(([, spec]) => spec.kind !== "slot")
+    .map(([name, spec]) => serializeProp(name, node.props[name], spec))
+    .filter((attr): attr is string => attr !== null);
+  const attrString = attrs.length ? ` ${attrs.join(" ")}` : "";
+
+  if (node.children.length === 0) {
+    return `${indent}<${tag}${attrString} />`;
+  }
+
+  const [onlyChild] = node.children;
+
+  if (node.children.length === 1 && isTextNode(onlyChild)) {
+    return `${indent}<${tag}${attrString}>${onlyChild.value}</${tag}>`;
+  }
+
+  const inner = node.children.map((child) => serializeNode(child, indent + INDENT)).join("\n");
+
+  return `${indent}<${tag}${attrString}>\n${inner}\n${indent}</${tag}>`;
+};
+
+/** 문서에서 쓰인 컴포넌트들의 import 문을 source별로 모은다. */
+const collectImports = (doc: StudioDocument): string[] => {
+  const bindingsBySource = new Map<string, Set<string>>();
+
+  const visit = (node: DocumentNode): void => {
+    if (!isComponentNode(node)) {
+      return;
+    }
+
+    const manifest = getManifest(node.type);
+
+    if (manifest) {
+      const binding = manifest.import.access.split(".")[0];
+      const bindings = bindingsBySource.get(manifest.import.source) ?? new Set<string>();
+
+      bindings.add(binding);
+      bindingsBySource.set(manifest.import.source, bindings);
+    }
+
+    node.children.forEach(visit);
+  };
+
+  doc.children.forEach(visit);
+
+  return [...bindingsBySource.entries()].map(
+    ([source, bindings]) => `import { ${[...bindings].sort().join(", ")} } from "${source}";`,
+  );
+};
+
+/** Document Model을 production JSX 문자열로 생성한다. */
+export const generateJsx = (doc: StudioDocument): string => {
+  const imports = collectImports(doc);
+  const body = doc.children.map((node) => serializeNode(node, "")).join("\n");
+
+  return imports.length ? `${imports.join("\n")}\n\n${body}` : body;
+};

--- a/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
+++ b/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
@@ -1,0 +1,31 @@
+import { Hb } from "@/shared/ui";
+import type { StudioDocument } from "@/entities/document";
+import { generateJsx } from "../lib/generate-jsx.lib";
+
+interface CodePanelProps {
+  document: StudioDocument;
+}
+
+/** Document Model에서 생성한 JSX 코드를 보여준다. 문서가 바뀌면 즉시 갱신. */
+export function CodePanel({ document }: CodePanelProps) {
+  const code = generateJsx(document);
+
+  return (
+    <Hb.Box
+      component="pre"
+      sx={{
+        m: 0,
+        p: 1.5,
+        bgcolor: "background.default",
+        borderRadius: 1,
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+        fontSize: "0.75rem",
+        lineHeight: 1.6,
+        overflow: "auto",
+        whiteSpace: "pre",
+      }}
+    >
+      {code}
+    </Hb.Box>
+  );
+}


### PR DESCRIPTION
## 개요
**walking skeleton의 마지막 조각**입니다. Document Model을 production JSX로 생성해 보여주고, 인스펙터에서 편집하면 **캔버스와 코드가 동시에 갱신**됩니다 — 디자인 + 코드 스니펫이라는 핵심 경험 완성.

## 변경 사항
- `generateJsx` — Document Model → JSX 문자열(순수 함수)
  - 매니페스트 default와 같은 prop은 **생략**
  - boolean 단축 속성(`disabled`), self-closing, import 자동 수집
  - 미등록 컴포넌트는 주석 처리
- `CodePanel` — 생성 코드 표시(문서 변경 시 즉시 갱신)
- `StudioPage` 우측 pane에 인스펙터 + 코드 패널 배치

## 동작 예시
```
import { Hb } from "hobom-design-system";

<Hb.Button>저장</Hb.Button>          // variant=primary(default) 생략
```
variant를 danger로 바꾸면 → `<Hb.Button variant="danger">저장</Hb.Button>`

## 설계 노트
- v0는 문자열 직렬화. 추후 AST(ts-morph) 기반으로 교체 가능(설계상 P4).

## 검증
- 타입체크 통과 / 테스트(code-panel 5건 포함) 통과 / eslint 통과 / **knip 통과**

## 마일스톤
이 PR로 **매니페스트 → 문서 → 캔버스 → 인스펙터 → 코드** 척추가 1개 컴포넌트로 끝까지 관통됩니다. 이후엔 컴포넌트 매니페스트를 늘리는 반복 작업.