### PR TITLE
feat: Studio 피그마식 UI 리디자인 + 코드 복사

### DIFF
--- a/apps/hobom-system/src/pages/studio/config/studio-theme.ts
+++ b/apps/hobom-system/src/pages/studio/config/studio-theme.ts
@@ -1,0 +1,20 @@
+import { createTheme } from "hobom-design-system";
+
+/**
+ * Studio 전용 다크 뉴트럴 테마. 디자인 툴 느낌(피그마 류)을 위해 앱의 라이트/다크와
+ * 무관하게 고정한다. 패널/캔버스/셀렉션 색을 토큰으로 제공해 내부 컴포넌트가 상속받는다.
+ */
+export const studioTheme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: { main: "#0d99ff", contrastText: "#ffffff" },
+    background: { default: "#1e1e1e", paper: "#2c2c2c" },
+    text: { primary: "#e6e6e6", secondary: "#9b9b9b" },
+    divider: "rgba(255, 255, 255, 0.10)",
+    action: {
+      hover: "rgba(255, 255, 255, 0.06)",
+      selected: "rgba(13, 153, 255, 0.16)",
+    },
+  },
+  shape: { borderRadius: 6 },
+});

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -2,71 +2,119 @@ import { Hb } from "@/shared/ui";
 import { Canvas } from "@/widgets/canvas";
 import { CodePanel } from "@/widgets/code-panel";
 import { Inspector } from "@/widgets/inspector";
+import { LayersPanel } from "@/widgets/layers-panel";
 import { useStudioEditor } from "../model/useStudioEditor";
+import { studioTheme } from "../config/studio-theme";
 
 /**
  * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
- * 좌: 컴포넌트 팔레트 / 중앙: 캔버스 / 우: 인스펙터+코드.
+ * 좌: 레이어 / 중앙: 캔버스(아트보드) / 우: 속성 + 코드. (디자인 툴 류 다크 UI)
  */
 export default function StudioPage() {
   const { document, selectedId, selectedNode, selectNode, updateProp } = useStudioEditor();
 
   return (
-    <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
-      <Pane label="컴포넌트" width={240} border="right">
-        <Hb.Text variant="body2" color="text.secondary">
-          매니페스트 기반 Insert 팔레트 (예정)
-        </Hb.Text>
-      </Pane>
-
-      <Hb.Box
+    <Hb.ThemeProvider theme={studioTheme}>
+      <Hb.Stack
+        direction="row"
         sx={{
-          flex: 1,
-          minWidth: 0,
+          height: "100%",
+          minHeight: 0,
           bgcolor: "background.default",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
+          color: "text.primary",
         }}
       >
-        <Canvas document={document} selectedId={selectedId} onSelect={selectNode} />
-      </Hb.Box>
+        <Panel title="Layers" width={232} side="right">
+          <LayersPanel document={document} selectedId={selectedId} onSelect={selectNode} />
+        </Panel>
 
-      <Pane label="속성 · 코드" width={360} border="left">
-        <Inspector node={selectedNode} onChange={updateProp} />
-        <Hb.Divider sx={{ my: 1 }} />
-        <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
-          코드
-        </Hb.Text>
-        <CodePanel document={document} />
-      </Pane>
-    </Hb.Stack>
+        <Hb.Stack
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            minHeight: 0,
+            p: 4,
+            gap: 1,
+            overflow: "auto",
+          }}
+        >
+          <Hb.Text sx={{ fontSize: 11, color: "text.secondary", flexShrink: 0 }}>Frame</Hb.Text>
+          <Hb.Box
+            sx={{
+              flex: 1,
+              minHeight: 320,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              p: 4,
+              bgcolor: "#ffffff",
+              borderRadius: 1,
+              boxShadow: "0 8px 30px rgba(0, 0, 0, 0.35)",
+            }}
+          >
+            <Canvas document={document} selectedId={selectedId} onSelect={selectNode} />
+          </Hb.Box>
+        </Hb.Stack>
+
+        <Panel width={280} side="left">
+          <Inspector node={selectedNode} onChange={updateProp} />
+          <Hb.Divider />
+          <Hb.Box sx={{ p: 1.5 }}>
+            <CodePanel document={document} />
+          </Hb.Box>
+        </Panel>
+      </Hb.Stack>
+    </Hb.ThemeProvider>
   );
 }
 
-interface PaneProps {
-  label: string;
+interface PanelProps {
+  title?: string;
   width: number;
-  border: "left" | "right";
+  side: "left" | "right";
   children: React.ReactNode;
 }
 
-function Pane({ label, width, border, children }: PaneProps) {
+/** 좌/우 사이드 패널. 선택적 sticky 헤더 + 스크롤 본문. */
+function Panel({ title, width, side, children }: PanelProps) {
   return (
     <Hb.Stack
       sx={{
         width,
         flexShrink: 0,
+        minWidth: 0,
         bgcolor: "background.paper",
-        [`border${border === "right" ? "Right" : "Left"}`]: 1,
+        [side === "right" ? "borderRight" : "borderLeft"]: 1,
         borderColor: "divider",
-        p: 2,
-        gap: 1,
+        overflow: "auto",
       }}
     >
-      <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
-        {label}
-      </Hb.Text>
+      {title && (
+        <Hb.Box
+          sx={{
+            px: 1.5,
+            py: 1,
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            bgcolor: "background.paper",
+            borderBottom: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Hb.Text
+            sx={{
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: 0.5,
+              textTransform: "uppercase",
+              color: "text.secondary",
+            }}
+          >
+            {title}
+          </Hb.Text>
+        </Hb.Box>
+      )}
       {children}
     </Hb.Stack>
   );

--- a/apps/hobom-system/src/widgets/code-panel/model/useCopyToClipboard.ts
+++ b/apps/hobom-system/src/widgets/code-panel/model/useCopyToClipboard.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * 텍스트를 클립보드에 복사하고, 일정 시간 동안 `copied`를 true로 유지한다.
+ * 복사 성공 피드백("복사됨!") 표시에 사용.
+ */
+export function useCopyToClipboard(resetMs = 1500) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(
+    async (text: string) => {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), resetMs);
+    },
+    [resetMs],
+  );
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  return { copied, copy };
+}

--- a/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
+++ b/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
@@ -1,31 +1,60 @@
+import { Check, ContentCopyOutlined } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
 import type { StudioDocument } from "@/entities/document";
 import { generateJsx } from "../lib/generate-jsx.lib";
+import { useCopyToClipboard } from "../model/useCopyToClipboard";
 
 interface CodePanelProps {
   document: StudioDocument;
 }
 
-/** Document Model에서 생성한 JSX 코드를 보여준다. 문서가 바뀌면 즉시 갱신. */
+/** Document Model에서 생성한 JSX 코드를 보여주고 복사할 수 있게 한다. */
 export function CodePanel({ document }: CodePanelProps) {
   const code = generateJsx(document);
+  const { copied, copy } = useCopyToClipboard();
 
   return (
-    <Hb.Box
-      component="pre"
-      sx={{
-        m: 0,
-        p: 1.5,
-        bgcolor: "background.default",
-        borderRadius: 1,
-        fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-        fontSize: "0.75rem",
-        lineHeight: 1.6,
-        overflow: "auto",
-        whiteSpace: "pre",
-      }}
-    >
-      {code}
-    </Hb.Box>
+    <Hb.Stack gap={1} sx={{ minWidth: 0 }}>
+      <Hb.Stack direction="row" alignItems="center" gap={0.5}>
+        <Hb.Text
+          sx={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+            color: "text.secondary",
+          }}
+        >
+          코드
+        </Hb.Text>
+        <Hb.Button.Icon
+          size="small"
+          aria-label="코드 복사"
+          onClick={() => copy(code)}
+          sx={{ p: 0.25, color: copied ? "primary.main" : "text.secondary" }}
+        >
+          {copied ? <Check sx={{ fontSize: 16 }} /> : <ContentCopyOutlined sx={{ fontSize: 16 }} />}
+        </Hb.Button.Icon>
+      </Hb.Stack>
+
+      <Hb.Box
+        component="pre"
+        sx={{
+          m: 0,
+          p: 1.5,
+          minWidth: 0,
+          maxWidth: "100%",
+          bgcolor: "background.default",
+          borderRadius: 1,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: "0.75rem",
+          lineHeight: 1.6,
+          whiteSpace: "pre-wrap",
+          overflowWrap: "anywhere",
+        }}
+      >
+        {code}
+      </Hb.Box>
+    </Hb.Stack>
   );
 }

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
@@ -10,7 +10,7 @@ describe("Inspector", () => {
   it("선택된 노드가 없으면 안내 문구를 보여준다", () => {
     render(<Inspector node={undefined} onChange={vi.fn()} />);
 
-    expect(screen.getByText("노드를 선택하세요")).toBeDefined();
+    expect(screen.getByText("요소를 선택하세요")).toBeDefined();
   });
 
   it("매니페스트의 enum 옵션을 버튼으로 렌더한다", () => {

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -7,41 +7,40 @@ interface InspectorProps {
   onChange: (prop: string, value: PropValue) => void;
 }
 
-/** 선택된 노드의 prop을 매니페스트 기반 컨트롤로 편집한다. */
+/** 선택된 노드의 prop을 매니페스트 기반 컨트롤로 편집한다(피그마식 속성 패널). */
 export function Inspector({ node, onChange }: InspectorProps) {
   if (!node || !isComponentNode(node)) {
     return (
-      <Hb.Text variant="body2" color="text.secondary">
-        노드를 선택하세요
-      </Hb.Text>
+      <Hb.Box sx={{ p: 2 }}>
+        <Hb.Text sx={{ fontSize: 12, color: "text.secondary" }}>요소를 선택하세요</Hb.Text>
+      </Hb.Box>
     );
   }
 
   const manifest = getManifest(node.type);
 
-  if (!manifest) {
-    return (
-      <Hb.Text variant="caption" color="error">
-        ⚠ 미등록 컴포넌트: {node.type}
-      </Hb.Text>
-    );
-  }
-
   return (
-    <Hb.Stack gap={2}>
-      <Hb.Text variant="body2" sx={{ fontWeight: 600 }}>
-        {node.type}
-      </Hb.Text>
-      {Object.entries(manifest.props).map(([name, spec]) => (
-        <PropField
-          key={name}
-          name={name}
-          spec={spec}
-          value={node.props[name]}
-          onChange={onChange}
-        />
-      ))}
-    </Hb.Stack>
+    <Hb.Box sx={{ p: 1.5 }}>
+      <Hb.Text sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>{node.type}</Hb.Text>
+
+      {!manifest ? (
+        <Hb.Text sx={{ fontSize: 12, color: "error.main" }}>
+          미등록 컴포넌트: {node.type}
+        </Hb.Text>
+      ) : (
+        <Hb.Stack gap={1.25}>
+          {Object.entries(manifest.props).map(([name, spec]) => (
+            <PropField
+              key={name}
+              name={name}
+              spec={spec}
+              value={node.props[name]}
+              onChange={onChange}
+            />
+          ))}
+        </Hb.Stack>
+      )}
+    </Hb.Box>
   );
 }
 
@@ -52,39 +51,72 @@ interface PropFieldProps {
   onChange: (prop: string, value: PropValue) => void;
 }
 
+const labelSx = { fontSize: 11, color: "text.secondary" } as const;
+
 /** prop 한 개를 spec.kind에 맞는 컨트롤로 렌더한다. slot은 편집 대상이 아니다. */
 function PropField({ name, spec, value, onChange }: PropFieldProps) {
   if (spec.kind === "slot") {
     return null;
   }
 
-  return (
-    <Hb.Stack gap={0.5}>
-      <Hb.Text variant="caption" color="text.secondary">
-        {name}
-      </Hb.Text>
-
-      {spec.kind === "enum" && (
-        <Hb.Stack direction="row" gap={0.5} sx={{ flexWrap: "wrap" }}>
-          {spec.values.map((option) => (
-            <Hb.Button
-              key={option}
-              size="small"
-              variant={value === option ? "primary" : "ghost"}
-              onClick={() => onChange(name, option)}
-            >
-              {option}
-            </Hb.Button>
-          ))}
-        </Hb.Stack>
-      )}
-
-      {spec.kind === "boolean" && (
+  if (spec.kind === "boolean") {
+    return (
+      <Hb.Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ minHeight: 24 }}
+      >
+        <Hb.Text sx={labelSx}>{name}</Hb.Text>
         <Hb.Checkbox
+          size="small"
+          sx={{ p: 0 }}
           checked={Boolean(value)}
           onChange={(event) => onChange(name, event.target.checked)}
         />
-      )}
+      </Hb.Stack>
+    );
+  }
+
+  return (
+    <Hb.Stack gap={0.5} sx={{ minWidth: 0 }}>
+      <Hb.Text sx={labelSx}>{name}</Hb.Text>
+      <Hb.Box
+        sx={{
+          display: "flex",
+          borderRadius: 1,
+          overflow: "hidden",
+          border: 1,
+          borderColor: "divider",
+        }}
+      >
+        {spec.values.map((option, index) => (
+          <Hb.Box
+            key={option}
+            component="button"
+            onClick={() => onChange(name, option)}
+            sx={{
+              flex: 1,
+              border: 0,
+              borderLeft: index === 0 ? 0 : 1,
+              borderColor: "divider",
+              py: 0.5,
+              px: 0.5,
+              fontSize: 11,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              transition: "background-color 0.12s",
+              bgcolor: value === option ? "primary.main" : "transparent",
+              color: value === option ? "primary.contrastText" : "text.secondary",
+              "&:hover": {
+                bgcolor: value === option ? "primary.main" : "action.hover",
+              },
+            }}
+          >
+            {option}
+          </Hb.Box>
+        ))}
+      </Hb.Box>
     </Hb.Stack>
   );
 }

--- a/apps/hobom-system/src/widgets/layers-panel/index.ts
+++ b/apps/hobom-system/src/widgets/layers-panel/index.ts
@@ -1,0 +1,1 @@
+export { LayersPanel } from "./ui/LayersPanel";

--- a/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
+++ b/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
@@ -1,0 +1,77 @@
+import { Hb } from "@/shared/ui";
+import {
+  isComponentNode,
+  isTextNode,
+  type DocumentNode,
+  type NodeId,
+  type StudioDocument,
+} from "@/entities/document";
+
+interface LayersPanelProps {
+  document: StudioDocument;
+  selectedId?: NodeId;
+  onSelect: (id: NodeId) => void;
+}
+
+/** 문서 트리를 레이어 목록으로 보여준다(피그마 Layers 패널). 선택은 캔버스와 동기화. */
+export function LayersPanel({ document, selectedId, onSelect }: LayersPanelProps) {
+  return (
+    <Hb.Box sx={{ py: 0.5 }}>
+      {document.children.map((node) => (
+        <LayerRow
+          key={node.id}
+          node={node}
+          depth={0}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </Hb.Box>
+  );
+}
+
+interface LayerRowProps {
+  node: DocumentNode;
+  depth: number;
+  selectedId?: NodeId;
+  onSelect: (id: NodeId) => void;
+}
+
+function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
+  const isSelected = node.id === selectedId;
+  const label = isTextNode(node) ? `"${node.value}"` : node.type.replace(/^Hb\./, "");
+
+  return (
+    <>
+      <Hb.Box
+        onClick={() => onSelect(node.id)}
+        sx={{
+          pl: `${8 + depth * 14}px`,
+          pr: 1,
+          py: 0.5,
+          fontSize: 12,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          color: isSelected ? "text.primary" : "text.secondary",
+          bgcolor: isSelected ? "action.selected" : "transparent",
+          "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+        }}
+      >
+        {label}
+      </Hb.Box>
+
+      {isComponentNode(node) &&
+        node.children.map((child) => (
+          <LayerRow
+            key={child.id}
+            node={child}
+            depth={depth + 1}
+            selectedId={selectedId}
+            onSelect={onSelect}
+          />
+        ))}
+    </>
+  );
+}

--- a/packages/hobom-design-system/src/index.ts
+++ b/packages/hobom-design-system/src/index.ts
@@ -16,6 +16,7 @@ import { SkeletonList } from "./components/SkeletonList";
 export const HoBomSkeleton = { Card: SkeletonCard, List: SkeletonList };
 
 export { theme, DRAWER_WIDTH, DRAWER_WIDTH_COLLAPSED, APPBAR_HEIGHT } from "./theme";
+export { createTheme } from "@mui/material";
 
 export { Hb } from "./hb";
 


### PR DESCRIPTION
## 개요
Studio를 디자인 툴 류(피그마 느낌)의 다크 UI로 리디자인하고, 코드 복사 기능을 추가합니다. 스켈레톤(매니페스트→문서→캔버스→인스펙터→코드)은 그대로 두고 **표현 계층(UX)만** 개선했습니다.

## 변경 사항
- **Studio 전용 다크 뉴트럴 테마**(`studioTheme`) — 패널 #2c2c2c, 셀렉션 #0d99ff. `Hb.ThemeProvider`로 Studio 영역에만 적용(앱 라이트/다크와 분리).
- **Layers 패널**(`widgets/layers-panel`) — 문서 트리를 레이어 목록으로. 클릭 시 캔버스 선택과 동기화.
- **캔버스**: 아트보드를 영역에 가득 채우게(flex) + `Frame` 라벨.
- **속성 패널**: 컴팩트 행(라벨/컨트롤), enum은 **세그먼트 컨트롤**, 떠다니던 boolean 체크박스 정렬 수정.
- **코드 패널**: '코드' 옆 **아이콘 복사 버튼**(`ContentCopy`→`Check`), 복사 로직은 `useCopyToClipboard` 훅. 긴 줄 줄바꿈으로 오버플로/잘림 수정.
- **DS**: `createTheme` export 추가(MUI 경계는 디자인 시스템이 소유).

## 검증
- 타입체크 통과 / 테스트 47건 통과 / eslint 통과 / **knip 통과**

## 비고
- Studio는 의도적으로 다크 고정(디자인 툴 관례). 추후 토큰 SoT(P0) 작업 시 테마 정리 가능.