### PR TITLE
feat: Studio 컴포넌트 카탈로그 확장

### DIFF
--- a/apps/hobom-system/src/entities/document/model/document.model.spec.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.spec.ts
@@ -27,20 +27,35 @@ describe("document.model 타입 가드", () => {
 });
 
 describe("createSampleDocument", () => {
-  it("primary 버튼 1개와 텍스트 자식을 가진다", () => {
+  it("Stack 루트에 카탈로그 컴포넌트들을 중첩해 담는다", () => {
     const doc = createSampleDocument();
 
     expect(doc.children).toHaveLength(1);
 
-    const [button] = doc.children;
+    const [root] = doc.children;
 
-    expect(isComponentNode(button)).toBe(true);
-    if (!isComponentNode(button)) return;
+    expect(isComponentNode(root) && root.type).toBe("Hb.Stack");
 
-    expect(button.type).toBe("Hb.Button");
-    expect(button.props.variant).toBe("primary");
-    expect(button.children).toHaveLength(1);
-    expect(isTextNode(button.children[0])).toBe(true);
+    const types: string[] = [];
+    const walk = (node: DocumentNode) => {
+      if (!isComponentNode(node)) return;
+      types.push(node.type);
+      node.children.forEach(walk);
+    };
+
+    walk(root);
+
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "Hb.Stack",
+        "Hb.Text",
+        "Hb.Card.Root",
+        "Hb.TextField",
+        "Hb.Chip",
+        "Hb.Divider",
+        "Hb.Button",
+      ]),
+    );
   });
 
   it("호출마다 동일한 트리를 반환한다(결정론적 id)", () => {

--- a/apps/hobom-system/src/entities/document/model/document.model.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.ts
@@ -47,16 +47,84 @@ export const isComponentNode = (node: DocumentNode): node is ComponentNode =>
   node.type !== "text";
 
 /**
- * 스켈레톤 검증용 샘플 문서: "저장" 라벨을 가진 primary 버튼 1개.
+ * 샘플 문서: 카탈로그 전반을 보여주는 회원가입 카드 폼.
+ * Stack 중첩(세로/가로) · Card · Text · TextField · Chip · Divider · Button 변형을 포함한다.
  * id는 결정론적으로 고정한다(테스트·스냅샷 안정성).
  */
 export const createSampleDocument = (): StudioDocument => ({
   children: [
     {
-      id: "n_btn",
-      type: "Hb.Button",
-      props: { variant: "primary", disabled: false },
-      children: [{ id: "n_btn_label", type: "text", value: "저장" }],
+      id: "n_root",
+      type: "Hb.Stack",
+      props: { direction: "column", gap: 3 },
+      children: [
+        {
+          id: "n_title",
+          type: "Hb.Text",
+          props: { variant: "h6" },
+          children: [{ id: "n_title_text", type: "text", value: "회원 가입" }],
+        },
+        {
+          id: "n_card",
+          type: "Hb.Card.Root",
+          props: { variant: "outlined" },
+          children: [
+            {
+              id: "n_card_body",
+              type: "Hb.Stack",
+              props: { direction: "column", gap: 2 },
+              children: [
+                { id: "n_name", type: "Hb.TextField", props: { label: "이름" }, children: [] },
+                {
+                  id: "n_email",
+                  type: "Hb.TextField",
+                  props: { label: "이메일", placeholder: "you@example.com" },
+                  children: [],
+                },
+                { id: "n_div", type: "Hb.Divider", props: {}, children: [] },
+                {
+                  id: "n_chips",
+                  type: "Hb.Stack",
+                  props: { direction: "row", gap: 1 },
+                  children: [
+                    {
+                      id: "n_chip_role",
+                      type: "Hb.Chip",
+                      props: { label: "관리자", variant: "outlined" },
+                      children: [],
+                    },
+                    {
+                      id: "n_chip_status",
+                      type: "Hb.Chip",
+                      props: { label: "활성", variant: "filled" },
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "n_actions",
+          type: "Hb.Stack",
+          props: { direction: "row", gap: 1 },
+          children: [
+            {
+              id: "n_cancel",
+              type: "Hb.Button",
+              props: { variant: "ghost" },
+              children: [{ id: "n_cancel_label", type: "text", value: "취소" }],
+            },
+            {
+              id: "n_btn",
+              type: "Hb.Button",
+              props: { variant: "primary", disabled: false },
+              children: [{ id: "n_btn_label", type: "text", value: "저장" }],
+            },
+          ],
+        },
+      ],
     },
   ],
 });

--- a/apps/hobom-system/src/entities/manifest/model/card.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/card.manifest.ts
@@ -1,0 +1,12 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.Card.Root` 매니페스트. 컨테이너 — 임의 컴포넌트를 자식으로 받는다. */
+export const cardManifest: ComponentManifest = {
+  name: "Hb.Card.Root",
+  import: { source: "hobom-design-system", access: "Hb.Card.Root" },
+  category: "layout",
+  props: {
+    variant: { kind: "enum", values: ["outlined", "elevation"], default: "outlined" },
+    children: { kind: "slot", accepts: ["*"] },
+  },
+};

--- a/apps/hobom-system/src/entities/manifest/model/chip.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/chip.manifest.ts
@@ -1,0 +1,12 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.Chip` 매니페스트. label prop으로 구성, 자식 없음. */
+export const chipManifest: ComponentManifest = {
+  name: "Hb.Chip",
+  import: { source: "hobom-design-system", access: "Hb.Chip" },
+  category: "data-display",
+  props: {
+    label: { kind: "string", default: "Chip" },
+    variant: { kind: "enum", values: ["filled", "outlined"], default: "filled" },
+  },
+};

--- a/apps/hobom-system/src/entities/manifest/model/divider.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/divider.manifest.ts
@@ -1,0 +1,9 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.Divider` 매니페스트. prop·자식 없는 단순 구분선. */
+export const dividerManifest: ComponentManifest = {
+  name: "Hb.Divider",
+  import: { source: "hobom-design-system", access: "Hb.Divider" },
+  category: "layout",
+  props: {},
+};

--- a/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
@@ -11,6 +11,8 @@
 /** prop 한 개의 편집/생성 스펙. `kind`로 구분되는 discriminated union. */
 export type PropSpec =
   | { kind: "enum"; values: readonly string[]; default: string }
+  | { kind: "string"; default: string }
+  | { kind: "number"; default: number }
   | { kind: "boolean"; default: boolean }
   | { kind: "slot"; accepts: readonly NodeKind[] };
 

--- a/apps/hobom-system/src/entities/manifest/model/manifest.registry.spec.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.registry.spec.ts
@@ -14,6 +14,22 @@ describe("manifest.registry", () => {
     expect(listManifests()).toEqual(Object.values(MANIFEST_REGISTRY));
   });
 
+  it("확장된 컴포넌트 카탈로그를 모두 등록한다", () => {
+    const names = listManifests().map((manifest) => manifest.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "Hb.Stack",
+        "Hb.Text",
+        "Hb.Button",
+        "Hb.TextField",
+        "Hb.Chip",
+        "Hb.Card.Root",
+        "Hb.Divider",
+      ]),
+    );
+  });
+
   it("레지스트리 키는 매니페스트의 name과 일치한다", () => {
     for (const [key, manifest] of Object.entries(MANIFEST_REGISTRY)) {
       expect(key).toBe(manifest.name);

--- a/apps/hobom-system/src/entities/manifest/model/manifest.registry.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.registry.ts
@@ -1,9 +1,21 @@
 import { buttonManifest } from "./button.manifest";
+import { cardManifest } from "./card.manifest";
+import { chipManifest } from "./chip.manifest";
+import { dividerManifest } from "./divider.manifest";
+import { stackManifest } from "./stack.manifest";
+import { textManifest } from "./text.manifest";
+import { textFieldManifest } from "./text-field.manifest";
 import type { ComponentKey, ComponentManifest } from "./manifest.model";
 
 /** 컴포넌트 키 → 매니페스트. 새 컴포넌트는 여기 등록한다. */
 export const MANIFEST_REGISTRY: Readonly<Record<ComponentKey, ComponentManifest>> = {
+  [stackManifest.name]: stackManifest,
+  [textManifest.name]: textManifest,
   [buttonManifest.name]: buttonManifest,
+  [textFieldManifest.name]: textFieldManifest,
+  [chipManifest.name]: chipManifest,
+  [cardManifest.name]: cardManifest,
+  [dividerManifest.name]: dividerManifest,
 };
 
 /** 등록된 매니페스트를 조회한다. 미등록 키는 `undefined`. */

--- a/apps/hobom-system/src/entities/manifest/model/stack.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/stack.manifest.ts
@@ -1,0 +1,13 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.Stack` 매니페스트. 흐름(flex) 레이아웃 컨테이너 — 임의 컴포넌트를 자식으로 받는다. */
+export const stackManifest: ComponentManifest = {
+  name: "Hb.Stack",
+  import: { source: "hobom-design-system", access: "Hb.Stack" },
+  category: "layout",
+  props: {
+    direction: { kind: "enum", values: ["row", "column"], default: "column" },
+    gap: { kind: "number", default: 2 },
+    children: { kind: "slot", accepts: ["*"] },
+  },
+};

--- a/apps/hobom-system/src/entities/manifest/model/text-field.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/text-field.manifest.ts
@@ -1,0 +1,13 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.TextField` 매니페스트. 자식 없이 prop으로 구성. */
+export const textFieldManifest: ComponentManifest = {
+  name: "Hb.TextField",
+  import: { source: "hobom-design-system", access: "Hb.TextField" },
+  category: "input",
+  props: {
+    label: { kind: "string", default: "Label" },
+    placeholder: { kind: "string", default: "" },
+    disabled: { kind: "boolean", default: false },
+  },
+};

--- a/apps/hobom-system/src/entities/manifest/model/text.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/text.manifest.ts
@@ -1,0 +1,16 @@
+import type { ComponentManifest } from "./manifest.model";
+
+/** `Hb.Text` 매니페스트. 텍스트 내용은 자식 텍스트 노드로 둔다. */
+export const textManifest: ComponentManifest = {
+  name: "Hb.Text",
+  import: { source: "hobom-design-system", access: "Hb.Text" },
+  category: "typography",
+  props: {
+    variant: {
+      kind: "enum",
+      values: ["h6", "body1", "body2", "caption"],
+      default: "body1",
+    },
+    children: { kind: "slot", accepts: ["text"] },
+  },
+};

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
@@ -4,13 +4,35 @@ import { generateJsx } from "./generate-jsx.lib";
 
 describe("generateJsx", () => {
   it("default와 같은 prop은 생략한다", () => {
-    // 샘플: variant=primary(default), disabled=false(default) → 둘 다 생략
-    const code = generateJsx(createSampleDocument());
+    // variant=primary(default), disabled=false(default) → 둘 다 생략
+    const doc: StudioDocument = {
+      children: [
+        {
+          id: "b",
+          type: "Hb.Button",
+          props: { variant: "primary", disabled: false },
+          children: [{ id: "t", type: "text", value: "저장" }],
+        },
+      ],
+    };
+    const code = generateJsx(doc);
 
     expect(code).toContain('import { Hb } from "hobom-design-system";');
     expect(code).toContain("<Hb.Button>저장</Hb.Button>");
     expect(code).not.toContain("variant");
     expect(code).not.toContain("disabled");
+  });
+
+  it("컨테이너(Stack/Card)와 자식을 중첩 코드로 생성한다", () => {
+    const code = generateJsx(createSampleDocument());
+
+    expect(code).toContain('<Hb.Text variant="h6">회원 가입</Hb.Text>');
+    expect(code).toContain("<Hb.Card.Root>");
+    expect(code).toContain('<Hb.TextField label="이름" />');
+    expect(code).toContain('<Hb.Chip label="관리자" variant="outlined" />');
+    expect(code).toContain("<Hb.Divider />");
+    expect(code).toContain("<Hb.Button>저장</Hb.Button>");
+    expect(code).toContain("</Hb.Card.Root>");
   });
 
   it("default와 다른 enum 값은 속성으로 출력한다", () => {

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment happy-dom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { createSampleDocument } from "@/entities/document";
+import type { DocumentNode } from "@/entities/document";
 import { Inspector } from "./Inspector";
 
-const buttonNode = createSampleDocument().children[0];
+const buttonNode: DocumentNode = {
+  id: "btn",
+  type: "Hb.Button",
+  props: { variant: "primary", disabled: false },
+  children: [{ id: "btn_label", type: "text", value: "저장" }],
+};
 
 describe("Inspector", () => {
   it("선택된 노드가 없으면 안내 문구를 보여준다", () => {

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -52,6 +52,7 @@ interface PropFieldProps {
 }
 
 const labelSx = { fontSize: 11, color: "text.secondary" } as const;
+const inputSx = { "& .MuiInputBase-input": { fontSize: 12, py: 0.75 } } as const;
 
 /** prop 한 개를 spec.kind에 맞는 컨트롤로 렌더한다. slot은 편집 대상이 아니다. */
 function PropField({ name, spec, value, onChange }: PropFieldProps) {
@@ -73,6 +74,40 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
           sx={{ p: 0 }}
           checked={Boolean(value)}
           onChange={(event) => onChange(name, event.target.checked)}
+        />
+      </Hb.Stack>
+    );
+  }
+
+  if (spec.kind === "string") {
+    return (
+      <Hb.Stack gap={0.5} sx={{ minWidth: 0 }}>
+        <Hb.Text sx={labelSx}>{name}</Hb.Text>
+        <Hb.TextField
+          size="small"
+          value={value === undefined ? "" : String(value)}
+          onChange={(event) => onChange(name, event.target.value)}
+          sx={inputSx}
+        />
+      </Hb.Stack>
+    );
+  }
+
+  if (spec.kind === "number") {
+    return (
+      <Hb.Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ minHeight: 24 }}
+      >
+        <Hb.Text sx={labelSx}>{name}</Hb.Text>
+        <Hb.TextField
+          size="small"
+          type="number"
+          value={value === undefined ? "" : String(value)}
+          onChange={(event) => onChange(name, Number(event.target.value))}
+          sx={{ ...inputSx, width: 72 }}
         />
       </Hb.Stack>
     );


### PR DESCRIPTION
## 개요
Studio가 다룰 수 있는 컴포넌트를 버튼 1종에서 **7종으로 확장**합니다. 흐름 D&D/삽입(다음 PR) 전에, 컨테이너 중첩과 다양한 prop이 **렌더 + 코드 생성까지 실제로 도는지** 먼저 검증합니다.

## 변경 사항
- **PropSpec 확장**: `string`(텍스트 입력) · `number`(숫자 입력) 종류 추가 → 인스펙터 컨트롤도 추가
- **매니페스트 6종 추가**: `Hb.Stack`(컨테이너) · `Hb.Text` · `Hb.Card.Root`(컨테이너) · `Hb.TextField` · `Hb.Chip` · `Hb.Divider`
- **샘플 문서** → 카탈로그 전반을 보여주는 회원가입 카드 폼(중첩 Stack·Card·Chip 2종·Divider·Button 2종)

## 동작
캔버스에 폼이 렌더되고, 코드 패널은 전체를 중첩 JSX로 생성:
```jsx
<Hb.Stack>
  <Hb.Text variant="h6">회원 가입</Hb.Text>
  <Hb.Card.Root>
    ...
    <Hb.Chip label="관리자" variant="outlined" />
    <Hb.Divider />
  </Hb.Card.Root>
  ...
</Hb.Stack>
```

## 검증
- 타입체크 통과 / 테스트 242건 통과 / eslint 통과 / knip 통과

## 다음
- PR-B: Insert 팔레트(클릭으로 추가) + 트리 연산(insert/remove) + 삭제
- PR-C: dnd-kit 흐름 드래그(순서변경·중첩)