### PR TITLE
feat: Studio Insert 팔레트 + 노드 삽입/삭제

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -1,8 +1,10 @@
 export type {
+  ComponentNode,
   DocumentNode,
   NodeId,
   PropValue,
   StudioDocument,
 } from "./model/document.model";
 export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
-export { findNode, updateNodeProps } from "./lib/document-tree.lib";
+export { findNode, insertNode, removeNode, updateNodeProps } from "./lib/document-tree.lib";
+export { createNodeId } from "./lib/create-node-id.lib";

--- a/apps/hobom-system/src/entities/document/lib/create-node-id.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/create-node-id.lib.ts
@@ -1,0 +1,4 @@
+import type { NodeId } from "../model/document.model";
+
+/** 새 노드용 고유 id를 생성한다. */
+export const createNodeId = (): NodeId => `n_${crypto.randomUUID()}`;

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -52,3 +52,41 @@ export const updateNodeProps = (
 
   return { ...doc, children: doc.children.map(mapNode) };
 };
+
+/**
+ * 노드를 부모의 자식 끝에 삽입한 새 문서를 반환한다(불변).
+ * `parentId`가 null이면 문서 루트에 삽입한다.
+ */
+export const insertNode = (
+  doc: StudioDocument,
+  parentId: NodeId | null,
+  node: DocumentNode,
+): StudioDocument => {
+  if (parentId === null) {
+    return { ...doc, children: [...doc.children, node] };
+  }
+
+  const mapNode = (current: DocumentNode): DocumentNode => {
+    if (!isComponentNode(current)) {
+      return current;
+    }
+
+    const children = current.children.map(mapNode);
+
+    return current.id === parentId
+      ? { ...current, children: [...children, node] }
+      : { ...current, children };
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
+};
+
+/** id에 해당하는 노드를 제거한 새 문서를 반환한다(불변, 깊이 우선). */
+export const removeNode = (doc: StudioDocument, id: NodeId): StudioDocument => {
+  const filterNodes = (nodes: DocumentNode[]): DocumentNode[] =>
+    nodes
+      .filter((node) => node.id !== id)
+      .map((node) => (isComponentNode(node) ? { ...node, children: filterNodes(node.children) } : node));
+
+  return { ...doc, children: filterNodes(doc.children) };
+};

--- a/apps/hobom-system/src/entities/document/lib/insert-remove.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/insert-remove.lib.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { isComponentNode, type DocumentNode, type StudioDocument } from "../model/document.model";
+import { findNode, insertNode, removeNode  } from "./document-tree.lib";
+import { createNodeId } from "./create-node-id.lib";
+
+const button = (id: string): DocumentNode => ({ id, type: "Hb.Button", props: {}, children: [] });
+
+const baseDoc = (): StudioDocument => ({
+  children: [{ id: "stack", type: "Hb.Stack", props: {}, children: [button("a")] }],
+});
+
+describe("insertNode", () => {
+  it("부모(컨테이너)의 자식 끝에 삽입한다", () => {
+    const next = insertNode(baseDoc(), "stack", button("b"));
+    const stack = findNode(next, "stack");
+
+    expect(stack && isComponentNode(stack) && stack.children.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("parentId가 null이면 루트에 삽입한다", () => {
+    const next = insertNode(baseDoc(), null, button("root2"));
+
+    expect(next.children.map((c) => c.id)).toEqual(["stack", "root2"]);
+  });
+
+  it("원본은 불변", () => {
+    const doc = baseDoc();
+
+    insertNode(doc, "stack", button("b"));
+
+    expect(findNode(doc, "b")).toBeUndefined();
+  });
+});
+
+describe("removeNode", () => {
+  it("중첩된 노드를 제거한다", () => {
+    const next = removeNode(baseDoc(), "a");
+    const stack = findNode(next, "stack");
+
+    expect(stack && isComponentNode(stack) && stack.children).toHaveLength(0);
+  });
+
+  it("최상위 노드를 제거한다", () => {
+    expect(removeNode(baseDoc(), "stack").children).toHaveLength(0);
+  });
+});
+
+describe("createNodeId", () => {
+  it("n_ 접두사 + 매번 고유", () => {
+    const a = createNodeId();
+    const b = createNodeId();
+
+    expect(a.startsWith("n_")).toBe(true);
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/hobom-system/src/entities/manifest/index.ts
+++ b/apps/hobom-system/src/entities/manifest/index.ts
@@ -1,2 +1,2 @@
-export type { PropSpec } from "./model/manifest.model";
-export { getManifest } from "./model/manifest.registry";
+export type { ComponentKey, ComponentManifest, PropSpec } from "./model/manifest.model";
+export { getManifest, listManifests } from "./model/manifest.registry";

--- a/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.spec.ts
+++ b/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getManifest } from "@/entities/manifest";
+import { createComponentNode } from "./create-component-node.lib";
+
+const counter = () => {
+  let n = 0;
+
+  return () => `id_${n++}`;
+};
+
+const manifest = (key: string) => {
+  const found = getManifest(key);
+
+  if (!found) {
+    throw new Error(`no manifest: ${key}`);
+  }
+
+  return found;
+};
+
+describe("createComponentNode", () => {
+  it("매니페스트 기본 prop을 채운다", () => {
+    const node = createComponentNode(manifest("Hb.Stack"), counter());
+
+    expect(node.type).toBe("Hb.Stack");
+    expect(node.props.direction).toBe("column");
+    expect(node.props.gap).toBe(2);
+  });
+
+  it("slot이 text를 받으면 기본 텍스트 자식을 둔다", () => {
+    const node = createComponentNode(manifest("Hb.Button"), counter());
+
+    expect(node.children).toHaveLength(1);
+    expect(node.children[0]).toMatchObject({ type: "text", value: "버튼" });
+  });
+
+  it("컨테이너(slot이 컴포넌트만 받음)는 빈 자식으로 둔다", () => {
+    const node = createComponentNode(manifest("Hb.Card.Root"), counter());
+
+    expect(node.children).toHaveLength(0);
+  });
+});

--- a/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.ts
+++ b/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.ts
@@ -1,0 +1,42 @@
+import type { ComponentManifest } from "@/entities/manifest";
+import type { ComponentNode, NodeId, PropValue } from "@/entities/document";
+
+/** slot이 text를 받는 컴포넌트의 기본 텍스트 자식 내용. */
+const DEFAULT_TEXT: Record<string, string> = {
+  "Hb.Button": "버튼",
+  "Hb.Text": "텍스트",
+};
+
+/**
+ * 매니페스트 기본값으로 새 컴포넌트 노드를 만든다.
+ * slot이 text를 받으면 기본 텍스트 자식을 두고, 그 외 컨테이너는 빈 채로 둔다.
+ */
+export function createComponentNode(
+  manifest: ComponentManifest,
+  createId: () => NodeId,
+): ComponentNode {
+  const id = createId();
+  const props: Record<string, PropValue> = {};
+  let acceptsText = false;
+
+  for (const [name, spec] of Object.entries(manifest.props)) {
+    if (spec.kind === "slot") {
+      acceptsText = spec.accepts.includes("text");
+      continue;
+    }
+
+    props[name] = spec.default;
+  }
+
+  const children = acceptsText
+    ? [{ id: createId(), type: "text" as const, value: DEFAULT_TEXT[manifest.name] ?? "텍스트" }]
+    : [];
+
+  return { id, type: manifest.name, props, children };
+}
+
+/** 컴포넌트를 자식으로 받는 컨테이너인지(slot이 text 외의 노드를 허용). */
+export const acceptsComponentChildren = (manifest: ComponentManifest): boolean =>
+  Object.values(manifest.props).some(
+    (spec) => spec.kind === "slot" && spec.accepts.some((accept) => accept !== "text"),
+  );

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -1,20 +1,31 @@
 import { useCallback, useMemo, useState } from "react";
+import { getManifest, type ComponentKey } from "@/entities/manifest";
 import {
+  createNodeId,
   createSampleDocument,
   findNode,
+  insertNode,
+  isComponentNode,
+  removeNode,
   updateNodeProps,
   type DocumentNode,
   type NodeId,
   type PropValue,
 } from "@/entities/document";
+import { acceptsComponentChildren, createComponentNode } from "../lib/create-component-node.lib";
 
 /**
- * Studio 에디터 상태 오케스트레이션 — 문서·선택·prop 편집을 한 곳에서 소유한다.
- * 캔버스와 인스펙터가 이 훅의 상태를 공유한다(컴포넌트는 순수 렌더).
+ * Studio 에디터 상태 오케스트레이션 — 문서·선택·삽입·삭제·prop 편집을 한 곳에서 소유한다.
+ * 캔버스/팔레트/인스펙터가 이 훅의 상태를 공유한다(컴포넌트는 순수 렌더).
  */
 export function useStudioEditor() {
   const [document, setDocument] = useState(createSampleDocument);
   const [selectedId, setSelectedId] = useState<NodeId | undefined>(undefined);
+
+  const selectedNode: DocumentNode | undefined = useMemo(
+    () => (selectedId ? findNode(document, selectedId) : undefined),
+    [document, selectedId],
+  );
 
   const selectNode = useCallback((id: NodeId) => setSelectedId(id), []);
 
@@ -29,10 +40,45 @@ export function useStudioEditor() {
     [selectedId],
   );
 
-  const selectedNode: DocumentNode | undefined = useMemo(
-    () => (selectedId ? findNode(document, selectedId) : undefined),
-    [document, selectedId],
+  const insertComponent = useCallback(
+    (key: ComponentKey) => {
+      const manifest = getManifest(key);
+
+      if (!manifest) {
+        return;
+      }
+
+      const node = createComponentNode(manifest, createNodeId);
+      const container =
+        selectedNode && isComponentNode(selectedNode) ? selectedNode : undefined;
+      const containerManifest = container ? getManifest(container.type) : undefined;
+      const parentId =
+        container && containerManifest && acceptsComponentChildren(containerManifest)
+          ? container.id
+          : null;
+
+      setDocument((doc) => insertNode(doc, parentId, node));
+      setSelectedId(node.id);
+    },
+    [selectedNode],
   );
 
-  return { document, selectedId, selectedNode, selectNode, updateProp };
+  const deleteSelected = useCallback(() => {
+    if (!selectedId) {
+      return;
+    }
+
+    setDocument((doc) => removeNode(doc, selectedId));
+    setSelectedId(undefined);
+  }, [selectedId]);
+
+  return {
+    document,
+    selectedId,
+    selectedNode,
+    selectNode,
+    updateProp,
+    insertComponent,
+    deleteSelected,
+  };
 }

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,6 +1,7 @@
 import { Hb } from "@/shared/ui";
 import { Canvas } from "@/widgets/canvas";
 import { CodePanel } from "@/widgets/code-panel";
+import { InsertPalette } from "@/widgets/insert-palette";
 import { Inspector } from "@/widgets/inspector";
 import { LayersPanel } from "@/widgets/layers-panel";
 import { useStudioEditor } from "../model/useStudioEditor";
@@ -8,10 +9,11 @@ import { studioTheme } from "../config/studio-theme";
 
 /**
  * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
- * 좌: 레이어 / 중앙: 캔버스(아트보드) / 우: 속성 + 코드. (디자인 툴 류 다크 UI)
+ * 좌: 삽입+레이어 / 중앙: 캔버스(아트보드) / 우: 속성 + 코드. (디자인 툴 류 다크 UI)
  */
 export default function StudioPage() {
-  const { document, selectedId, selectedNode, selectNode, updateProp } = useStudioEditor();
+  const { document, selectedId, selectedNode, selectNode, updateProp, insertComponent, deleteSelected } =
+    useStudioEditor();
 
   return (
     <Hb.ThemeProvider theme={studioTheme}>
@@ -24,7 +26,11 @@ export default function StudioPage() {
           color: "text.primary",
         }}
       >
-        <Panel title="Layers" width={232} side="right">
+        <Panel width={232} side="right">
+          <SectionHeader>삽입</SectionHeader>
+          <InsertPalette onInsert={insertComponent} />
+          <Hb.Divider />
+          <SectionHeader>레이어</SectionHeader>
           <LayersPanel document={document} selectedId={selectedId} onSelect={selectNode} />
         </Panel>
 
@@ -57,7 +63,7 @@ export default function StudioPage() {
         </Hb.Stack>
 
         <Panel width={280} side="left">
-          <Inspector node={selectedNode} onChange={updateProp} />
+          <Inspector node={selectedNode} onChange={updateProp} onDelete={deleteSelected} />
           <Hb.Divider />
           <Hb.Box sx={{ p: 1.5 }}>
             <CodePanel document={document} />
@@ -69,14 +75,13 @@ export default function StudioPage() {
 }
 
 interface PanelProps {
-  title?: string;
   width: number;
   side: "left" | "right";
   children: React.ReactNode;
 }
 
-/** 좌/우 사이드 패널. 선택적 sticky 헤더 + 스크롤 본문. */
-function Panel({ title, width, side, children }: PanelProps) {
+/** 좌/우 사이드 패널 — 스크롤 본문 컨테이너. */
+function Panel({ width, side, children }: PanelProps) {
   return (
     <Hb.Stack
       sx={{
@@ -89,33 +94,26 @@ function Panel({ title, width, side, children }: PanelProps) {
         overflow: "auto",
       }}
     >
-      {title && (
-        <Hb.Box
-          sx={{
-            px: 1.5,
-            py: 1,
-            position: "sticky",
-            top: 0,
-            zIndex: 1,
-            bgcolor: "background.paper",
-            borderBottom: 1,
-            borderColor: "divider",
-          }}
-        >
-          <Hb.Text
-            sx={{
-              fontSize: 11,
-              fontWeight: 600,
-              letterSpacing: 0.5,
-              textTransform: "uppercase",
-              color: "text.secondary",
-            }}
-          >
-            {title}
-          </Hb.Text>
-        </Hb.Box>
-      )}
       {children}
     </Hb.Stack>
+  );
+}
+
+/** 패널 내 섹션 헤더(작은 대문자 라벨). */
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <Hb.Box sx={{ px: 1.5, py: 1, borderBottom: 1, borderColor: "divider" }}>
+      <Hb.Text
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: 0.5,
+          textTransform: "uppercase",
+          color: "text.secondary",
+        }}
+      >
+        {children}
+      </Hb.Text>
+    </Hb.Box>
   );
 }

--- a/apps/hobom-system/src/widgets/insert-palette/index.ts
+++ b/apps/hobom-system/src/widgets/insert-palette/index.ts
@@ -1,0 +1,1 @@
+export { InsertPalette } from "./ui/InsertPalette";

--- a/apps/hobom-system/src/widgets/insert-palette/ui/InsertPalette.tsx
+++ b/apps/hobom-system/src/widgets/insert-palette/ui/InsertPalette.tsx
@@ -1,0 +1,37 @@
+import { Hb } from "@/shared/ui";
+import { listManifests, type ComponentKey } from "@/entities/manifest";
+
+interface InsertPaletteProps {
+  onInsert: (key: ComponentKey) => void;
+}
+
+/** 등록된 컴포넌트를 칩 목록으로 보여준다. 클릭하면 선택된 컨테이너(또는 루트)에 추가. */
+export function InsertPalette({ onInsert }: InsertPaletteProps) {
+  return (
+    <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, p: 1.5 }}>
+      {listManifests().map((manifest) => (
+        <Hb.Box
+          key={manifest.name}
+          component="button"
+          onClick={() => onInsert(manifest.name)}
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            bgcolor: "transparent",
+            color: "text.primary",
+            fontFamily: "inherit",
+            fontSize: 12,
+            px: 1,
+            py: 0.5,
+            cursor: "pointer",
+            transition: "background-color 0.12s",
+            "&:hover": { bgcolor: "action.hover" },
+          }}
+        >
+          {manifest.name.replace(/^Hb\./, "")}
+        </Hb.Box>
+      ))}
+    </Hb.Box>
+  );
+}

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
@@ -13,13 +13,13 @@ const buttonNode: DocumentNode = {
 
 describe("Inspector", () => {
   it("선택된 노드가 없으면 안내 문구를 보여준다", () => {
-    render(<Inspector node={undefined} onChange={vi.fn()} />);
+    render(<Inspector node={undefined} onChange={vi.fn()} onDelete={vi.fn()} />);
 
     expect(screen.getByText("요소를 선택하세요")).toBeDefined();
   });
 
   it("매니페스트의 enum 옵션을 버튼으로 렌더한다", () => {
-    render(<Inspector node={buttonNode} onChange={vi.fn()} />);
+    render(<Inspector node={buttonNode} onChange={vi.fn()} onDelete={vi.fn()} />);
 
     for (const variant of ["primary", "secondary", "danger", "ghost"]) {
       expect(screen.getByRole("button", { name: variant })).toBeDefined();
@@ -29,7 +29,7 @@ describe("Inspector", () => {
   it("enum 옵션 클릭 시 onChange(prop, value)를 호출한다", () => {
     const onChange = vi.fn();
 
-    render(<Inspector node={buttonNode} onChange={onChange} />);
+    render(<Inspector node={buttonNode} onChange={onChange} onDelete={vi.fn()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "danger" }));
 
@@ -37,7 +37,7 @@ describe("Inspector", () => {
   });
 
   it("boolean prop은 체크박스로 렌더한다", () => {
-    render(<Inspector node={buttonNode} onChange={vi.fn()} />);
+    render(<Inspector node={buttonNode} onChange={vi.fn()} onDelete={vi.fn()} />);
 
     expect(screen.getByRole("checkbox")).toBeDefined();
   });

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -1,3 +1,4 @@
+import { DeleteOutline } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
 import { getManifest, type PropSpec } from "@/entities/manifest";
 import { isComponentNode, type DocumentNode, type PropValue } from "@/entities/document";
@@ -5,10 +6,11 @@ import { isComponentNode, type DocumentNode, type PropValue } from "@/entities/d
 interface InspectorProps {
   node: DocumentNode | undefined;
   onChange: (prop: string, value: PropValue) => void;
+  onDelete: () => void;
 }
 
 /** 선택된 노드의 prop을 매니페스트 기반 컨트롤로 편집한다(피그마식 속성 패널). */
-export function Inspector({ node, onChange }: InspectorProps) {
+export function Inspector({ node, onChange, onDelete }: InspectorProps) {
   if (!node || !isComponentNode(node)) {
     return (
       <Hb.Box sx={{ p: 2 }}>
@@ -21,7 +23,22 @@ export function Inspector({ node, onChange }: InspectorProps) {
 
   return (
     <Hb.Box sx={{ p: 1.5 }}>
-      <Hb.Text sx={{ fontSize: 13, fontWeight: 600, mb: 1.5 }}>{node.type}</Hb.Text>
+      <Hb.Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ mb: 1.5 }}
+      >
+        <Hb.Text sx={{ fontSize: 13, fontWeight: 600 }}>{node.type}</Hb.Text>
+        <Hb.Button.Icon
+          size="small"
+          aria-label="삭제"
+          onClick={onDelete}
+          sx={{ p: 0.25, color: "text.secondary" }}
+        >
+          <DeleteOutline sx={{ fontSize: 16 }} />
+        </Hb.Button.Icon>
+      </Hb.Stack>
 
       {!manifest ? (
         <Hb.Text sx={{ fontSize: 12, color: "error.main" }}>


### PR DESCRIPTION
## 개요
컴포넌트를 캔버스에 **추가/삭제**할 수 있게 합니다. (흐름 D&D 드래그는 이후 PR)

## 변경 사항
- 트리 연산 `insertNode` / `removeNode` + `createNodeId` (불변, 단위테스트)
- **Insert 팔레트** 위젯 — 등록 컴포넌트를 칩으로, 클릭 시 선택된 컨테이너(또는 루트)에 추가
- `createComponentNode` — 매니페스트 기본값으로 노드 생성(text slot엔 기본 자식)
- `useStudioEditor`: `insertComponent` / `deleteSelected`
- 인스펙터 **삭제 아이콘 버튼**, 좌측 패널 삽입/레이어 섹션 분리

## 검증
- 타입체크 통과 / 테스트 통과 / eslint 통과 / knip 통과

## 다음
- 사이징(width/height) 인스펙터 + 코드생성 → 이어서 리사이즈 핸들