### PR TITLE
feat: Studio 사이징(width/height)

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -2,9 +2,16 @@ export type {
   ComponentNode,
   DocumentNode,
   NodeId,
+  NodeStyle,
   PropValue,
   StudioDocument,
 } from "./model/document.model";
 export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
-export { findNode, insertNode, removeNode, updateNodeProps } from "./lib/document-tree.lib";
+export {
+  findNode,
+  insertNode,
+  removeNode,
+  updateNodeProps,
+  updateNodeStyle,
+} from "./lib/document-tree.lib";
 export { createNodeId } from "./lib/create-node-id.lib";

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -3,6 +3,7 @@ import {
   type ComponentNode,
   type DocumentNode,
   type NodeId,
+  type NodeStyle,
   type PropValue,
   type StudioDocument,
 } from "../model/document.model";
@@ -89,4 +90,39 @@ export const removeNode = (doc: StudioDocument, id: NodeId): StudioDocument => {
       .map((node) => (isComponentNode(node) ? { ...node, children: filterNodes(node.children) } : node));
 
   return { ...doc, children: filterNodes(doc.children) };
+};
+
+/**
+ * 노드의 사이징(style) 한 키를 바꾼 새 문서를 반환한다(불변).
+ * `value`가 undefined면 해당 키를 제거한다(미설정).
+ */
+export const updateNodeStyle = (
+  doc: StudioDocument,
+  id: NodeId,
+  key: keyof NodeStyle,
+  value: number | undefined,
+): StudioDocument => {
+  const mapNode = (node: DocumentNode): DocumentNode => {
+    if (!isComponentNode(node)) {
+      return node;
+    }
+
+    const next: ComponentNode = { ...node, children: node.children.map(mapNode) };
+
+    if (node.id !== id) {
+      return next;
+    }
+
+    const style: NodeStyle = { ...node.style };
+
+    if (value === undefined) {
+      delete style[key];
+    } else {
+      style[key] = value;
+    }
+
+    return { ...next, style };
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
 };

--- a/apps/hobom-system/src/entities/document/lib/insert-remove.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/insert-remove.lib.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isComponentNode, type DocumentNode, type StudioDocument } from "../model/document.model";
-import { findNode, insertNode, removeNode  } from "./document-tree.lib";
+import { findNode, insertNode, removeNode, updateNodeStyle } from "./document-tree.lib";
 import { createNodeId } from "./create-node-id.lib";
 
 const button = (id: string): DocumentNode => ({ id, type: "Hb.Button", props: {}, children: [] });
@@ -42,6 +42,23 @@ describe("removeNode", () => {
 
   it("최상위 노드를 제거한다", () => {
     expect(removeNode(baseDoc(), "stack").children).toHaveLength(0);
+  });
+});
+
+describe("updateNodeStyle", () => {
+  it("사이징 키를 설정한다", () => {
+    const next = updateNodeStyle(baseDoc(), "a", "width", 200);
+    const node = findNode(next, "a");
+
+    expect(node && isComponentNode(node) && node.style?.width).toBe(200);
+  });
+
+  it("undefined면 키를 제거한다", () => {
+    const withWidth = updateNodeStyle(baseDoc(), "a", "width", 200);
+    const cleared = updateNodeStyle(withWidth, "a", "width", undefined);
+    const node = findNode(cleared, "a");
+
+    expect(node && isComponentNode(node) && node.style?.width).toBeUndefined();
   });
 });
 

--- a/apps/hobom-system/src/entities/document/model/document.model.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.ts
@@ -26,12 +26,19 @@ export interface TextNode {
   value: string;
 }
 
+/** 흐름 안에서의 사이징 오버라이드(px). 코드 생성 시 sx로 직렬화된다. */
+export interface NodeStyle {
+  width?: number;
+  height?: number;
+}
+
 /** 디자인 시스템 컴포넌트 노드. */
 export interface ComponentNode {
   id: NodeId;
   type: ComponentKey;
   props: NodeProps;
   children: DocumentNode[];
+  style?: NodeStyle;
 }
 
 export type DocumentNode = TextNode | ComponentNode;

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -8,8 +8,10 @@ import {
   isComponentNode,
   removeNode,
   updateNodeProps,
+  updateNodeStyle,
   type DocumentNode,
   type NodeId,
+  type NodeStyle,
   type PropValue,
 } from "@/entities/document";
 import { acceptsComponentChildren, createComponentNode } from "../lib/create-component-node.lib";
@@ -63,6 +65,17 @@ export function useStudioEditor() {
     [selectedNode],
   );
 
+  const updateStyle = useCallback(
+    (key: keyof NodeStyle, value: number | undefined) => {
+      if (!selectedId) {
+        return;
+      }
+
+      setDocument((doc) => updateNodeStyle(doc, selectedId, key, value));
+    },
+    [selectedId],
+  );
+
   const deleteSelected = useCallback(() => {
     if (!selectedId) {
       return;
@@ -78,6 +91,7 @@ export function useStudioEditor() {
     selectedNode,
     selectNode,
     updateProp,
+    updateStyle,
     insertComponent,
     deleteSelected,
   };

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -12,8 +12,16 @@ import { studioTheme } from "../config/studio-theme";
  * 좌: 삽입+레이어 / 중앙: 캔버스(아트보드) / 우: 속성 + 코드. (디자인 툴 류 다크 UI)
  */
 export default function StudioPage() {
-  const { document, selectedId, selectedNode, selectNode, updateProp, insertComponent, deleteSelected } =
-    useStudioEditor();
+  const {
+    document,
+    selectedId,
+    selectedNode,
+    selectNode,
+    updateProp,
+    updateStyle,
+    insertComponent,
+    deleteSelected,
+  } = useStudioEditor();
 
   return (
     <Hb.ThemeProvider theme={studioTheme}>
@@ -63,7 +71,12 @@ export default function StudioPage() {
         </Hb.Stack>
 
         <Panel width={280} side="left">
-          <Inspector node={selectedNode} onChange={updateProp} onDelete={deleteSelected} />
+          <Inspector
+            node={selectedNode}
+            onChange={updateProp}
+            onStyleChange={updateStyle}
+            onDelete={deleteSelected}
+          />
           <Hb.Divider />
           <Hb.Box sx={{ p: 1.5 }}>
             <CodePanel document={document} />

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
@@ -53,7 +53,7 @@ function NodeView({ node, selectedId, onSelect }: NodeViewProps) {
         outlineOffset: 2,
       }}
     >
-      <Component {...node.props}>
+      <Component {...node.props} sx={node.style}>
         {node.children.map((child) => (
           <NodeView key={child.id} node={child} selectedId={selectedId} onSelect={onSelect} />
         ))}

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
@@ -47,6 +47,22 @@ describe("generateJsx", () => {
     expect(generateJsx(doc)).toContain("<Hb.Button disabled>저장</Hb.Button>");
   });
 
+  it("사이징(style)이 있으면 sx로 출력한다", () => {
+    const doc: StudioDocument = {
+      children: [
+        {
+          id: "b",
+          type: "Hb.Button",
+          props: {},
+          children: [{ id: "t", type: "text", value: "저장" }],
+          style: { width: 200 },
+        },
+      ],
+    };
+
+    expect(generateJsx(doc)).toContain("<Hb.Button sx={{ width: 200 }}>저장</Hb.Button>");
+  });
+
   it("자식이 없으면 self-closing 태그", () => {
     const doc: StudioDocument = {
       children: [{ id: "b", type: "Hb.Button", props: { variant: "danger" }, children: [] }],

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
@@ -3,6 +3,7 @@ import {
   isComponentNode,
   isTextNode,
   type DocumentNode,
+  type NodeStyle,
   type PropValue,
   type StudioDocument,
 } from "@/entities/document";
@@ -37,6 +38,21 @@ const serializeProp = (
   return `${name}={${value}}`;
 };
 
+/** 사이징(style)을 sx 속성 문자열로 직렬화한다. 빈 값이면 null. */
+const serializeSx = (style: NodeStyle | undefined): string | null => {
+  if (!style) {
+    return null;
+  }
+
+  const entries = Object.entries(style).filter(([, value]) => value !== undefined);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return `sx={{ ${entries.map(([key, value]) => `${key}: ${value}`).join(", ")} }}`;
+};
+
 /** 노드 하나를 JSX 문자열로 직렬화한다. 재귀적. */
 const serializeNode = (node: DocumentNode, indent: string): string => {
   if (isTextNode(node)) {
@@ -54,6 +70,13 @@ const serializeNode = (node: DocumentNode, indent: string): string => {
     .filter(([, spec]) => spec.kind !== "slot")
     .map(([name, spec]) => serializeProp(name, node.props[name], spec))
     .filter((attr): attr is string => attr !== null);
+
+  const sx = serializeSx(node.style);
+
+  if (sx) {
+    attrs.push(sx);
+  }
+
   const attrString = attrs.length ? ` ${attrs.join(" ")}` : "";
 
   if (node.children.length === 0) {

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.spec.tsx
@@ -13,13 +13,13 @@ const buttonNode: DocumentNode = {
 
 describe("Inspector", () => {
   it("선택된 노드가 없으면 안내 문구를 보여준다", () => {
-    render(<Inspector node={undefined} onChange={vi.fn()} onDelete={vi.fn()} />);
+    render(<Inspector node={undefined} onChange={vi.fn()} onStyleChange={vi.fn()} onDelete={vi.fn()} />);
 
     expect(screen.getByText("요소를 선택하세요")).toBeDefined();
   });
 
   it("매니페스트의 enum 옵션을 버튼으로 렌더한다", () => {
-    render(<Inspector node={buttonNode} onChange={vi.fn()} onDelete={vi.fn()} />);
+    render(<Inspector node={buttonNode} onChange={vi.fn()} onStyleChange={vi.fn()} onDelete={vi.fn()} />);
 
     for (const variant of ["primary", "secondary", "danger", "ghost"]) {
       expect(screen.getByRole("button", { name: variant })).toBeDefined();
@@ -29,7 +29,7 @@ describe("Inspector", () => {
   it("enum 옵션 클릭 시 onChange(prop, value)를 호출한다", () => {
     const onChange = vi.fn();
 
-    render(<Inspector node={buttonNode} onChange={onChange} onDelete={vi.fn()} />);
+    render(<Inspector node={buttonNode} onChange={onChange} onStyleChange={vi.fn()} onDelete={vi.fn()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "danger" }));
 
@@ -37,7 +37,7 @@ describe("Inspector", () => {
   });
 
   it("boolean prop은 체크박스로 렌더한다", () => {
-    render(<Inspector node={buttonNode} onChange={vi.fn()} onDelete={vi.fn()} />);
+    render(<Inspector node={buttonNode} onChange={vi.fn()} onStyleChange={vi.fn()} onDelete={vi.fn()} />);
 
     expect(screen.getByRole("checkbox")).toBeDefined();
   });

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -1,16 +1,22 @@
 import { DeleteOutline } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
 import { getManifest, type PropSpec } from "@/entities/manifest";
-import { isComponentNode, type DocumentNode, type PropValue } from "@/entities/document";
+import {
+  isComponentNode,
+  type DocumentNode,
+  type NodeStyle,
+  type PropValue,
+} from "@/entities/document";
 
 interface InspectorProps {
   node: DocumentNode | undefined;
   onChange: (prop: string, value: PropValue) => void;
+  onStyleChange: (key: keyof NodeStyle, value: number | undefined) => void;
   onDelete: () => void;
 }
 
-/** 선택된 노드의 prop을 매니페스트 기반 컨트롤로 편집한다(피그마식 속성 패널). */
-export function Inspector({ node, onChange, onDelete }: InspectorProps) {
+/** 선택된 노드의 prop·사이징을 매니페스트 기반 컨트롤로 편집한다(피그마식 속성 패널). */
+export function Inspector({ node, onChange, onStyleChange, onDelete }: InspectorProps) {
   if (!node || !isComponentNode(node)) {
     return (
       <Hb.Box sx={{ p: 2 }}>
@@ -57,7 +63,60 @@ export function Inspector({ node, onChange, onDelete }: InspectorProps) {
           ))}
         </Hb.Stack>
       )}
+
+      <Hb.Divider sx={{ my: 1.5 }} />
+
+      <Hb.Text
+        sx={{
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: 0.5,
+          textTransform: "uppercase",
+          color: "text.secondary",
+          mb: 1,
+        }}
+      >
+        사이징
+      </Hb.Text>
+      <Hb.Stack gap={1.25}>
+        <SizeField label="W" value={node.style?.width} onChange={(v) => onStyleChange("width", v)} />
+        <SizeField
+          label="H"
+          value={node.style?.height}
+          onChange={(v) => onStyleChange("height", v)}
+        />
+      </Hb.Stack>
     </Hb.Box>
+  );
+}
+
+interface SizeFieldProps {
+  label: string;
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+}
+
+/** 사이징(W/H) 숫자 입력 행. 비우면 미설정(auto). */
+function SizeField({ label, value, onChange }: SizeFieldProps) {
+  return (
+    <Hb.Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="space-between"
+      sx={{ minHeight: 24 }}
+    >
+      <Hb.Text sx={labelSx}>{label}</Hb.Text>
+      <Hb.TextField
+        size="small"
+        type="number"
+        placeholder="auto"
+        value={value === undefined ? "" : String(value)}
+        onChange={(event) =>
+          onChange(event.target.value === "" ? undefined : Number(event.target.value))
+        }
+        sx={{ ...inputSx, width: 72 }}
+      />
+    </Hb.Stack>
   );
 }
 


### PR DESCRIPTION
## 개요
선택한 요소의 **width/height**를 조절합니다. 흐름(flex)을 유지하면서 사이징은 `sx` 스타일로 적용 → **코드 깨끗**(자유좌표 아님).

## 변경 사항
- `ComponentNode.style`(`NodeStyle`: width/height) + `updateNodeStyle` 트리 연산(불변)
- 인스펙터 **'사이징' 섹션** — W/H 숫자 입력(비우면 auto)
- 캔버스가 `sx={node.style}`로 적용, 코드 생성기가 `sx={{ width, height }}`로 직렬화
- 단위 테스트(updateNodeStyle, codegen sx)

## 동작
요소 선택 → W=200 입력 → 캔버스 크기 변경 + 코드에 `<Hb.Button sx={{ width: 200 }}>...` 출력.

## 검증
- 타입체크 통과 / 테스트 60건 통과 / eslint 통과 / knip 통과

## 다음
- PR-D: 캔버스 요소 **모서리 리사이즈 핸들**(직접 끌어서 W/H 조절)