### PR TITLE
feat: Studio 캔버스 리사이즈 핸들

### DIFF
--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -76,6 +76,22 @@ export function useStudioEditor() {
     [selectedId],
   );
 
+  const resizeNode = useCallback((id: NodeId, size: { width?: number; height?: number }) => {
+    setDocument((doc) => {
+      let next = doc;
+
+      if (size.width !== undefined) {
+        next = updateNodeStyle(next, id, "width", size.width);
+      }
+
+      if (size.height !== undefined) {
+        next = updateNodeStyle(next, id, "height", size.height);
+      }
+
+      return next;
+    });
+  }, []);
+
   const deleteSelected = useCallback(() => {
     if (!selectedId) {
       return;
@@ -92,6 +108,7 @@ export function useStudioEditor() {
     selectNode,
     updateProp,
     updateStyle,
+    resizeNode,
     insertComponent,
     deleteSelected,
   };

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -19,6 +19,7 @@ export default function StudioPage() {
     selectNode,
     updateProp,
     updateStyle,
+    resizeNode,
     insertComponent,
     deleteSelected,
   } = useStudioEditor();
@@ -66,7 +67,12 @@ export default function StudioPage() {
               boxShadow: "0 8px 30px rgba(0, 0, 0, 0.35)",
             }}
           >
-            <Canvas document={document} selectedId={selectedId} onSelect={selectNode} />
+            <Canvas
+              document={document}
+              selectedId={selectedId}
+              onSelect={selectNode}
+              onResize={resizeNode}
+            />
           </Hb.Box>
         </Hb.Stack>
 

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, MouseEvent } from "react";
+import type { ComponentType, MouseEvent, PointerEvent } from "react";
 import { Hb } from "@/shared/ui";
 import { getManifest } from "@/entities/manifest";
 import {
@@ -12,14 +12,36 @@ import { resolvePath } from "../lib/resolve-component.lib";
 /** 매니페스트 `import.access` 경로 해석의 시작점. */
 const COMPONENT_ROOT = { Hb };
 
+/** 리사이즈 최소 크기(px). */
+const MIN_SIZE = 24;
+
+/** 부분 사이징 — 축에 따라 width/height만 갱신한다. */
+interface ResizeSize {
+  width?: number;
+  height?: number;
+}
+
+type ResizeAxis = "x" | "y" | "both";
+
+/**
+ * 흐름 레이아웃에서 의미 있는 핸들 세트.
+ * 위/왼쪽은 레이아웃이 고정하므로 오른쪽(너비)·아래(높이)·우하단(둘 다)만 둔다.
+ */
+const HANDLES: { axis: ResizeAxis; sx: Record<string, unknown> }[] = [
+  { axis: "x", sx: { right: -10, top: "50%", transform: "translateY(-50%)", cursor: "ew-resize" } },
+  { axis: "y", sx: { bottom: -10, left: "50%", transform: "translateX(-50%)", cursor: "ns-resize" } },
+  { axis: "both", sx: { right: -10, bottom: -10, cursor: "nwse-resize" } },
+];
+
 interface NodeViewProps {
   node: DocumentNode;
   selectedId?: NodeId;
   onSelect?: (id: NodeId) => void;
+  onResize?: (id: NodeId, size: ResizeSize) => void;
 }
 
 /** Document 노드 하나를 실제 컴포넌트(또는 텍스트)로 렌더한다. 재귀적. */
-function NodeView({ node, selectedId, onSelect }: NodeViewProps) {
+function NodeView({ node, selectedId, onSelect, onResize }: NodeViewProps) {
   if (isTextNode(node)) {
     return <>{node.value}</>;
   }
@@ -35,9 +57,49 @@ function NodeView({ node, selectedId, onSelect }: NodeViewProps) {
     return <UnknownNode type={node.type} />;
   }
 
+  const isSelected = node.id === selectedId;
+
   const handleSelect = (event: MouseEvent) => {
     event.stopPropagation();
     onSelect?.(node.id);
+  };
+
+  /** 핸들 드래그로 부모(wrapper) 크기를 측정해 축에 맞는 W/H를 갱신한다. */
+  const startResize = (axis: ResizeAxis) => (event: PointerEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const wrapper = event.currentTarget.parentElement;
+
+    if (!wrapper || !onResize) {
+      return;
+    }
+
+    const rect = wrapper.getBoundingClientRect();
+    const startX = event.clientX;
+    const startY = event.clientY;
+
+    const onMove = (move: globalThis.PointerEvent) => {
+      const size: ResizeSize = {};
+
+      if (axis !== "y") {
+        size.width = Math.max(MIN_SIZE, Math.round(rect.width + (move.clientX - startX)));
+      }
+
+      if (axis !== "x") {
+        size.height = Math.max(MIN_SIZE, Math.round(rect.height + (move.clientY - startY)));
+      }
+
+      onResize(node.id, size);
+    };
+
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
   };
 
   return (
@@ -45,19 +107,58 @@ function NodeView({ node, selectedId, onSelect }: NodeViewProps) {
       component="span"
       onClick={handleSelect}
       sx={{
+        position: "relative",
         display: "inline-flex",
         cursor: "pointer",
         borderRadius: 1,
         outline: "2px solid",
-        outlineColor: node.id === selectedId ? "primary.main" : "transparent",
+        outlineColor: isSelected ? "primary.main" : "transparent",
         outlineOffset: 2,
       }}
     >
       <Component {...node.props} sx={node.style}>
         {node.children.map((child) => (
-          <NodeView key={child.id} node={child} selectedId={selectedId} onSelect={onSelect} />
+          <NodeView
+            key={child.id}
+            node={child}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            onResize={onResize}
+          />
         ))}
       </Component>
+
+      {isSelected &&
+        onResize &&
+        HANDLES.map((handle) => (
+          <Hb.Box
+            key={handle.axis}
+            onPointerDown={startResize(handle.axis)}
+            onClick={(event) => event.stopPropagation()}
+            sx={{
+              position: "absolute",
+              width: 20,
+              height: 20,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              touchAction: "none",
+              zIndex: 3,
+              ...handle.sx,
+            }}
+          >
+            <Hb.Box
+              sx={{
+                width: 10,
+                height: 10,
+                bgcolor: "primary.main",
+                border: "2px solid",
+                borderColor: "background.paper",
+                borderRadius: "2px",
+              }}
+            />
+          </Hb.Box>
+        ))}
     </Hb.Box>
   );
 }
@@ -74,14 +175,21 @@ interface CanvasProps {
   document: StudioDocument;
   selectedId?: NodeId;
   onSelect?: (id: NodeId) => void;
+  onResize?: (id: NodeId, size: ResizeSize) => void;
 }
 
 /** Document Model을 실제 `Hb.*` 컴포넌트 트리로 렌더하는 캔버스. */
-export function Canvas({ document, selectedId, onSelect }: CanvasProps) {
+export function Canvas({ document, selectedId, onSelect, onResize }: CanvasProps) {
   return (
     <>
       {document.children.map((node) => (
-        <NodeView key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} />
+        <NodeView
+          key={node.id}
+          node={node}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onResize={onResize}
+        />
       ))}
     </>
   );


### PR DESCRIPTION
## 개요
캔버스에서 선택한 요소의 **우하단 모서리를 끌어서 크기를 직접 조절**합니다. 사이징은 `sx` 스타일로 적용돼 흐름 유지 + 코드 깨끗.

## 변경 사항
- 선택 요소 wrapper 우하단에 리사이즈 핸들 표시
- 포인터 드래그 → wrapper 크기 측정 → W/H 갱신(최소 24px)
- `useStudioEditor.resizeNode`(width/height 동시 갱신, updateNodeStyle 합성)
- 캔버스 `onResize` 콜백 배선

## 동작
요소 선택 → 우하단 파란 핸들 → 끌면 캔버스에서 크기 변경 + 코드 패널 `sx={{ width, height }}` 실시간 갱신.

## 검증
- 타입체크 통과 / 테스트 통과 / eslint 통과 / knip 통과
- 참고: 핸들 드래그(포인터+getBoundingClientRect)는 happy-dom 단위테스트가 어려워 수동 검증 영역. 스크린샷으로 확인 부탁.

## 다음(선택)
- 좌/우/모서리 8방향 핸들, 드래그 중 치수 배지, dnd-kit 순서변경