### PR TITLE
feat: Studio 레이어 드래그 순서변경(흐름 D&D)

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -9,8 +9,11 @@ export type {
 export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
 export {
   findNode,
+  findParentId,
+  getSiblings,
   insertNode,
   removeNode,
+  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
 } from "./lib/document-tree.lib";

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -126,3 +126,78 @@ export const updateNodeStyle = (
 
   return { ...doc, children: doc.children.map(mapNode) };
 };
+
+/** 노드의 부모 id를 찾는다. 최상위면 null, 없으면 undefined. */
+export const findParentId = (doc: StudioDocument, id: NodeId): NodeId | null | undefined => {
+  if (doc.children.some((node) => node.id === id)) {
+    return null;
+  }
+
+  const visit = (nodes: DocumentNode[]): NodeId | undefined => {
+    for (const node of nodes) {
+      if (!isComponentNode(node)) {
+        continue;
+      }
+
+      if (node.children.some((child) => child.id === id)) {
+        return node.id;
+      }
+
+      const found = visit(node.children);
+
+      if (found !== undefined) {
+        return found;
+      }
+    }
+
+    return undefined;
+  };
+
+  return visit(doc.children);
+};
+
+/** parentId(null=루트)의 직계 자식 목록을 반환한다. */
+export const getSiblings = (doc: StudioDocument, parentId: NodeId | null): DocumentNode[] => {
+  if (parentId === null) {
+    return doc.children;
+  }
+
+  const parent = findNode(doc, parentId);
+
+  return parent && isComponentNode(parent) ? parent.children : [];
+};
+
+/** parentId(null=루트)의 자식 순서를 from→to로 바꾼 새 문서를 반환한다(불변). */
+export const reorderChildren = (
+  doc: StudioDocument,
+  parentId: NodeId | null,
+  from: number,
+  to: number,
+): StudioDocument => {
+  const reorder = (nodes: DocumentNode[]): DocumentNode[] => {
+    const next = nodes.slice();
+    const [moved] = next.splice(from, 1);
+
+    next.splice(to, 0, moved);
+
+    return next;
+  };
+
+  if (parentId === null) {
+    return { ...doc, children: reorder(doc.children) };
+  }
+
+  const mapNode = (node: DocumentNode): DocumentNode => {
+    if (!isComponentNode(node)) {
+      return node;
+    }
+
+    if (node.id === parentId) {
+      return { ...node, children: reorder(node.children) };
+    }
+
+    return { ...node, children: node.children.map(mapNode) };
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
+};

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -1,3 +1,4 @@
+import { Bom } from "hobom-utils";
 import {
   isComponentNode,
   type ComponentNode,
@@ -8,28 +9,18 @@ import {
   type StudioDocument,
 } from "../model/document.model";
 
-/** 문서 트리에서 id로 노드를 찾는다(깊이 우선). 없으면 undefined. */
-export const findNode = (doc: StudioDocument, id: NodeId): DocumentNode | undefined => {
-  const visit = (nodes: DocumentNode[]): DocumentNode | undefined => {
-    for (const node of nodes) {
-      if (node.id === id) {
-        return node;
-      }
+/** 트리를 깊이 우선으로 평탄화한다(모든 노드를 한 줄로). */
+const flatten = (nodes: DocumentNode[]): DocumentNode[] =>
+  Bom.flatMap(nodes, (node) =>
+    isComponentNode(node) ? [node, ...flatten(node.children)] : [node],
+  );
 
-      if (isComponentNode(node)) {
-        const found = visit(node.children);
-
-        if (found) {
-          return found;
-        }
-      }
-    }
-
-    return undefined;
-  };
-
-  return visit(doc.children);
-};
+/** 문서 트리에서 id로 노드를 찾는다. 없으면 undefined. */
+export const findNode = (doc: StudioDocument, id: NodeId): DocumentNode | undefined =>
+  Bom.pipe(
+    flatten(doc.children),
+    Bom.find((node) => node.id === id),
+  );
 
 /**
  * 특정 노드의 prop 하나를 바꾼 새 문서를 반환한다(불변 업데이트).
@@ -129,31 +120,14 @@ export const updateNodeStyle = (
 
 /** 노드의 부모 id를 찾는다. 최상위면 null, 없으면 undefined. */
 export const findParentId = (doc: StudioDocument, id: NodeId): NodeId | null | undefined => {
-  if (doc.children.some((node) => node.id === id)) {
+  if (Bom.some(doc.children, (node) => node.id === id)) {
     return null;
   }
 
-  const visit = (nodes: DocumentNode[]): NodeId | undefined => {
-    for (const node of nodes) {
-      if (!isComponentNode(node)) {
-        continue;
-      }
-
-      if (node.children.some((child) => child.id === id)) {
-        return node.id;
-      }
-
-      const found = visit(node.children);
-
-      if (found !== undefined) {
-        return found;
-      }
-    }
-
-    return undefined;
-  };
-
-  return visit(doc.children);
+  return Bom.pipe(
+    flatten(doc.children),
+    Bom.find((node) => isComponentNode(node) && Bom.some(node.children, (child) => child.id === id)),
+  )?.id;
 };
 
 /** parentId(null=루트)의 직계 자식 목록을 반환한다. */

--- a/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { isComponentNode, type DocumentNode, type StudioDocument } from "../model/document.model";
+import { findNode, findParentId, getSiblings, reorderChildren } from "./document-tree.lib";
+
+const leaf = (id: string): DocumentNode => ({ id, type: "Hb.Button", props: {}, children: [] });
+
+const doc = (): StudioDocument => ({
+  children: [
+    {
+      id: "stack",
+      type: "Hb.Stack",
+      props: {},
+      children: [leaf("a"), leaf("b"), leaf("c")],
+    },
+  ],
+});
+
+describe("findParentId", () => {
+  it("최상위 노드는 null", () => {
+    expect(findParentId(doc(), "stack")).toBeNull();
+  });
+
+  it("중첩 노드는 부모 id", () => {
+    expect(findParentId(doc(), "b")).toBe("stack");
+  });
+
+  it("없는 노드는 undefined", () => {
+    expect(findParentId(doc(), "zzz")).toBeUndefined();
+  });
+});
+
+describe("getSiblings", () => {
+  it("부모의 직계 자식 목록", () => {
+    expect(getSiblings(doc(), "stack").map((n) => n.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("null이면 루트 자식", () => {
+    expect(getSiblings(doc(), null).map((n) => n.id)).toEqual(["stack"]);
+  });
+});
+
+describe("reorderChildren", () => {
+  it("자식 순서를 from→to로 바꾼다", () => {
+    const next = reorderChildren(doc(), "stack", 0, 2);
+    const stack = findNode(next, "stack");
+
+    expect(stack && isComponentNode(stack) && stack.children.map((n) => n.id)).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+  });
+
+  it("원본은 불변", () => {
+    const base = doc();
+
+    reorderChildren(base, "stack", 0, 2);
+    const stack = findNode(base, "stack");
+
+    expect(stack && isComponentNode(stack) && stack.children.map((n) => n.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});

--- a/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.ts
+++ b/apps/hobom-system/src/pages/studio/lib/create-component-node.lib.ts
@@ -1,3 +1,4 @@
+import { Bom } from "hobom-utils";
 import type { ComponentManifest } from "@/entities/manifest";
 import type { ComponentNode, NodeId, PropValue } from "@/entities/document";
 
@@ -16,17 +17,17 @@ export function createComponentNode(
   createId: () => NodeId,
 ): ComponentNode {
   const id = createId();
-  const props: Record<string, PropValue> = {};
-  let acceptsText = false;
 
-  for (const [name, spec] of Object.entries(manifest.props)) {
-    if (spec.kind === "slot") {
-      acceptsText = spec.accepts.includes("text");
-      continue;
-    }
+  const props: Record<string, PropValue> = Object.fromEntries(
+    Bom.flatMap(Object.entries(manifest.props), ([name, spec]) =>
+      spec.kind === "slot" ? [] : [[name, spec.default] as const],
+    ),
+  );
 
-    props[name] = spec.default;
-  }
+  const acceptsText = Bom.some(
+    Object.values(manifest.props),
+    (spec) => spec.kind === "slot" && spec.accepts.includes("text"),
+  );
 
   const children = acceptsText
     ? [{ id: createId(), type: "text" as const, value: DEFAULT_TEXT[manifest.name] ?? "텍스트" }]
@@ -37,6 +38,7 @@ export function createComponentNode(
 
 /** 컴포넌트를 자식으로 받는 컨테이너인지(slot이 text 외의 노드를 허용). */
 export const acceptsComponentChildren = (manifest: ComponentManifest): boolean =>
-  Object.values(manifest.props).some(
-    (spec) => spec.kind === "slot" && spec.accepts.some((accept) => accept !== "text"),
+  Bom.some(
+    Object.values(manifest.props),
+    (spec) => spec.kind === "slot" && Bom.some(spec.accepts, (accept) => accept !== "text"),
   );

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -4,9 +4,12 @@ import {
   createNodeId,
   createSampleDocument,
   findNode,
+  findParentId,
+  getSiblings,
   insertNode,
   isComponentNode,
   removeNode,
+  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
   type DocumentNode,
@@ -92,6 +95,27 @@ export function useStudioEditor() {
     });
   }, []);
 
+  /** 같은 부모 안에서만 순서변경한다(흐름 D&D, v1). */
+  const reorderNode = useCallback((activeId: NodeId, overId: NodeId) => {
+    setDocument((doc) => {
+      const parent = findParentId(doc, activeId);
+
+      if (parent === undefined || parent !== findParentId(doc, overId)) {
+        return doc;
+      }
+
+      const siblings = getSiblings(doc, parent);
+      const from = siblings.findIndex((node) => node.id === activeId);
+      const to = siblings.findIndex((node) => node.id === overId);
+
+      if (from === -1 || to === -1) {
+        return doc;
+      }
+
+      return reorderChildren(doc, parent, from, to);
+    });
+  }, []);
+
   const deleteSelected = useCallback(() => {
     if (!selectedId) {
       return;
@@ -109,6 +133,7 @@ export function useStudioEditor() {
     updateProp,
     updateStyle,
     resizeNode,
+    reorderNode,
     insertComponent,
     deleteSelected,
   };

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -20,6 +20,7 @@ export default function StudioPage() {
     updateProp,
     updateStyle,
     resizeNode,
+    reorderNode,
     insertComponent,
     deleteSelected,
   } = useStudioEditor();
@@ -40,7 +41,12 @@ export default function StudioPage() {
           <InsertPalette onInsert={insertComponent} />
           <Hb.Divider />
           <SectionHeader>레이어</SectionHeader>
-          <LayersPanel document={document} selectedId={selectedId} onSelect={selectNode} />
+          <LayersPanel
+            document={document}
+            selectedId={selectedId}
+            onSelect={selectNode}
+            onReorder={reorderNode}
+          />
         </Panel>
 
         <Hb.Stack

--- a/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
+++ b/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
@@ -1,4 +1,5 @@
-import { Hb } from "@/shared/ui";
+import { DragIndicatorOutlined } from "hobom-design-system/icons";
+import { Hb, Sortable } from "@/shared/ui";
 import {
   isComponentNode,
   isTextNode,
@@ -6,27 +7,55 @@ import {
   type NodeId,
   type StudioDocument,
 } from "@/entities/document";
+import type { DragEndEvent } from "hobom-design-system";
 
 interface LayersPanelProps {
   document: StudioDocument;
   selectedId?: NodeId;
   onSelect: (id: NodeId) => void;
+  onReorder: (activeId: NodeId, overId: NodeId) => void;
 }
 
-/** 문서 트리를 레이어 목록으로 보여준다(피그마 Layers 패널). 선택은 캔버스와 동기화. */
-export function LayersPanel({ document, selectedId, onSelect }: LayersPanelProps) {
+/** 문서 트리를 레이어 목록으로 보여준다. 핸들 드래그로 같은 부모 안에서 순서변경. */
+export function LayersPanel({ document, selectedId, onSelect, onReorder }: LayersPanelProps) {
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      onReorder(String(active.id), String(over.id));
+    }
+  };
+
   return (
-    <Hb.Box sx={{ py: 0.5 }}>
-      {document.children.map((node) => (
-        <LayerRow
-          key={node.id}
-          node={node}
+    <Sortable.Root onDragEnd={handleDragEnd}>
+      <Hb.Box sx={{ py: 0.5 }}>
+        <LayerList
+          nodes={document.children}
           depth={0}
           selectedId={selectedId}
           onSelect={onSelect}
         />
+      </Hb.Box>
+    </Sortable.Root>
+  );
+}
+
+interface LayerListProps {
+  nodes: DocumentNode[];
+  depth: number;
+  selectedId?: NodeId;
+  onSelect: (id: NodeId) => void;
+}
+
+function LayerList({ nodes, depth, selectedId, onSelect }: LayerListProps) {
+  return (
+    <Sortable.List items={nodes.map((node) => node.id)} strategy="vertical">
+      {nodes.map((node) => (
+        <Sortable.Item key={node.id} id={node.id} useHandle>
+          <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
+        </Sortable.Item>
       ))}
-    </Hb.Box>
+    </Sortable.List>
   );
 }
 
@@ -44,34 +73,47 @@ function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
   return (
     <>
       <Hb.Box
-        onClick={() => onSelect(node.id)}
         sx={{
-          pl: `${8 + depth * 14}px`,
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          pl: `${4 + depth * 14}px`,
           pr: 1,
           py: 0.5,
-          fontSize: 12,
-          cursor: "pointer",
-          whiteSpace: "nowrap",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          color: isSelected ? "text.primary" : "text.secondary",
           bgcolor: isSelected ? "action.selected" : "transparent",
           "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
         }}
       >
-        {label}
+        <Sortable.Handle>
+          <DragIndicatorOutlined
+            sx={{ fontSize: 16, color: "text.disabled", cursor: "grab", display: "block" }}
+          />
+        </Sortable.Handle>
+        <Hb.Box
+          onClick={() => onSelect(node.id)}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 12,
+            cursor: "pointer",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            color: isSelected ? "text.primary" : "text.secondary",
+          }}
+        >
+          {label}
+        </Hb.Box>
       </Hb.Box>
 
-      {isComponentNode(node) &&
-        node.children.map((child) => (
-          <LayerRow
-            key={child.id}
-            node={child}
-            depth={depth + 1}
-            selectedId={selectedId}
-            onSelect={onSelect}
-          />
-        ))}
+      {isComponentNode(node) && node.children.length > 0 && (
+        <LayerList
+          nodes={node.children}
+          depth={depth + 1}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 개요
**Layers 패널에서 드래그로 요소 순서를 바꿉니다**(피그마식). 흐름 유지 — 같은 부모 안에서 형제 순서만 변경하므로 코드는 자식 순서가 그대로 반영됩니다.

## 변경 사항
- 트리 연산 `findParentId` / `getSiblings` / `reorderChildren`(불변, 단위테스트)
- Layers 패널을 `Sortable`(dnd-kit 래퍼)로 — 각 행에 **드래그 핸들**(⠿), 중첩 리스트
- `useStudioEditor.reorderNode` — 같은 부모일 때만 순서변경(v1), 코드/캔버스 동시 갱신
- 핸들 분리로 선택(라벨 클릭)과 드래그를 구분(중첩 그랩 충돌 회피)

## 동작
좌측 Layers에서 행의 핸들을 잡고 위/아래로 끌면 같은 그룹 내 순서가 바뀌고 → 캔버스/코드 즉시 반영.

## 검증
- 타입체크 통과 / 테스트 28건 통과 / eslint 통과 / knip 통과
- 참고: 드래그 상호작용은 수동 검증 영역 — 스크린샷으로 확인 부탁.

## 다음(선택)
- 다른 부모로 이동(중첩 변경), 캔버스에서 직접 드래그, 패딩/정렬 컨트롤