### PR TITLE
feat: Studio 레이어 다른 부모로 이동(re-parenting)

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -9,11 +9,9 @@ export type {
 export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
 export {
   findNode,
-  findParentId,
-  getSiblings,
   insertNode,
+  moveNode,
   removeNode,
-  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
 } from "./lib/document-tree.lib";

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -175,3 +175,74 @@ export const reorderChildren = (
 
   return { ...doc, children: doc.children.map(mapNode) };
 };
+
+/** parentId(null=루트)의 index 위치에 노드를 끼워 넣은 새 문서를 반환한다(불변). */
+const insertNodeAt = (
+  doc: StudioDocument,
+  parentId: NodeId | null,
+  index: number,
+  node: DocumentNode,
+): StudioDocument => {
+  const insertInto = (children: DocumentNode[]): DocumentNode[] => {
+    const next = children.slice();
+
+    next.splice(index, 0, node);
+
+    return next;
+  };
+
+  if (parentId === null) {
+    return { ...doc, children: insertInto(doc.children) };
+  }
+
+  const mapNode = (node_: DocumentNode): DocumentNode => {
+    if (!isComponentNode(node_)) {
+      return node_;
+    }
+
+    if (node_.id === parentId) {
+      return { ...node_, children: insertInto(node_.children) };
+    }
+
+    return { ...node_, children: node_.children.map(mapNode) };
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
+};
+
+/**
+ * 노드를 over 위치로 옮긴 새 문서를 반환한다(불변).
+ * 같은 부모면 순서변경, 다른 부모면 그 부모로 이동(re-parenting).
+ * 자기 자신의 하위로는 이동하지 않는다(순환 방지).
+ */
+export const moveNode = (doc: StudioDocument, activeId: NodeId, overId: NodeId): StudioDocument => {
+  if (activeId === overId) {
+    return doc;
+  }
+
+  const node = findNode(doc, activeId);
+  const activeParent = findParentId(doc, activeId);
+  const overParent = findParentId(doc, overId);
+
+  if (!node || activeParent === undefined || overParent === undefined) {
+    return doc;
+  }
+
+  if (isComponentNode(node) && Bom.some(flatten(node.children), (child) => child.id === overId)) {
+    return doc;
+  }
+
+  if (activeParent === overParent) {
+    const siblings = getSiblings(doc, activeParent);
+    const from = Bom.findIndex(siblings, (sibling) => sibling.id === activeId);
+    const to = Bom.findIndex(siblings, (sibling) => sibling.id === overId);
+
+    return from < 0 || to < 0 ? doc : reorderChildren(doc, activeParent, from, to);
+  }
+
+  const removed = removeNode(doc, activeId);
+  const siblings = getSiblings(removed, overParent);
+  const overIndex = Bom.findIndex(siblings, (sibling) => sibling.id === overId);
+
+  return insertNodeAt(removed, overParent, overIndex < 0 ? siblings.length : overIndex, node);
+};

--- a/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { isComponentNode, type DocumentNode, type StudioDocument } from "../model/document.model";
-import { findNode, findParentId, getSiblings, reorderChildren } from "./document-tree.lib";
+import {
+  findNode,
+  findParentId,
+  getSiblings,
+  moveNode,
+  reorderChildren,
+} from "./document-tree.lib";
 
 const leaf = (id: string): DocumentNode => ({ id, type: "Hb.Button", props: {}, children: [] });
 
@@ -62,5 +68,36 @@ describe("reorderChildren", () => {
       "b",
       "c",
     ]);
+  });
+});
+
+describe("moveNode", () => {
+  const twoGroups = (): StudioDocument => ({
+    children: [
+      { id: "g1", type: "Hb.Stack", props: {}, children: [leaf("a"), leaf("b")] },
+      { id: "g2", type: "Hb.Stack", props: {}, children: [leaf("c")] },
+    ],
+  });
+
+  const childIds = (doc: StudioDocument, parentId: string) => {
+    const parent = findNode(doc, parentId);
+
+    return parent && isComponentNode(parent) ? parent.children.map((n) => n.id) : [];
+  };
+
+  it("다른 부모로 이동한다(re-parenting)", () => {
+    const next = moveNode(twoGroups(), "a", "c");
+
+    expect(findParentId(next, "a")).toBe("g2");
+    expect(childIds(next, "g2")).toEqual(["a", "c"]);
+    expect(childIds(next, "g1")).toEqual(["b"]);
+  });
+
+  it("같은 부모면 순서변경", () => {
+    expect(childIds(moveNode(twoGroups(), "a", "b"), "g1")).toEqual(["b", "a"]);
+  });
+
+  it("자기 하위로는 이동하지 않는다(순환 방지)", () => {
+    expect(moveNode(twoGroups(), "g1", "a")).toEqual(twoGroups());
   });
 });

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -4,12 +4,10 @@ import {
   createNodeId,
   createSampleDocument,
   findNode,
-  findParentId,
-  getSiblings,
   insertNode,
   isComponentNode,
+  moveNode,
   removeNode,
-  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
   type DocumentNode,
@@ -95,25 +93,9 @@ export function useStudioEditor() {
     });
   }, []);
 
-  /** 같은 부모 안에서만 순서변경한다(흐름 D&D, v1). */
+  /** 같은 부모면 순서변경, 다른 부모면 그 부모로 이동(흐름 D&D). */
   const reorderNode = useCallback((activeId: NodeId, overId: NodeId) => {
-    setDocument((doc) => {
-      const parent = findParentId(doc, activeId);
-
-      if (parent === undefined || parent !== findParentId(doc, overId)) {
-        return doc;
-      }
-
-      const siblings = getSiblings(doc, parent);
-      const from = siblings.findIndex((node) => node.id === activeId);
-      const to = siblings.findIndex((node) => node.id === overId);
-
-      if (from === -1 || to === -1) {
-        return doc;
-      }
-
-      return reorderChildren(doc, parent, from, to);
-    });
+    setDocument((doc) => moveNode(doc, activeId, overId));
   }, []);
 
   const deleteSelected = useCallback(() => {

--- a/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
+++ b/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
@@ -1,3 +1,4 @@
+import { Bom } from "hobom-utils";
 import { DragIndicatorOutlined } from "hobom-design-system/icons";
 import { Hb, Sortable } from "@/shared/ui";
 import {
@@ -16,8 +17,25 @@ interface LayersPanelProps {
   onReorder: (activeId: NodeId, overId: NodeId) => void;
 }
 
-/** 문서 트리를 레이어 목록으로 보여준다. 핸들 드래그로 같은 부모 안에서 순서변경. */
+interface FlatLayer {
+  node: DocumentNode;
+  depth: number;
+}
+
+/** 트리를 깊이 우선으로 평탄화한다(들여쓰기 깊이 포함). */
+const flattenLayers = (nodes: DocumentNode[], depth: number): FlatLayer[] =>
+  Bom.flatMap(nodes, (node) => [
+    { node, depth },
+    ...(isComponentNode(node) ? flattenLayers(node.children, depth + 1) : []),
+  ]);
+
+/**
+ * 문서 트리를 단일 평탄 리스트의 레이어 목록으로 보여준다(들여쓰기로 계층 표현).
+ * 단일 SortableContext라 충돌 감지가 안정적 — 핸들 드래그로 순서변경 및 다른 부모로 이동.
+ */
 export function LayersPanel({ document, selectedId, onSelect, onReorder }: LayersPanelProps) {
+  const layers = flattenLayers(document.children, 0);
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
@@ -28,34 +46,16 @@ export function LayersPanel({ document, selectedId, onSelect, onReorder }: Layer
 
   return (
     <Sortable.Root onDragEnd={handleDragEnd}>
-      <Hb.Box sx={{ py: 0.5 }}>
-        <LayerList
-          nodes={document.children}
-          depth={0}
-          selectedId={selectedId}
-          onSelect={onSelect}
-        />
-      </Hb.Box>
+      <Sortable.List items={layers.map((layer) => layer.node.id)} strategy="vertical">
+        <Hb.Box sx={{ py: 0.5 }}>
+          {layers.map(({ node, depth }) => (
+            <Sortable.Item key={node.id} id={node.id} useHandle>
+              <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
+            </Sortable.Item>
+          ))}
+        </Hb.Box>
+      </Sortable.List>
     </Sortable.Root>
-  );
-}
-
-interface LayerListProps {
-  nodes: DocumentNode[];
-  depth: number;
-  selectedId?: NodeId;
-  onSelect: (id: NodeId) => void;
-}
-
-function LayerList({ nodes, depth, selectedId, onSelect }: LayerListProps) {
-  return (
-    <Sortable.List items={nodes.map((node) => node.id)} strategy="vertical">
-      {nodes.map((node) => (
-        <Sortable.Item key={node.id} id={node.id} useHandle>
-          <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
-        </Sortable.Item>
-      ))}
-    </Sortable.List>
   );
 }
 
@@ -71,49 +71,38 @@ function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
   const label = isTextNode(node) ? `"${node.value}"` : node.type.replace(/^Hb\./, "");
 
   return (
-    <>
+    <Hb.Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        pl: `${4 + depth * 14}px`,
+        pr: 1,
+        py: 0.5,
+        bgcolor: isSelected ? "action.selected" : "transparent",
+        "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+      }}
+    >
+      <Sortable.Handle>
+        <DragIndicatorOutlined
+          sx={{ fontSize: 16, color: "text.disabled", cursor: "grab", display: "block" }}
+        />
+      </Sortable.Handle>
       <Hb.Box
+        onClick={() => onSelect(node.id)}
         sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 0.5,
-          pl: `${4 + depth * 14}px`,
-          pr: 1,
-          py: 0.5,
-          bgcolor: isSelected ? "action.selected" : "transparent",
-          "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+          flex: 1,
+          minWidth: 0,
+          fontSize: 12,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          color: isSelected ? "text.primary" : "text.secondary",
         }}
       >
-        <Sortable.Handle>
-          <DragIndicatorOutlined
-            sx={{ fontSize: 16, color: "text.disabled", cursor: "grab", display: "block" }}
-          />
-        </Sortable.Handle>
-        <Hb.Box
-          onClick={() => onSelect(node.id)}
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            fontSize: 12,
-            cursor: "pointer",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            color: isSelected ? "text.primary" : "text.secondary",
-          }}
-        >
-          {label}
-        </Hb.Box>
+        {label}
       </Hb.Box>
-
-      {isComponentNode(node) && node.children.length > 0 && (
-        <LayerList
-          nodes={node.children}
-          depth={depth + 1}
-          selectedId={selectedId}
-          onSelect={onSelect}
-        />
-      )}
-    </>
+    </Hb.Box>
   );
 }


### PR DESCRIPTION
## 개요
레이어 드래그를 **다른 부모(그룹)로 이동**까지 확장합니다. 지금까진 같은 부모 안 순서변경만 됐는데, 이제 한 컨테이너의 자식을 끌어 **다른 컨테이너로 옮길 수 있습니다.**

## 변경 사항
- `moveNode` 트리 연산 — 같은 부모면 순서변경, **다른 부모면 그 부모로 이동(re-parenting)**
- `insertNodeAt`(인덱스 삽입) + **순환 방지**(자기 자신의 하위로는 이동 금지)
- `useStudioEditor.reorderNode`를 `moveNode`로 통일(드래그 로직 단일화)
- 배럴 정리(`moveNode`만 공개, 내부 헬퍼는 비공개)
- 단위 테스트: cross-parent 이동, 같은 부모 순서변경, 순환 방지

## 동작
Layers에서 어떤 그룹의 행을 잡고 다른 그룹의 행 위로 떨어뜨리면 → 그 그룹으로 이동, 캔버스/코드 즉시 반영.

## 검증
- 타입체크 통과 / 테스트 31건 통과 / eslint 통과 / knip 통과
- 참고: 드래그 상호작용 자체는 수동 검증 영역. 또한 중첩 그룹에서는 `closestCenter` 특성상 대상 지정이 까다로울 수 있어(드롭 위치가 다른 노드로 잡힘) — 불안정하면 sibling-scoped collision detection을 별도로 보강하면 됩니다.