### PR TITLE
feat: Studio 키보드 단축키 + 배경클릭 선택 해제

### DIFF
--- a/apps/hobom-system/src/entities/document/index.ts
+++ b/apps/hobom-system/src/entities/document/index.ts
@@ -9,11 +9,9 @@ export type {
 export { createSampleDocument, isComponentNode, isTextNode } from "./model/document.model";
 export {
   findNode,
-  findParentId,
-  getSiblings,
   insertNode,
+  moveNode,
   removeNode,
-  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
 } from "./lib/document-tree.lib";

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -175,3 +175,74 @@ export const reorderChildren = (
 
   return { ...doc, children: doc.children.map(mapNode) };
 };
+
+/** parentId(null=루트)의 index 위치에 노드를 끼워 넣은 새 문서를 반환한다(불변). */
+const insertNodeAt = (
+  doc: StudioDocument,
+  parentId: NodeId | null,
+  index: number,
+  node: DocumentNode,
+): StudioDocument => {
+  const insertInto = (children: DocumentNode[]): DocumentNode[] => {
+    const next = children.slice();
+
+    next.splice(index, 0, node);
+
+    return next;
+  };
+
+  if (parentId === null) {
+    return { ...doc, children: insertInto(doc.children) };
+  }
+
+  const mapNode = (node_: DocumentNode): DocumentNode => {
+    if (!isComponentNode(node_)) {
+      return node_;
+    }
+
+    if (node_.id === parentId) {
+      return { ...node_, children: insertInto(node_.children) };
+    }
+
+    return { ...node_, children: node_.children.map(mapNode) };
+  };
+
+  return { ...doc, children: doc.children.map(mapNode) };
+};
+
+/**
+ * 노드를 over 위치로 옮긴 새 문서를 반환한다(불변).
+ * 같은 부모면 순서변경, 다른 부모면 그 부모로 이동(re-parenting).
+ * 자기 자신의 하위로는 이동하지 않는다(순환 방지).
+ */
+export const moveNode = (doc: StudioDocument, activeId: NodeId, overId: NodeId): StudioDocument => {
+  if (activeId === overId) {
+    return doc;
+  }
+
+  const node = findNode(doc, activeId);
+  const activeParent = findParentId(doc, activeId);
+  const overParent = findParentId(doc, overId);
+
+  if (!node || activeParent === undefined || overParent === undefined) {
+    return doc;
+  }
+
+  if (isComponentNode(node) && Bom.some(flatten(node.children), (child) => child.id === overId)) {
+    return doc;
+  }
+
+  if (activeParent === overParent) {
+    const siblings = getSiblings(doc, activeParent);
+    const from = Bom.findIndex(siblings, (sibling) => sibling.id === activeId);
+    const to = Bom.findIndex(siblings, (sibling) => sibling.id === overId);
+
+    return from < 0 || to < 0 ? doc : reorderChildren(doc, activeParent, from, to);
+  }
+
+  const removed = removeNode(doc, activeId);
+  const siblings = getSiblings(removed, overParent);
+  const overIndex = Bom.findIndex(siblings, (sibling) => sibling.id === overId);
+
+  return insertNodeAt(removed, overParent, overIndex < 0 ? siblings.length : overIndex, node);
+};

--- a/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
+++ b/apps/hobom-system/src/entities/document/lib/reorder.lib.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { isComponentNode, type DocumentNode, type StudioDocument } from "../model/document.model";
-import { findNode, findParentId, getSiblings, reorderChildren } from "./document-tree.lib";
+import {
+  findNode,
+  findParentId,
+  getSiblings,
+  moveNode,
+  reorderChildren,
+} from "./document-tree.lib";
 
 const leaf = (id: string): DocumentNode => ({ id, type: "Hb.Button", props: {}, children: [] });
 
@@ -62,5 +68,36 @@ describe("reorderChildren", () => {
       "b",
       "c",
     ]);
+  });
+});
+
+describe("moveNode", () => {
+  const twoGroups = (): StudioDocument => ({
+    children: [
+      { id: "g1", type: "Hb.Stack", props: {}, children: [leaf("a"), leaf("b")] },
+      { id: "g2", type: "Hb.Stack", props: {}, children: [leaf("c")] },
+    ],
+  });
+
+  const childIds = (doc: StudioDocument, parentId: string) => {
+    const parent = findNode(doc, parentId);
+
+    return parent && isComponentNode(parent) ? parent.children.map((n) => n.id) : [];
+  };
+
+  it("다른 부모로 이동한다(re-parenting)", () => {
+    const next = moveNode(twoGroups(), "a", "c");
+
+    expect(findParentId(next, "a")).toBe("g2");
+    expect(childIds(next, "g2")).toEqual(["a", "c"]);
+    expect(childIds(next, "g1")).toEqual(["b"]);
+  });
+
+  it("같은 부모면 순서변경", () => {
+    expect(childIds(moveNode(twoGroups(), "a", "b"), "g1")).toEqual(["b", "a"]);
+  });
+
+  it("자기 하위로는 이동하지 않는다(순환 방지)", () => {
+    expect(moveNode(twoGroups(), "g1", "a")).toEqual(twoGroups());
   });
 });

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -32,6 +32,8 @@ export function useStudioEditor() {
 
   const selectNode = useCallback((id: NodeId) => setSelectedId(id), []);
 
+  const clearSelection = useCallback(() => setSelectedId(undefined), []);
+
   const updateProp = useCallback(
     (prop: string, value: PropValue) => {
       if (!selectedId) {
@@ -112,6 +114,7 @@ export function useStudioEditor() {
     selectedId,
     selectedNode,
     selectNode,
+    clearSelection,
     updateProp,
     updateStyle,
     resizeNode,

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -4,12 +4,10 @@ import {
   createNodeId,
   createSampleDocument,
   findNode,
-  findParentId,
-  getSiblings,
   insertNode,
   isComponentNode,
+  moveNode,
   removeNode,
-  reorderChildren,
   updateNodeProps,
   updateNodeStyle,
   type DocumentNode,
@@ -95,25 +93,9 @@ export function useStudioEditor() {
     });
   }, []);
 
-  /** 같은 부모 안에서만 순서변경한다(흐름 D&D, v1). */
+  /** 같은 부모면 순서변경, 다른 부모면 그 부모로 이동(흐름 D&D). */
   const reorderNode = useCallback((activeId: NodeId, overId: NodeId) => {
-    setDocument((doc) => {
-      const parent = findParentId(doc, activeId);
-
-      if (parent === undefined || parent !== findParentId(doc, overId)) {
-        return doc;
-      }
-
-      const siblings = getSiblings(doc, parent);
-      const from = siblings.findIndex((node) => node.id === activeId);
-      const to = siblings.findIndex((node) => node.id === overId);
-
-      if (from === -1 || to === -1) {
-        return doc;
-      }
-
-      return reorderChildren(doc, parent, from, to);
-    });
+    setDocument((doc) => moveNode(doc, activeId, overId));
   }, []);
 
   const deleteSelected = useCallback(() => {

--- a/apps/hobom-system/src/pages/studio/model/useStudioKeyboard.spec.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioKeyboard.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { fireEvent, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useStudioKeyboard } from "./useStudioKeyboard";
+
+describe("useStudioKeyboard", () => {
+  it("Escape는 onDeselect를 호출한다", () => {
+    const onDeselect = vi.fn();
+
+    renderHook(() => useStudioKeyboard({ onDelete: vi.fn(), onDeselect }));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onDeselect).toHaveBeenCalledTimes(1);
+  });
+
+  it("Delete/Backspace는 onDelete를 호출한다", () => {
+    const onDelete = vi.fn();
+
+    renderHook(() => useStudioKeyboard({ onDelete, onDeselect: vi.fn() }));
+
+    fireEvent.keyDown(window, { key: "Delete" });
+    fireEvent.keyDown(window, { key: "Backspace" });
+
+    expect(onDelete).toHaveBeenCalledTimes(2);
+  });
+
+  it("입력 요소에 포커스된 동안은 무시한다", () => {
+    const onDelete = vi.fn();
+
+    renderHook(() => useStudioKeyboard({ onDelete, onDeselect: vi.fn() }));
+
+    const input = document.createElement("input");
+
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: "Delete" });
+    input.remove();
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hobom-system/src/pages/studio/model/useStudioKeyboard.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioKeyboard.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+interface StudioKeyboardHandlers {
+  onDelete: () => void;
+  onDeselect: () => void;
+}
+
+/**
+ * Studio 전역 키보드 단축키.
+ * - Escape: 선택 해제
+ * - Delete/Backspace: 선택 노드 삭제
+ * 입력 요소(input/textarea/contenteditable)에 포커스된 동안은 무시한다.
+ */
+export function useStudioKeyboard({ onDelete, onDeselect }: StudioKeyboardHandlers) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+
+      if (
+        target instanceof HTMLElement &&
+        target.closest("input, textarea, [contenteditable='true']")
+      ) {
+        return;
+      }
+
+      if (event.key === "Escape") {
+        onDeselect();
+
+        return;
+      }
+
+      if (event.key === "Delete" || event.key === "Backspace") {
+        event.preventDefault();
+        onDelete();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onDelete, onDeselect]);
+}

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -5,6 +5,7 @@ import { InsertPalette } from "@/widgets/insert-palette";
 import { Inspector } from "@/widgets/inspector";
 import { LayersPanel } from "@/widgets/layers-panel";
 import { useStudioEditor } from "../model/useStudioEditor";
+import { useStudioKeyboard } from "../model/useStudioKeyboard";
 import { studioTheme } from "../config/studio-theme";
 
 /**
@@ -17,6 +18,7 @@ export default function StudioPage() {
     selectedId,
     selectedNode,
     selectNode,
+    clearSelection,
     updateProp,
     updateStyle,
     resizeNode,
@@ -24,6 +26,8 @@ export default function StudioPage() {
     insertComponent,
     deleteSelected,
   } = useStudioEditor();
+
+  useStudioKeyboard({ onDelete: deleteSelected, onDeselect: clearSelection });
 
   return (
     <Hb.ThemeProvider theme={studioTheme}>
@@ -50,6 +54,7 @@ export default function StudioPage() {
         </Panel>
 
         <Hb.Stack
+          onClick={clearSelection}
           sx={{
             flex: 1,
             minWidth: 0,

--- a/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
+++ b/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
@@ -1,3 +1,4 @@
+import { Bom } from "hobom-utils";
 import { DragIndicatorOutlined } from "hobom-design-system/icons";
 import { Hb, Sortable } from "@/shared/ui";
 import {
@@ -16,8 +17,25 @@ interface LayersPanelProps {
   onReorder: (activeId: NodeId, overId: NodeId) => void;
 }
 
-/** 문서 트리를 레이어 목록으로 보여준다. 핸들 드래그로 같은 부모 안에서 순서변경. */
+interface FlatLayer {
+  node: DocumentNode;
+  depth: number;
+}
+
+/** 트리를 깊이 우선으로 평탄화한다(들여쓰기 깊이 포함). */
+const flattenLayers = (nodes: DocumentNode[], depth: number): FlatLayer[] =>
+  Bom.flatMap(nodes, (node) => [
+    { node, depth },
+    ...(isComponentNode(node) ? flattenLayers(node.children, depth + 1) : []),
+  ]);
+
+/**
+ * 문서 트리를 단일 평탄 리스트의 레이어 목록으로 보여준다(들여쓰기로 계층 표현).
+ * 단일 SortableContext라 충돌 감지가 안정적 — 핸들 드래그로 순서변경 및 다른 부모로 이동.
+ */
 export function LayersPanel({ document, selectedId, onSelect, onReorder }: LayersPanelProps) {
+  const layers = flattenLayers(document.children, 0);
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
@@ -28,34 +46,16 @@ export function LayersPanel({ document, selectedId, onSelect, onReorder }: Layer
 
   return (
     <Sortable.Root onDragEnd={handleDragEnd}>
-      <Hb.Box sx={{ py: 0.5 }}>
-        <LayerList
-          nodes={document.children}
-          depth={0}
-          selectedId={selectedId}
-          onSelect={onSelect}
-        />
-      </Hb.Box>
+      <Sortable.List items={layers.map((layer) => layer.node.id)} strategy="vertical">
+        <Hb.Box sx={{ py: 0.5 }}>
+          {layers.map(({ node, depth }) => (
+            <Sortable.Item key={node.id} id={node.id} useHandle>
+              <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
+            </Sortable.Item>
+          ))}
+        </Hb.Box>
+      </Sortable.List>
     </Sortable.Root>
-  );
-}
-
-interface LayerListProps {
-  nodes: DocumentNode[];
-  depth: number;
-  selectedId?: NodeId;
-  onSelect: (id: NodeId) => void;
-}
-
-function LayerList({ nodes, depth, selectedId, onSelect }: LayerListProps) {
-  return (
-    <Sortable.List items={nodes.map((node) => node.id)} strategy="vertical">
-      {nodes.map((node) => (
-        <Sortable.Item key={node.id} id={node.id} useHandle>
-          <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
-        </Sortable.Item>
-      ))}
-    </Sortable.List>
   );
 }
 
@@ -71,49 +71,38 @@ function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
   const label = isTextNode(node) ? `"${node.value}"` : node.type.replace(/^Hb\./, "");
 
   return (
-    <>
+    <Hb.Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        pl: `${4 + depth * 14}px`,
+        pr: 1,
+        py: 0.5,
+        bgcolor: isSelected ? "action.selected" : "transparent",
+        "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+      }}
+    >
+      <Sortable.Handle>
+        <DragIndicatorOutlined
+          sx={{ fontSize: 16, color: "text.disabled", cursor: "grab", display: "block" }}
+        />
+      </Sortable.Handle>
       <Hb.Box
+        onClick={() => onSelect(node.id)}
         sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 0.5,
-          pl: `${4 + depth * 14}px`,
-          pr: 1,
-          py: 0.5,
-          bgcolor: isSelected ? "action.selected" : "transparent",
-          "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+          flex: 1,
+          minWidth: 0,
+          fontSize: 12,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          color: isSelected ? "text.primary" : "text.secondary",
         }}
       >
-        <Sortable.Handle>
-          <DragIndicatorOutlined
-            sx={{ fontSize: 16, color: "text.disabled", cursor: "grab", display: "block" }}
-          />
-        </Sortable.Handle>
-        <Hb.Box
-          onClick={() => onSelect(node.id)}
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            fontSize: 12,
-            cursor: "pointer",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            color: isSelected ? "text.primary" : "text.secondary",
-          }}
-        >
-          {label}
-        </Hb.Box>
+        {label}
       </Hb.Box>
-
-      {isComponentNode(node) && node.children.length > 0 && (
-        <LayerList
-          nodes={node.children}
-          depth={depth + 1}
-          selectedId={selectedId}
-          onSelect={onSelect}
-        />
-      )}
-    </>
+    </Hb.Box>
   );
 }


### PR DESCRIPTION
## 개요
조작 체감을 높이는 소소하지만 중요한 개선. (#106 위 스택 — 머지 시 develop으로 자동 리타게팅)

## 변경 사항
- `useStudioKeyboard` 훅: **Esc**=선택 해제, **Delete/Backspace**=선택 노드 삭제 (input/textarea 포커스 중엔 무시)
- **캔버스 배경 클릭** 시 선택 해제 (노드 클릭은 stopPropagation이라 안 겹침)
- `useStudioEditor.clearSelection` 추가
- `useStudioKeyboard` 단위 테스트(Esc/Delete/입력가드)

## 검증
- 타입체크 통과 / 테스트 통과 / eslint 통과 / knip 통과

## 로드맵(합의)
다음: 컨테이너 레이아웃 컨트롤(padding/gap/정렬) → 서버 영속화