### PR TITLE
feat: Studio 컨테이너 레이아웃 컨트롤(정렬/패딩)

### DIFF
--- a/apps/hobom-system/src/entities/manifest/model/stack.manifest.ts
+++ b/apps/hobom-system/src/entities/manifest/model/stack.manifest.ts
@@ -7,7 +7,18 @@ export const stackManifest: ComponentManifest = {
   category: "layout",
   props: {
     direction: { kind: "enum", values: ["row", "column"], default: "column" },
+    justifyContent: {
+      kind: "enum",
+      values: ["flex-start", "center", "flex-end", "space-between"],
+      default: "flex-start",
+    },
+    alignItems: {
+      kind: "enum",
+      values: ["flex-start", "center", "flex-end", "stretch"],
+      default: "stretch",
+    },
     gap: { kind: "number", default: 2 },
+    padding: { kind: "number", default: 0 },
     children: { kind: "slot", accepts: ["*"] },
   },
 };

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.spec.ts
@@ -71,6 +71,32 @@ describe("generateJsx", () => {
     expect(generateJsx(doc)).toContain('<Hb.Button variant="danger" />');
   });
 
+  it("컨테이너 레이아웃 prop(정렬/패딩)을 출력한다", () => {
+    const doc: StudioDocument = {
+      children: [
+        {
+          id: "s",
+          type: "Hb.Stack",
+          props: {
+            direction: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 2,
+            padding: 3,
+          },
+          children: [],
+        },
+      ],
+    };
+    const code = generateJsx(doc);
+
+    expect(code).toContain('direction="row"');
+    expect(code).toContain('justifyContent="space-between"');
+    expect(code).toContain('alignItems="center"');
+    expect(code).toContain("padding={3}");
+    expect(code).not.toContain("gap"); // 기본값(2) → 생략
+  });
+
   it("미등록 컴포넌트는 주석으로 표시한다", () => {
     const doc: StudioDocument = {
       children: [{ id: "x", type: "Hb.Unknown", props: {}, children: [] }],


### PR DESCRIPTION
## 개요
흐름(flex) 안에서 **자식 배치**를 인스펙터로 조정합니다 — 정렬·간격·여백. 자유 좌표 없이 "위치 조정"을 흐름 방식으로 본격 지원.

## 변경 사항
- `Hb.Stack` 매니페스트에 추가:
  - `justifyContent` (enum: flex-start/center/flex-end/space-between)
  - `alignItems` (enum: flex-start/center/flex-end/stretch)
  - `padding` (number)
- **매니페스트 데이터만 추가** — 인스펙터(컨트롤)·캔버스(렌더)·코드생성(prop)이 전부 자동 처리. MUI Stack이 `SystemProps`를 처리하므로 prop으로 직접 적용됨.

## 동작
Stack 선택 → 인스펙터에서 정렬/간격/패딩 조절 → 캔버스 즉시 반영 + 코드 `<Hb.Stack justifyContent="space-between" padding={3}>` 출력.

## 검증
- 타입체크 통과 / 테스트 13건 통과 / eslint 통과 / knip 통과

## 비고
- 매니페스트 한 곳 추가로 새 컨트롤이 붙는 게 이 아키텍처의 핵심 — 캔버스/codegen 코드는 0줄 수정.
- 참고: 인스펙터 enum 세그먼트에 긴 라벨(`space-between`)은 패널 폭에서 다소 빡빡할 수 있음 — 불편하면 컨트롤(드롭다운 등) 보강 가능.

## 로드맵 다음
서버 영속화(메모리 → 백엔드 저장)