### PR TITLE
feat: Studio 워크스페이스(폴더/아이템/이름변경) + 에디터 연동

### DIFF
--- a/apps/hobom-system/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-system/src/apps/ui/AppRouter.tsx
@@ -34,6 +34,8 @@ const pageImports = {
   projectDashboard: () => import("@/pages/project-dashboard"),
   projectSettings: () => import("@/pages/project-settings"),
   adminUsers: () => import("@/pages/admin-users"),
+  studioLayout: () => import("@/pages/studio-layout"),
+  studioWorkspace: () => import("@/pages/studio-workspace"),
   studio: () => import("@/pages/studio"),
   wikiSpaces: () => import("@/pages/wiki-spaces"),
   wikiSpaceLayout: () => import("@/pages/wiki-space-layout"),
@@ -74,6 +76,8 @@ const ProjectIssuesPage = lazy(pageImports.projectIssues);
 const ProjectDashboardPage = lazy(pageImports.projectDashboard);
 const ProjectSettingsPage = lazy(pageImports.projectSettings);
 const AdminUsersPage = lazy(pageImports.adminUsers);
+const StudioLayoutPage = lazy(pageImports.studioLayout);
+const WorkspacePage = lazy(pageImports.studioWorkspace);
 const StudioPage = lazy(pageImports.studio);
 const WikiSpacesPage = lazy(pageImports.wikiSpaces);
 const WikiSpaceLayoutPage = lazy(pageImports.wikiSpaceLayout);
@@ -300,10 +304,13 @@ export const AppRouter = () => {
           path={RoutesConfig.STUDIO.HOME}
           element={
             <Shell>
-              <StudioPage />
+              <StudioLayoutPage />
             </Shell>
           }
-        />
+        >
+          <Route index element={<WorkspacePage />} />
+          <Route path=":itemId" element={<StudioPage />} />
+        </Route>
         <Route
           path={RoutesConfig.PROJECTS.LIST}
           element={

--- a/apps/hobom-system/src/entities/workspace/index.ts
+++ b/apps/hobom-system/src/entities/workspace/index.ts
@@ -1,0 +1,1 @@
+export type { Folder, FolderId, ItemId, WorkspaceItem } from "./model/workspace.model";

--- a/apps/hobom-system/src/entities/workspace/model/workspace.model.ts
+++ b/apps/hobom-system/src/entities/workspace/model/workspace.model.ts
@@ -1,0 +1,23 @@
+/**
+ * 워크스페이스 메타데이터 모델 — 폴더/아이템의 "정보"만 다룬다.
+ *
+ * 주의(FSD): 이 엔티티는 동일 레이어인 `entities/document`를 import할 수 없다.
+ * 따라서 Item은 문서(StudioDocument) 자체를 들지 않고, 문서와의 결합은
+ * 상위 레이어(features/workspace)에서 한다.
+ */
+
+export type FolderId = string;
+export type ItemId = string;
+
+/** 작업 폴더. 이름 변경 가능. */
+export interface Folder {
+  id: FolderId;
+  name: string;
+}
+
+/** 작업 결과물(저장된 디자인)의 메타데이터. 실제 문서는 features 레이어가 보관한다. */
+export interface WorkspaceItem {
+  id: ItemId;
+  name: string;
+  folderId: FolderId;
+}

--- a/apps/hobom-system/src/features/workspace/index.ts
+++ b/apps/hobom-system/src/features/workspace/index.ts
@@ -1,0 +1,2 @@
+export { WorkspaceProvider } from "./model/WorkspaceProvider";
+export { useWorkspace } from "./model/workspace-context";

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  addDesign,
+  addFolder,
+  itemsInFolder,
+  renameFolder,
+  renameItem,
+  setItemDocument,
+} from "./workspace-ops.lib";
+import type { WorkspaceState } from "./workspace-ops.lib";
+
+const doc = (): WorkspaceState => ({
+  folders: [{ id: "f1", name: "내 작업" }],
+  items: [{ id: "i1", name: "샘플", folderId: "f1" }],
+  documents: { i1: { children: [] } },
+});
+
+describe("workspace-ops", () => {
+  it("addFolder는 폴더를 추가한다(불변)", () => {
+    const base = doc();
+    const next = addFolder(base, { id: "f2", name: "새 폴더" });
+
+    expect(next.folders.map((f) => f.id)).toEqual(["f1", "f2"]);
+    expect(base.folders).toHaveLength(1);
+  });
+
+  it("addDesign은 아이템 메타와 문서를 함께 추가한다", () => {
+    const next = addDesign(doc(), { id: "i2", name: "디자인", folderId: "f1" }, { children: [] });
+
+    expect(next.items.map((i) => i.id)).toEqual(["i1", "i2"]);
+    expect(next.documents.i2).toEqual({ children: [] });
+  });
+
+  it("setItemDocument는 문서를 교체한다", () => {
+    const updated = { children: [{ id: "n", type: "Hb.Button", props: {}, children: [] }] };
+    const next = setItemDocument(doc(), "i1", updated);
+
+    expect(next.documents.i1).toBe(updated);
+  });
+
+  it("itemsInFolder는 해당 폴더 아이템만 반환한다", () => {
+    const state = addDesign(doc(), { id: "i2", name: "x", folderId: "f2" }, { children: [] });
+
+    expect(itemsInFolder(state, "f1").map((i) => i.id)).toEqual(["i1"]);
+  });
+
+  it("renameFolder는 폴더 이름을 바꾼다", () => {
+    expect(renameFolder(doc(), "f1", "기획").folders[0].name).toBe("기획");
+  });
+
+  it("renameItem은 아이템 이름을 바꾼다", () => {
+    expect(renameItem(doc(), "i1", "메인 폼").items[0].name).toBe("메인 폼");
+  });
+});

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
@@ -1,0 +1,56 @@
+import type { Folder, FolderId, ItemId, WorkspaceItem } from "@/entities/workspace";
+import type { StudioDocument } from "@/entities/document";
+
+/** 워크스페이스 인메모리 상태 — 폴더·아이템 메타 + 아이템별 문서. */
+export interface WorkspaceState {
+  folders: Folder[];
+  items: WorkspaceItem[];
+  documents: Record<ItemId, StudioDocument>;
+}
+
+/** 폴더를 추가한 새 상태를 반환한다(불변). */
+export const addFolder = (state: WorkspaceState, folder: Folder): WorkspaceState => ({
+  ...state,
+  folders: [...state.folders, folder],
+});
+
+/** 아이템(메타 + 문서)을 추가한 새 상태를 반환한다(불변). */
+export const addDesign = (
+  state: WorkspaceState,
+  item: WorkspaceItem,
+  document: StudioDocument,
+): WorkspaceState => ({
+  ...state,
+  items: [...state.items, item],
+  documents: { ...state.documents, [item.id]: document },
+});
+
+/** 아이템의 문서를 교체한 새 상태를 반환한다(불변). */
+export const setItemDocument = (
+  state: WorkspaceState,
+  itemId: ItemId,
+  document: StudioDocument,
+): WorkspaceState => ({
+  ...state,
+  documents: { ...state.documents, [itemId]: document },
+});
+
+/** 폴더에 속한 아이템 목록. */
+export const itemsInFolder = (state: WorkspaceState, folderId: FolderId): WorkspaceItem[] =>
+  state.items.filter((item) => item.folderId === folderId);
+
+/** 폴더 이름을 바꾼 새 상태를 반환한다(불변). */
+export const renameFolder = (
+  state: WorkspaceState,
+  folderId: FolderId,
+  name: string,
+): WorkspaceState => ({
+  ...state,
+  folders: state.folders.map((folder) => (folder.id === folderId ? { ...folder, name } : folder)),
+});
+
+/** 아이템 이름을 바꾼 새 상태를 반환한다(불변). */
+export const renameItem = (state: WorkspaceState, itemId: ItemId, name: string): WorkspaceState => ({
+  ...state,
+  items: state.items.map((item) => (item.id === itemId ? { ...item, name } : item)),
+});

--- a/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
+++ b/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { createSampleDocument, type StudioDocument } from "@/entities/document";
+import type { FolderId, ItemId } from "@/entities/workspace";
+import {
+  addDesign,
+  addFolder,
+  itemsInFolder as itemsInFolderOp,
+  renameFolder as renameFolderOp,
+  renameItem as renameItemOp,
+  setItemDocument as setItemDocumentOp,
+  type WorkspaceState,
+} from "../lib/workspace-ops.lib";
+import { WorkspaceContext, type WorkspaceContextValue } from "./workspace-context";
+
+const createInitialState = (): WorkspaceState => ({
+  folders: [{ id: "f_default", name: "내 작업" }],
+  items: [{ id: "i_sample", name: "샘플 폼", folderId: "f_default" }],
+  documents: { i_sample: createSampleDocument() },
+});
+
+/** 워크스페이스 인메모리 store. 폴더·아이템·문서를 보관하고 ops를 제공한다. */
+export function WorkspaceProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<WorkspaceState>(createInitialState);
+
+  const createFolder = useCallback((name: string) => {
+    const id = `f_${crypto.randomUUID()}`;
+
+    setState((prev) => addFolder(prev, { id, name }));
+
+    return id;
+  }, []);
+
+  const createDesign = useCallback((folderId: FolderId, name: string) => {
+    const id = `i_${crypto.randomUUID()}`;
+
+    setState((prev) => addDesign(prev, { id, name, folderId }, { children: [] }));
+
+    return id;
+  }, []);
+
+  const renameFolder = useCallback((id: FolderId, name: string) => {
+    setState((prev) => renameFolderOp(prev, id, name));
+  }, []);
+
+  const renameItem = useCallback((id: ItemId, name: string) => {
+    setState((prev) => renameItemOp(prev, id, name));
+  }, []);
+
+  const updateDocument = useCallback(
+    (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => {
+      setState((prev) => {
+        const current = prev.documents[id];
+
+        return current ? setItemDocumentOp(prev, id, updater(current)) : prev;
+      });
+    },
+    [],
+  );
+
+  const value = useMemo<WorkspaceContextValue>(
+    () => ({
+      folders: state.folders,
+      items: state.items,
+      itemsInFolder: (folderId) => itemsInFolderOp(state, folderId),
+      getItem: (id) => state.items.find((item) => item.id === id),
+      getDocument: (id) => state.documents[id],
+      createFolder,
+      createDesign,
+      renameFolder,
+      renameItem,
+      updateDocument,
+    }),
+    [state, createFolder, createDesign, renameFolder, renameItem, updateDocument],
+  );
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}

--- a/apps/hobom-system/src/features/workspace/model/workspace-context.ts
+++ b/apps/hobom-system/src/features/workspace/model/workspace-context.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext } from "react";
+import type { StudioDocument } from "@/entities/document";
+import type { Folder, FolderId, ItemId, WorkspaceItem } from "@/entities/workspace";
+
+export interface WorkspaceContextValue {
+  folders: Folder[];
+  items: WorkspaceItem[];
+  itemsInFolder: (folderId: FolderId) => WorkspaceItem[];
+  getItem: (id: ItemId) => WorkspaceItem | undefined;
+  getDocument: (id: ItemId) => StudioDocument | undefined;
+  createFolder: (name: string) => FolderId;
+  createDesign: (folderId: FolderId, name: string) => ItemId;
+  renameFolder: (id: FolderId, name: string) => void;
+  renameItem: (id: ItemId, name: string) => void;
+  updateDocument: (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => void;
+}
+
+export const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+/** 워크스페이스 store 접근 훅. WorkspaceProvider 내부에서만 사용. */
+export function useWorkspace(): WorkspaceContextValue {
+  const context = useContext(WorkspaceContext);
+
+  if (!context) {
+    throw new Error("useWorkspace must be used within WorkspaceProvider");
+  }
+
+  return context;
+}

--- a/apps/hobom-system/src/pages/studio-layout/index.ts
+++ b/apps/hobom-system/src/pages/studio-layout/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ui/StudioLayoutPage";

--- a/apps/hobom-system/src/pages/studio-layout/ui/StudioLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/studio-layout/ui/StudioLayoutPage.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import { WorkspaceProvider } from "@/features/workspace";
+
+/** /studio 하위(브라우저·에디터)를 워크스페이스 store로 감싸는 레이아웃. */
+export default function StudioLayoutPage() {
+  return (
+    <WorkspaceProvider>
+      <Outlet />
+    </WorkspaceProvider>
+  );
+}

--- a/apps/hobom-system/src/pages/studio-workspace/index.ts
+++ b/apps/hobom-system/src/pages/studio-workspace/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ui/WorkspacePage";

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AddOutlined, FolderOutlined } from "hobom-design-system/icons";
+import { Hb, EditableLabel } from "@/shared/ui";
+import { useWorkspace } from "@/features/workspace";
+import type { FolderId, ItemId } from "@/entities/workspace";
+
+/** 워크스페이스 브라우저 — 좌측 폴더 / 우측 아이템 그리드. 아이템 클릭 시 에디터로 이동. */
+export default function WorkspacePage() {
+  const navigate = useNavigate();
+  const { folders, itemsInFolder, createFolder, createDesign, renameFolder } = useWorkspace();
+  const [activeFolderId, setActiveFolderId] = useState<FolderId | undefined>(folders[0]?.id);
+
+  const activeFolder = folders.find((folder) => folder.id === activeFolderId) ?? folders[0];
+  const items = activeFolder ? itemsInFolder(activeFolder.id) : [];
+
+  const openItem = (id: ItemId) => navigate(`/studio/${id}`);
+
+  const handleNewFolder = () => setActiveFolderId(createFolder(`폴더 ${folders.length + 1}`));
+
+  const handleNewDesign = () => {
+    if (!activeFolder) {
+      return;
+    }
+
+    openItem(createDesign(activeFolder.id, `디자인 ${items.length + 1}`));
+  };
+
+  return (
+    <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
+      <Hb.Stack
+        sx={{
+          width: 240,
+          flexShrink: 0,
+          borderRight: 1,
+          borderColor: "divider",
+          p: 1.5,
+          gap: 0.25,
+          overflow: "auto",
+        }}
+      >
+        <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+          <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+            폴더
+          </Hb.Text>
+          <Hb.Button.Icon size="small" aria-label="새 폴더" onClick={handleNewFolder}>
+            <AddOutlined fontSize="small" />
+          </Hb.Button.Icon>
+        </Hb.Stack>
+
+        {folders.map((folder) => (
+          <Hb.Stack
+            key={folder.id}
+            direction="row"
+            alignItems="center"
+            gap={1}
+            onClick={() => setActiveFolderId(folder.id)}
+            sx={{
+              px: 1,
+              py: 0.75,
+              borderRadius: 1,
+              cursor: "pointer",
+              bgcolor: folder.id === activeFolder?.id ? "action.selected" : "transparent",
+              "&:hover": { bgcolor: "action.hover" },
+            }}
+          >
+            <FolderOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
+            <EditableLabel
+              value={folder.name}
+              onCommit={(name) => renameFolder(folder.id, name)}
+              textSx={{ fontSize: 14 }}
+            />
+            <Hb.Box sx={{ flex: 1 }} />
+          </Hb.Stack>
+        ))}
+      </Hb.Stack>
+
+      <Hb.Box sx={{ flex: 1, minWidth: 0, p: 3, overflow: "auto" }}>
+        <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+          <Hb.Text variant="h6">{activeFolder?.name ?? "워크스페이스"}</Hb.Text>
+          <Hb.Button variant="primary" startIcon={<AddOutlined />} onClick={handleNewDesign}>
+            새 디자인
+          </Hb.Button>
+        </Hb.Stack>
+
+        {items.length === 0 ? (
+          <Hb.Text variant="body2" color="text.secondary">
+            아직 디자인이 없어요. "새 디자인"으로 시작하세요.
+          </Hb.Text>
+        ) : (
+          <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+            {items.map((item) => (
+              <Hb.Card.Root
+                key={item.id}
+                onClick={() => openItem(item.id)}
+                sx={{
+                  width: 200,
+                  p: 1.5,
+                  cursor: "pointer",
+                  "&:hover": { borderColor: "primary.main" },
+                }}
+              >
+                <Hb.Box sx={{ height: 120, bgcolor: "background.default", borderRadius: 1, mb: 1 }} />
+                <Hb.Text variant="body2" sx={{ fontWeight: 600, px: 0.25 }}>
+                  {item.name}
+                </Hb.Text>
+              </Hb.Card.Root>
+            ))}
+          </Hb.Box>
+        )}
+      </Hb.Box>
+    </Hb.Stack>
+  );
+}

--- a/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
+++ b/apps/hobom-system/src/pages/studio/model/useStudioEditor.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from "react";
 import { getManifest, type ComponentKey } from "@/entities/manifest";
 import {
   createNodeId,
-  createSampleDocument,
   findNode,
   insertNode,
   isComponentNode,
@@ -14,15 +13,17 @@ import {
   type NodeId,
   type NodeStyle,
   type PropValue,
+  type StudioDocument,
 } from "@/entities/document";
 import { acceptsComponentChildren, createComponentNode } from "../lib/create-component-node.lib";
 
+type SetDocument = (updater: (prev: StudioDocument) => StudioDocument) => void;
+
 /**
  * Studio 에디터 상태 오케스트레이션 — 문서·선택·삽입·삭제·prop 편집을 한 곳에서 소유한다.
- * 캔버스/팔레트/인스펙터가 이 훅의 상태를 공유한다(컴포넌트는 순수 렌더).
+ * 문서는 외부(워크스페이스 store)에서 주입받고(controlled), 선택 상태만 로컬 보유한다.
  */
-export function useStudioEditor() {
-  const [document, setDocument] = useState(createSampleDocument);
+export function useStudioEditor(document: StudioDocument, setDocument: SetDocument) {
   const [selectedId, setSelectedId] = useState<NodeId | undefined>(undefined);
 
   const selectedNode: DocumentNode | undefined = useMemo(
@@ -42,7 +43,7 @@ export function useStudioEditor() {
 
       setDocument((doc) => updateNodeProps(doc, selectedId, prop, value));
     },
-    [selectedId],
+    [selectedId, setDocument],
   );
 
   const insertComponent = useCallback(
@@ -65,7 +66,7 @@ export function useStudioEditor() {
       setDocument((doc) => insertNode(doc, parentId, node));
       setSelectedId(node.id);
     },
-    [selectedNode],
+    [selectedNode, setDocument],
   );
 
   const updateStyle = useCallback(
@@ -76,7 +77,7 @@ export function useStudioEditor() {
 
       setDocument((doc) => updateNodeStyle(doc, selectedId, key, value));
     },
-    [selectedId],
+    [selectedId, setDocument],
   );
 
   const resizeNode = useCallback((id: NodeId, size: { width?: number; height?: number }) => {
@@ -93,12 +94,15 @@ export function useStudioEditor() {
 
       return next;
     });
-  }, []);
+  }, [setDocument]);
 
   /** 같은 부모면 순서변경, 다른 부모면 그 부모로 이동(흐름 D&D). */
-  const reorderNode = useCallback((activeId: NodeId, overId: NodeId) => {
-    setDocument((doc) => moveNode(doc, activeId, overId));
-  }, []);
+  const reorderNode = useCallback(
+    (activeId: NodeId, overId: NodeId) => {
+      setDocument((doc) => moveNode(doc, activeId, overId));
+    },
+    [setDocument],
+  );
 
   const deleteSelected = useCallback(() => {
     if (!selectedId) {
@@ -107,7 +111,7 @@ export function useStudioEditor() {
 
     setDocument((doc) => removeNode(doc, selectedId));
     setSelectedId(undefined);
-  }, [selectedId]);
+  }, [selectedId, setDocument]);
 
   return {
     document,

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -1,4 +1,10 @@
-import { Hb } from "@/shared/ui";
+import { useCallback } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { ArrowBackOutlined } from "hobom-design-system/icons";
+import { Hb, EditableLabel } from "@/shared/ui";
+import { RoutesConfig } from "@/shared/config";
+import { useWorkspace } from "@/features/workspace";
+import type { StudioDocument } from "@/entities/document";
 import { Canvas } from "@/widgets/canvas";
 import { CodePanel } from "@/widgets/code-panel";
 import { InsertPalette } from "@/widgets/insert-palette";
@@ -9,12 +15,39 @@ import { useStudioKeyboard } from "../model/useStudioKeyboard";
 import { studioTheme } from "../config/studio-theme";
 
 /**
- * HoBom Studio — 디자인 시스템 기반 웹 캔버스 진입점.
- * 좌: 삽입+레이어 / 중앙: 캔버스(아트보드) / 우: 속성 + 코드. (디자인 툴 류 다크 UI)
+ * HoBom Studio 에디터 — 워크스페이스 Item(:itemId)의 문서를 로드해 편집한다.
+ * 문서는 워크스페이스 store에 저장되고, 편집은 store로 흐른다.
  */
 export default function StudioPage() {
+  const { itemId } = useParams();
+  const { getItem, getDocument } = useWorkspace();
+
+  const item = itemId ? getItem(itemId) : undefined;
+  const document = itemId ? getDocument(itemId) : undefined;
+
+  if (!item || !document) {
+    return <Navigate to={RoutesConfig.STUDIO.HOME} replace />;
+  }
+
+  return <StudioEditor itemId={item.id} name={item.name} document={document} />;
+}
+
+interface StudioEditorProps {
+  itemId: string;
+  name: string;
+  document: StudioDocument;
+}
+
+function StudioEditor({ itemId, name, document }: StudioEditorProps) {
+  const navigate = useNavigate();
+  const { updateDocument, renameItem } = useWorkspace();
+
+  const setDocument = useCallback(
+    (updater: (prev: StudioDocument) => StudioDocument) => updateDocument(itemId, updater),
+    [updateDocument, itemId],
+  );
+
   const {
-    document,
     selectedId,
     selectedNode,
     selectNode,
@@ -25,7 +58,7 @@ export default function StudioPage() {
     reorderNode,
     insertComponent,
     deleteSelected,
-  } = useStudioEditor();
+  } = useStudioEditor(document, setDocument);
 
   useStudioKeyboard({ onDelete: deleteSelected, onDeselect: clearSelection });
 
@@ -41,6 +74,28 @@ export default function StudioPage() {
         }}
       >
         <Panel width={232} side="right">
+          <Hb.Stack
+            direction="row"
+            alignItems="center"
+            gap={0.5}
+            sx={{ px: 1, py: 1, borderBottom: 1, borderColor: "divider" }}
+          >
+            <Hb.Button.Icon
+              size="small"
+              aria-label="워크스페이스로"
+              onClick={() => navigate(RoutesConfig.STUDIO.HOME)}
+              sx={{ p: 0.25, color: "text.secondary" }}
+            >
+              <ArrowBackOutlined sx={{ fontSize: 18 }} />
+            </Hb.Button.Icon>
+            <EditableLabel
+              value={name}
+              onCommit={(next) => renameItem(itemId, next)}
+              textSx={{ fontSize: 12, fontWeight: 600, minWidth: 0 }}
+              inputSx={{ fontSize: 12, fontWeight: 600 }}
+            />
+          </Hb.Stack>
+
           <SectionHeader>삽입</SectionHeader>
           <InsertPalette onInsert={insertComponent} />
           <Hb.Divider />

--- a/apps/hobom-system/src/shared/config/routes.ts
+++ b/apps/hobom-system/src/shared/config/routes.ts
@@ -48,6 +48,7 @@ export const RoutesConfig = {
   },
   STUDIO: {
     HOME: "/studio",
+    EDITOR: "/studio/:itemId",
   },
   ADMIN: {
     USERS: "/admin/users",

--- a/apps/hobom-system/src/shared/ui/EditableLabel.tsx
+++ b/apps/hobom-system/src/shared/ui/EditableLabel.tsx
@@ -1,0 +1,66 @@
+import { useState, type KeyboardEvent } from "react";
+import { Hb, type SxProps, type Theme } from "hobom-design-system";
+
+interface EditableLabelProps {
+  value: string;
+  onCommit: (value: string) => void;
+  textSx?: SxProps<Theme>;
+  inputSx?: SxProps<Theme>;
+}
+
+/** 더블클릭으로 인라인 편집되는 라벨. Enter/blur 저장, Esc 취소. */
+export function EditableLabel({ value, onCommit, textSx, inputSx }: EditableLabelProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+
+  const start = () => {
+    setDraft(value);
+    setEditing(true);
+  };
+
+  const commit = () => {
+    setEditing(false);
+    const next = draft.trim();
+
+    if (next && next !== value) {
+      onCommit(next);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      commit();
+    } else if (event.key === "Escape") {
+      setEditing(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <Hb.InputBase
+        autoFocus
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        onClick={(event) => event.stopPropagation()}
+        sx={{
+          font: "inherit",
+          color: "inherit",
+          px: 0.5,
+          borderRadius: 0.5,
+          border: 1,
+          borderColor: "primary.main",
+          minWidth: 0,
+          ...inputSx,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Hb.Text onDoubleClick={start} sx={{ cursor: "default", ...textSx }}>
+      {value}
+    </Hb.Text>
+  );
+}

--- a/apps/hobom-system/src/shared/ui/index.ts
+++ b/apps/hobom-system/src/shared/ui/index.ts
@@ -24,4 +24,5 @@ export type {
   DragOverEvent,
 } from "hobom-design-system";
 export { Hb, useColorScheme } from "hobom-design-system";
+export { EditableLabel } from "./EditableLabel";
 export type { SxProps, Theme, SvgIconProps, SelectChangeEvent } from "hobom-design-system";


### PR DESCRIPTION
## 개요
Studio에 **워크스페이스(파일 관리) 레이어**를 추가합니다 — Figma 파일 브라우저처럼 폴더에 디자인(Item)을 담고, 열어서 편집. 저장은 **인메모리 localState**(서버는 추후 for-hobom-backend).

## 핵심 흐름
`/studio`(브라우저) → 새 디자인/열기 → `/studio/:itemId`(에디터) → 편집(store에 자동 반영) → 뒤로.

## 변경 사항
- **entities/workspace**: 폴더/아이템 메타 모델 (FSD상 document 비의존)
- **features/workspace**: 인메모리 store(`WorkspaceProvider`/`useWorkspace`) + 순수 ops(생성·이름변경·문서갱신) + 단위 테스트
- **라우팅 재구성**: `/studio`=브라우저, `/studio/:itemId`=에디터. `StudioLayout`이 Provider 제공(브라우저↔에디터 상태 공유)
- **WorkspacePage**: 폴더 사이드바 + 아이템 그리드, 새 폴더/새 디자인, **폴더명 인라인 편집**
- **에디터 controlled 리팩터**: 문서를 워크스페이스 store에서 주입받고 편집이 store로 흐름. **제목 인라인 편집** + 뒤로가기 버튼
- **shared/ui `EditableLabel`**: 더블클릭 인라인 편집(Enter 저장/Esc 취소)

## 검증
- 타입체크 통과 / 테스트 274건 통과 / eslint 통과 / knip 통과

## 다음(로드맵)
- 즐겨찾기(이름변경) · 아이템/폴더 삭제 · 템플릿 갤러리 · 서버(for-hobom-backend) 연동