### PR TITLE
feat: Studio 워크스페이스 폴더/디자인 삭제

### DIFF
--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
@@ -3,6 +3,8 @@ import {
   addDesign,
   addFolder,
   itemsInFolder,
+  removeDesign,
+  removeFolder,
   renameFolder,
   renameItem,
   setItemDocument,
@@ -50,5 +52,20 @@ describe("workspace-ops", () => {
 
   it("renameItem은 아이템 이름을 바꾼다", () => {
     expect(renameItem(doc(), "i1", "메인 폼").items[0].name).toBe("메인 폼");
+  });
+
+  it("removeDesign은 아이템과 문서를 제거한다", () => {
+    const next = removeDesign(doc(), "i1");
+
+    expect(next.items).toHaveLength(0);
+    expect(next.documents.i1).toBeUndefined();
+  });
+
+  it("removeFolder는 폴더와 그 안의 아이템·문서를 cascade 제거한다", () => {
+    const next = removeFolder(doc(), "f1");
+
+    expect(next.folders).toHaveLength(0);
+    expect(next.items).toHaveLength(0);
+    expect(next.documents.i1).toBeUndefined();
   });
 });

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
@@ -54,3 +54,29 @@ export const renameItem = (state: WorkspaceState, itemId: ItemId, name: string):
   ...state,
   items: state.items.map((item) => (item.id === itemId ? { ...item, name } : item)),
 });
+
+/** 아이템과 그 문서를 제거한 새 상태를 반환한다(불변). */
+export const removeDesign = (state: WorkspaceState, itemId: ItemId): WorkspaceState => {
+  const { [itemId]: _removed, ...documents } = state.documents;
+
+  return {
+    ...state,
+    items: state.items.filter((item) => item.id !== itemId),
+    documents,
+  };
+};
+
+/** 폴더와 그 안의 아이템·문서를 모두 제거한 새 상태를 반환한다(불변, cascade). */
+export const removeFolder = (state: WorkspaceState, folderId: FolderId): WorkspaceState => {
+  const keptItems = state.items.filter((item) => item.folderId !== folderId);
+  const keptIds = new Set(keptItems.map((item) => item.id));
+  const documents = Object.fromEntries(
+    Object.entries(state.documents).filter(([id]) => keptIds.has(id)),
+  );
+
+  return {
+    folders: state.folders.filter((folder) => folder.id !== folderId),
+    items: keptItems,
+    documents,
+  };
+};

--- a/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
+++ b/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
@@ -5,6 +5,8 @@ import {
   addDesign,
   addFolder,
   itemsInFolder as itemsInFolderOp,
+  removeDesign as removeDesignOp,
+  removeFolder as removeFolderOp,
   renameFolder as renameFolderOp,
   renameItem as renameItemOp,
   setItemDocument as setItemDocumentOp,
@@ -46,6 +48,14 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setState((prev) => renameItemOp(prev, id, name));
   }, []);
 
+  const deleteFolder = useCallback((id: FolderId) => {
+    setState((prev) => removeFolderOp(prev, id));
+  }, []);
+
+  const deleteDesign = useCallback((id: ItemId) => {
+    setState((prev) => removeDesignOp(prev, id));
+  }, []);
+
   const updateDocument = useCallback(
     (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => {
       setState((prev) => {
@@ -68,9 +78,20 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       createDesign,
       renameFolder,
       renameItem,
+      deleteFolder,
+      deleteDesign,
       updateDocument,
     }),
-    [state, createFolder, createDesign, renameFolder, renameItem, updateDocument],
+    [
+      state,
+      createFolder,
+      createDesign,
+      renameFolder,
+      renameItem,
+      deleteFolder,
+      deleteDesign,
+      updateDocument,
+    ],
   );
 
   return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;

--- a/apps/hobom-system/src/features/workspace/model/workspace-context.ts
+++ b/apps/hobom-system/src/features/workspace/model/workspace-context.ts
@@ -12,6 +12,8 @@ export interface WorkspaceContextValue {
   createDesign: (folderId: FolderId, name: string) => ItemId;
   renameFolder: (id: FolderId, name: string) => void;
   renameItem: (id: ItemId, name: string) => void;
+  deleteFolder: (id: FolderId) => void;
+  deleteDesign: (id: ItemId) => void;
   updateDocument: (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => void;
 }
 

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { AddOutlined, FolderOutlined } from "hobom-design-system/icons";
+import { AddOutlined, DeleteOutline, FolderOutlined } from "hobom-design-system/icons";
 import { Hb, EditableLabel } from "@/shared/ui";
 import { useWorkspace } from "@/features/workspace";
 import type { FolderId, ItemId } from "@/entities/workspace";
@@ -8,7 +8,15 @@ import type { FolderId, ItemId } from "@/entities/workspace";
 /** 워크스페이스 브라우저 — 좌측 폴더 / 우측 아이템 그리드. 아이템 클릭 시 에디터로 이동. */
 export default function WorkspacePage() {
   const navigate = useNavigate();
-  const { folders, itemsInFolder, createFolder, createDesign, renameFolder } = useWorkspace();
+  const {
+    folders,
+    itemsInFolder,
+    createFolder,
+    createDesign,
+    renameFolder,
+    deleteFolder,
+    deleteDesign,
+  } = useWorkspace();
   const [activeFolderId, setActiveFolderId] = useState<FolderId | undefined>(folders[0]?.id);
 
   const activeFolder = folders.find((folder) => folder.id === activeFolderId) ?? folders[0];
@@ -24,6 +32,20 @@ export default function WorkspacePage() {
     }
 
     openItem(createDesign(activeFolder.id, `디자인 ${items.length + 1}`));
+  };
+
+  const handleDeleteFolder = (event: MouseEvent, id: FolderId) => {
+    event.stopPropagation();
+    deleteFolder(id);
+
+    if (id === activeFolderId) {
+      setActiveFolderId(folders.find((folder) => folder.id !== id)?.id);
+    }
+  };
+
+  const handleDeleteDesign = (event: MouseEvent, id: ItemId) => {
+    event.stopPropagation();
+    deleteDesign(id);
   };
 
   return (
@@ -62,6 +84,7 @@ export default function WorkspacePage() {
               cursor: "pointer",
               bgcolor: folder.id === activeFolder?.id ? "action.selected" : "transparent",
               "&:hover": { bgcolor: "action.hover" },
+              "&:hover .row-action": { opacity: 1 },
             }}
           >
             <FolderOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
@@ -71,6 +94,15 @@ export default function WorkspacePage() {
               textSx={{ fontSize: 14 }}
             />
             <Hb.Box sx={{ flex: 1 }} />
+            <Hb.Button.Icon
+              size="small"
+              className="row-action"
+              aria-label="폴더 삭제"
+              onClick={(event) => handleDeleteFolder(event, folder.id)}
+              sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
+            >
+              <DeleteOutline sx={{ fontSize: 16 }} />
+            </Hb.Button.Icon>
           </Hb.Stack>
         ))}
       </Hb.Stack>
@@ -96,10 +128,30 @@ export default function WorkspacePage() {
                 sx={{
                   width: 200,
                   p: 1.5,
+                  position: "relative",
                   cursor: "pointer",
                   "&:hover": { borderColor: "primary.main" },
+                  "&:hover .card-action": { opacity: 1 },
                 }}
               >
+                <Hb.Button.Icon
+                  size="small"
+                  className="card-action"
+                  aria-label="디자인 삭제"
+                  onClick={(event) => handleDeleteDesign(event, item.id)}
+                  sx={{
+                    position: "absolute",
+                    top: 6,
+                    right: 6,
+                    bgcolor: "background.paper",
+                    opacity: 0,
+                    transition: "opacity 0.12s",
+                    "&:hover": { bgcolor: "background.paper" },
+                  }}
+                >
+                  <DeleteOutline sx={{ fontSize: 16 }} />
+                </Hb.Button.Icon>
+
                 <Hb.Box sx={{ height: 120, bgcolor: "background.default", borderRadius: 1, mb: 1 }} />
                 <Hb.Text variant="body2" sx={{ fontWeight: 600, px: 0.25 }}>
                   {item.name}


### PR DESCRIPTION
## 개요
워크스페이스에 **삭제**를 추가 — 생성·이름변경에 이어 기본 CRUD 완성.

## 변경 사항
- `removeDesign`(아이템+문서) / `removeFolder`(**cascade**: 폴더+자식 디자인·문서) 순수 ops + 단위 테스트
- `useWorkspace.deleteFolder` / `deleteDesign`
- 브라우저 UI: 폴더 행·디자인 카드에 **hover 삭제 버튼**, 활성 폴더 삭제 시 다른 폴더로 자동 전환

## 검증
- 타입체크 통과 / 테스트 8건 통과 / eslint 통과 / knip 통과

## 비고
- 폴더 삭제는 cascade(자식 디자인까지 삭제). 확인 다이얼로그는 추후 추가 가능.

## 다음
즐겨찾기(이름변경) → 템플릿 갤러리 → 서버 연동