### PR TITLE
feat: Studio 워크스페이스 즐겨찾기 섹션

### DIFF
--- a/apps/hobom-system/src/entities/workspace/index.ts
+++ b/apps/hobom-system/src/entities/workspace/index.ts
@@ -1,1 +1,8 @@
-export type { Folder, FolderId, ItemId, WorkspaceItem } from "./model/workspace.model";
+export type {
+  Favorite,
+  FavoriteId,
+  Folder,
+  FolderId,
+  ItemId,
+  WorkspaceItem,
+} from "./model/workspace.model";

--- a/apps/hobom-system/src/entities/workspace/model/workspace.model.ts
+++ b/apps/hobom-system/src/entities/workspace/model/workspace.model.ts
@@ -8,6 +8,7 @@
 
 export type FolderId = string;
 export type ItemId = string;
+export type FavoriteId = string;
 
 /** 작업 폴더. 이름 변경 가능. */
 export interface Folder {
@@ -20,4 +21,11 @@ export interface WorkspaceItem {
   id: ItemId;
   name: string;
   folderId: FolderId;
+}
+
+/** 즐겨찾기 — 디자인을 핀하고 커스텀 라벨(이름 변경 가능)을 가진다. */
+export interface Favorite {
+  id: FavoriteId;
+  designId: ItemId;
+  label: string;
 }

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   addDesign,
+  addFavorite,
   addFolder,
   itemsInFolder,
   removeDesign,
+  removeFavorite,
   removeFolder,
+  renameFavorite,
   renameFolder,
   renameItem,
   setItemDocument,
@@ -15,6 +18,7 @@ const doc = (): WorkspaceState => ({
   folders: [{ id: "f1", name: "내 작업" }],
   items: [{ id: "i1", name: "샘플", folderId: "f1" }],
   documents: { i1: { children: [] } },
+  favorites: [],
 });
 
 describe("workspace-ops", () => {
@@ -67,5 +71,30 @@ describe("workspace-ops", () => {
     expect(next.folders).toHaveLength(0);
     expect(next.items).toHaveLength(0);
     expect(next.documents.i1).toBeUndefined();
+  });
+
+  it("addFavorite은 즐겨찾기를 추가하고 같은 디자인 중복은 막는다", () => {
+    const once = addFavorite(doc(), { id: "fav1", designId: "i1", label: "샘플" });
+    const twice = addFavorite(once, { id: "fav2", designId: "i1", label: "또" });
+
+    expect(twice.favorites).toHaveLength(1);
+  });
+
+  it("renameFavorite은 라벨을 바꾼다", () => {
+    const withFav = addFavorite(doc(), { id: "fav1", designId: "i1", label: "샘플" });
+
+    expect(renameFavorite(withFav, "fav1", "즐겨").favorites[0].label).toBe("즐겨");
+  });
+
+  it("디자인 삭제 시 그 즐겨찾기도 제거된다", () => {
+    const withFav = addFavorite(doc(), { id: "fav1", designId: "i1", label: "샘플" });
+
+    expect(removeDesign(withFav, "i1").favorites).toHaveLength(0);
+  });
+
+  it("removeFavorite은 즐겨찾기를 제거한다", () => {
+    const withFav = addFavorite(doc(), { id: "fav1", designId: "i1", label: "샘플" });
+
+    expect(removeFavorite(withFav, "fav1").favorites).toHaveLength(0);
   });
 });

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.ts
@@ -1,11 +1,19 @@
-import type { Folder, FolderId, ItemId, WorkspaceItem } from "@/entities/workspace";
+import type {
+  Favorite,
+  FavoriteId,
+  Folder,
+  FolderId,
+  ItemId,
+  WorkspaceItem,
+} from "@/entities/workspace";
 import type { StudioDocument } from "@/entities/document";
 
-/** 워크스페이스 인메모리 상태 — 폴더·아이템 메타 + 아이템별 문서. */
+/** 워크스페이스 인메모리 상태 — 폴더·아이템 메타 + 아이템별 문서 + 즐겨찾기. */
 export interface WorkspaceState {
   folders: Folder[];
   items: WorkspaceItem[];
   documents: Record<ItemId, StudioDocument>;
+  favorites: Favorite[];
 }
 
 /** 폴더를 추가한 새 상태를 반환한다(불변). */
@@ -55,7 +63,7 @@ export const renameItem = (state: WorkspaceState, itemId: ItemId, name: string):
   items: state.items.map((item) => (item.id === itemId ? { ...item, name } : item)),
 });
 
-/** 아이템과 그 문서를 제거한 새 상태를 반환한다(불변). */
+/** 아이템과 그 문서·즐겨찾기를 제거한 새 상태를 반환한다(불변). */
 export const removeDesign = (state: WorkspaceState, itemId: ItemId): WorkspaceState => {
   const { [itemId]: _removed, ...documents } = state.documents;
 
@@ -63,10 +71,11 @@ export const removeDesign = (state: WorkspaceState, itemId: ItemId): WorkspaceSt
     ...state,
     items: state.items.filter((item) => item.id !== itemId),
     documents,
+    favorites: state.favorites.filter((favorite) => favorite.designId !== itemId),
   };
 };
 
-/** 폴더와 그 안의 아이템·문서를 모두 제거한 새 상태를 반환한다(불변, cascade). */
+/** 폴더와 그 안의 아이템·문서·즐겨찾기를 모두 제거한 새 상태를 반환한다(불변, cascade). */
 export const removeFolder = (state: WorkspaceState, folderId: FolderId): WorkspaceState => {
   const keptItems = state.items.filter((item) => item.folderId !== folderId);
   const keptIds = new Set(keptItems.map((item) => item.id));
@@ -78,5 +87,30 @@ export const removeFolder = (state: WorkspaceState, folderId: FolderId): Workspa
     folders: state.folders.filter((folder) => folder.id !== folderId),
     items: keptItems,
     documents,
+    favorites: state.favorites.filter((favorite) => keptIds.has(favorite.designId)),
   };
 };
+
+/** 즐겨찾기를 추가한다(같은 디자인 중복 방지, 불변). */
+export const addFavorite = (state: WorkspaceState, favorite: Favorite): WorkspaceState =>
+  state.favorites.some((existing) => existing.designId === favorite.designId)
+    ? state
+    : { ...state, favorites: [...state.favorites, favorite] };
+
+/** 즐겨찾기를 제거한다(불변). */
+export const removeFavorite = (state: WorkspaceState, id: FavoriteId): WorkspaceState => ({
+  ...state,
+  favorites: state.favorites.filter((favorite) => favorite.id !== id),
+});
+
+/** 즐겨찾기 라벨을 바꾼다(불변). */
+export const renameFavorite = (
+  state: WorkspaceState,
+  id: FavoriteId,
+  label: string,
+): WorkspaceState => ({
+  ...state,
+  favorites: state.favorites.map((favorite) =>
+    favorite.id === id ? { ...favorite, label } : favorite,
+  ),
+});

--- a/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
+++ b/apps/hobom-system/src/features/workspace/model/WorkspaceProvider.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { createSampleDocument, type StudioDocument } from "@/entities/document";
-import type { FolderId, ItemId } from "@/entities/workspace";
+import type { FavoriteId, FolderId, ItemId } from "@/entities/workspace";
 import {
   addDesign,
+  addFavorite as addFavoriteOp,
   addFolder,
   itemsInFolder as itemsInFolderOp,
   removeDesign as removeDesignOp,
+  removeFavorite as removeFavoriteOp,
   removeFolder as removeFolderOp,
+  renameFavorite as renameFavoriteOp,
   renameFolder as renameFolderOp,
   renameItem as renameItemOp,
   setItemDocument as setItemDocumentOp,
@@ -18,6 +21,7 @@ const createInitialState = (): WorkspaceState => ({
   folders: [{ id: "f_default", name: "내 작업" }],
   items: [{ id: "i_sample", name: "샘플 폼", folderId: "f_default" }],
   documents: { i_sample: createSampleDocument() },
+  favorites: [],
 });
 
 /** 워크스페이스 인메모리 store. 폴더·아이템·문서를 보관하고 ops를 제공한다. */
@@ -56,6 +60,20 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     setState((prev) => removeDesignOp(prev, id));
   }, []);
 
+  const addFavorite = useCallback((designId: ItemId, label: string) => {
+    const id = `fav_${crypto.randomUUID()}`;
+
+    setState((prev) => addFavoriteOp(prev, { id, designId, label }));
+  }, []);
+
+  const removeFavorite = useCallback((id: FavoriteId) => {
+    setState((prev) => removeFavoriteOp(prev, id));
+  }, []);
+
+  const renameFavorite = useCallback((id: FavoriteId, label: string) => {
+    setState((prev) => renameFavoriteOp(prev, id, label));
+  }, []);
+
   const updateDocument = useCallback(
     (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => {
       setState((prev) => {
@@ -71,6 +89,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     () => ({
       folders: state.folders,
       items: state.items,
+      favorites: state.favorites,
       itemsInFolder: (folderId) => itemsInFolderOp(state, folderId),
       getItem: (id) => state.items.find((item) => item.id === id),
       getDocument: (id) => state.documents[id],
@@ -80,6 +99,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       renameItem,
       deleteFolder,
       deleteDesign,
+      addFavorite,
+      removeFavorite,
+      renameFavorite,
       updateDocument,
     }),
     [
@@ -90,6 +112,9 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
       renameItem,
       deleteFolder,
       deleteDesign,
+      addFavorite,
+      removeFavorite,
+      renameFavorite,
       updateDocument,
     ],
   );

--- a/apps/hobom-system/src/features/workspace/model/workspace-context.ts
+++ b/apps/hobom-system/src/features/workspace/model/workspace-context.ts
@@ -1,10 +1,18 @@
 import { createContext, useContext } from "react";
 import type { StudioDocument } from "@/entities/document";
-import type { Folder, FolderId, ItemId, WorkspaceItem } from "@/entities/workspace";
+import type {
+  Favorite,
+  FavoriteId,
+  Folder,
+  FolderId,
+  ItemId,
+  WorkspaceItem,
+} from "@/entities/workspace";
 
 export interface WorkspaceContextValue {
   folders: Folder[];
   items: WorkspaceItem[];
+  favorites: Favorite[];
   itemsInFolder: (folderId: FolderId) => WorkspaceItem[];
   getItem: (id: ItemId) => WorkspaceItem | undefined;
   getDocument: (id: ItemId) => StudioDocument | undefined;
@@ -14,6 +22,9 @@ export interface WorkspaceContextValue {
   renameItem: (id: ItemId, name: string) => void;
   deleteFolder: (id: FolderId) => void;
   deleteDesign: (id: ItemId) => void;
+  addFavorite: (designId: ItemId, label: string) => void;
+  removeFavorite: (id: FavoriteId) => void;
+  renameFavorite: (id: FavoriteId, label: string) => void;
   updateDocument: (id: ItemId, updater: (prev: StudioDocument) => StudioDocument) => void;
 }
 

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -1,21 +1,32 @@
-import { useState, type MouseEvent } from "react";
+import { useState, type KeyboardEvent, type MouseEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { AddOutlined, DeleteOutline, FolderOutlined } from "hobom-design-system/icons";
+import {
+  AddOutlined,
+  DeleteOutline,
+  EditOutlined,
+  FolderOutlined,
+  PushPin,
+  PushPinOutlined,
+} from "hobom-design-system/icons";
 import { Hb, EditableLabel } from "@/shared/ui";
 import { useWorkspace } from "@/features/workspace";
 import type { FolderId, ItemId } from "@/entities/workspace";
 
-/** 워크스페이스 브라우저 — 좌측 폴더 / 우측 아이템 그리드. 아이템 클릭 시 에디터로 이동. */
+/** 워크스페이스 브라우저 — 좌측 즐겨찾기·폴더 / 우측 아이템 그리드. */
 export default function WorkspacePage() {
   const navigate = useNavigate();
   const {
     folders,
+    favorites,
     itemsInFolder,
     createFolder,
     createDesign,
     renameFolder,
     deleteFolder,
     deleteDesign,
+    addFavorite,
+    removeFavorite,
+    renameFavorite,
   } = useWorkspace();
   const [activeFolderId, setActiveFolderId] = useState<FolderId | undefined>(folders[0]?.id);
 
@@ -61,6 +72,24 @@ export default function WorkspacePage() {
           overflow: "auto",
         }}
       >
+        {favorites.length > 0 && (
+          <>
+            <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600, mb: 0.5 }}>
+              즐겨찾기
+            </Hb.Text>
+            {favorites.map((favorite) => (
+              <FavoriteRow
+                key={favorite.id}
+                label={favorite.label}
+                onOpen={() => openItem(favorite.designId)}
+                onRename={(label) => renameFavorite(favorite.id, label)}
+                onRemove={() => removeFavorite(favorite.id)}
+              />
+            ))}
+            <Hb.Divider sx={{ my: 1 }} />
+          </>
+        )}
+
         <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
           <Hb.Text variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
             폴더
@@ -121,46 +150,189 @@ export default function WorkspacePage() {
           </Hb.Text>
         ) : (
           <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-            {items.map((item) => (
-              <Hb.Card.Root
-                key={item.id}
-                onClick={() => openItem(item.id)}
-                sx={{
-                  width: 200,
-                  p: 1.5,
-                  position: "relative",
-                  cursor: "pointer",
-                  "&:hover": { borderColor: "primary.main" },
-                  "&:hover .card-action": { opacity: 1 },
-                }}
-              >
-                <Hb.Button.Icon
-                  size="small"
-                  className="card-action"
-                  aria-label="디자인 삭제"
-                  onClick={(event) => handleDeleteDesign(event, item.id)}
+            {items.map((item) => {
+              const favorite = favorites.find((entry) => entry.designId === item.id);
+
+              return (
+                <Hb.Card.Root
+                  key={item.id}
+                  onClick={() => openItem(item.id)}
                   sx={{
-                    position: "absolute",
-                    top: 6,
-                    right: 6,
-                    bgcolor: "background.paper",
-                    opacity: 0,
-                    transition: "opacity 0.12s",
-                    "&:hover": { bgcolor: "background.paper" },
+                    width: 200,
+                    p: 1.5,
+                    position: "relative",
+                    cursor: "pointer",
+                    "&:hover": { borderColor: "primary.main" },
+                    "&:hover .card-action": { opacity: 1 },
                   }}
                 >
-                  <DeleteOutline sx={{ fontSize: 16 }} />
-                </Hb.Button.Icon>
+                  <Hb.Button.Icon
+                    size="small"
+                    className="card-action"
+                    aria-label={favorite ? "즐겨찾기 해제" : "즐겨찾기"}
+                    onClick={(event) => {
+                      event.stopPropagation();
 
-                <Hb.Box sx={{ height: 120, bgcolor: "background.default", borderRadius: 1, mb: 1 }} />
-                <Hb.Text variant="body2" sx={{ fontWeight: 600, px: 0.25 }}>
-                  {item.name}
-                </Hb.Text>
-              </Hb.Card.Root>
-            ))}
+                      if (favorite) {
+                        removeFavorite(favorite.id);
+                      } else {
+                        addFavorite(item.id, item.name);
+                      }
+                    }}
+                    sx={{
+                      position: "absolute",
+                      top: 6,
+                      right: 38,
+                      bgcolor: "background.paper",
+                      color: favorite ? "primary.main" : "inherit",
+                      opacity: favorite ? 1 : 0,
+                      transition: "opacity 0.12s",
+                      "&:hover": { bgcolor: "background.paper" },
+                    }}
+                  >
+                    {favorite ? (
+                      <PushPin sx={{ fontSize: 16 }} />
+                    ) : (
+                      <PushPinOutlined sx={{ fontSize: 16 }} />
+                    )}
+                  </Hb.Button.Icon>
+
+                  <Hb.Button.Icon
+                    size="small"
+                    className="card-action"
+                    aria-label="디자인 삭제"
+                    onClick={(event) => handleDeleteDesign(event, item.id)}
+                    sx={{
+                      position: "absolute",
+                      top: 6,
+                      right: 6,
+                      bgcolor: "background.paper",
+                      opacity: 0,
+                      transition: "opacity 0.12s",
+                      "&:hover": { bgcolor: "background.paper" },
+                    }}
+                  >
+                    <DeleteOutline sx={{ fontSize: 16 }} />
+                  </Hb.Button.Icon>
+
+                  <Hb.Box
+                    sx={{ height: 120, bgcolor: "background.default", borderRadius: 1, mb: 1 }}
+                  />
+                  <Hb.Text variant="body2" sx={{ fontWeight: 600, px: 0.25 }}>
+                    {item.name}
+                  </Hb.Text>
+                </Hb.Card.Root>
+              );
+            })}
           </Hb.Box>
         )}
       </Hb.Box>
+    </Hb.Stack>
+  );
+}
+
+interface FavoriteRowProps {
+  label: string;
+  onOpen: () => void;
+  onRename: (label: string) => void;
+  onRemove: () => void;
+}
+
+/** 즐겨찾기 행 — 클릭 시 열기, 연필로 이름변경(클릭-열기와 충돌 방지). */
+function FavoriteRow({ label, onOpen, onRename, onRemove }: FavoriteRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(label);
+
+  const commit = () => {
+    setEditing(false);
+    const next = draft.trim();
+
+    if (next && next !== label) {
+      onRename(next);
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      commit();
+    } else if (event.key === "Escape") {
+      setEditing(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <Hb.InputBase
+        autoFocus
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        sx={{
+          fontSize: 14,
+          px: 1,
+          py: 0.5,
+          borderRadius: 1,
+          border: 1,
+          borderColor: "primary.main",
+        }}
+      />
+    );
+  }
+
+  return (
+    <Hb.Stack
+      direction="row"
+      alignItems="center"
+      gap={1}
+      onClick={onOpen}
+      sx={{
+        px: 1,
+        py: 0.75,
+        borderRadius: 1,
+        cursor: "pointer",
+        "&:hover": { bgcolor: "action.hover" },
+        "&:hover .fav-action": { opacity: 1 },
+      }}
+    >
+      <PushPin sx={{ fontSize: 16, color: "primary.main" }} />
+      <Hb.Text
+        sx={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 14,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </Hb.Text>
+      <Hb.Button.Icon
+        size="small"
+        className="fav-action"
+        aria-label="즐겨찾기 이름변경"
+        onClick={(event) => {
+          event.stopPropagation();
+          setDraft(label);
+          setEditing(true);
+        }}
+        sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
+      >
+        <EditOutlined sx={{ fontSize: 15 }} />
+      </Hb.Button.Icon>
+      <Hb.Button.Icon
+        size="small"
+        className="fav-action"
+        aria-label="즐겨찾기 해제"
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove();
+        }}
+        sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
+      >
+        <DeleteOutline sx={{ fontSize: 15 }} />
+      </Hb.Button.Icon>
     </Hb.Stack>
   );
 }


### PR DESCRIPTION
## 개요
워크스페이스에 **즐겨찾기 섹션**을 추가 — 디자인을 핀하고 **커스텀 라벨(자유 이름변경)**을 붙인다.

## 변경 사항
- `Favorite` 모델(designId + label) + 순수 ops `addFavorite`(중복 방지)/`removeFavorite`/`renameFavorite` + 단위 테스트
- 디자인 삭제·폴더 cascade 삭제 시 관련 즐겨찾기도 함께 정리
- `useWorkspace`: addFavorite/removeFavorite/renameFavorite
- 브라우저 UI:
  - 좌측 사이드바 상단 **즐겨찾기 섹션** — 클릭 시 열기, 연필로 라벨 인라인 변경, 삭제
  - 디자인 카드에 **핀 토글**(즐겨찾기 추가/해제)

## 검증
- 타입체크 통과 / 테스트 12건 통과 / eslint 통과 / knip 통과

## 다음
템플릿 갤러리 → 서버 연동