### PR TITLE
feat: introduce design token layer (primitive/semantic)

### DIFF
--- a/packages/hobom-design-system/src/tokens/index.ts
+++ b/packages/hobom-design-system/src/tokens/index.ts
@@ -1,0 +1,9 @@
+export { primitives } from "./primitives";
+export type { Primitives } from "./primitives";
+export { semantic } from "./semantic";
+export type {
+  SemanticTokens,
+  SemanticIntent,
+  SemanticStatus,
+  ColorScheme,
+} from "./semantic";

--- a/packages/hobom-design-system/src/tokens/primitives.ts
+++ b/packages/hobom-design-system/src/tokens/primitives.ts
@@ -1,0 +1,108 @@
+/**
+ * Primitive tokens — raw atomic values, independent of color scheme.
+ *
+ * These carry no meaning. The "role" of a color is assigned only in the
+ * semantic layer; components never reference primitives directly.
+ *
+ * Source of values: the existing `theme.ts` (as of 2026-07). To guarantee
+ * "zero pixel change", values here must not be altered arbitrarily. Filling
+ * in intermediate scale steps is allowed only as additive, no-visual-change
+ * additions.
+ */
+export const primitives = {
+  color: {
+    /** brand (blue) ramp. 500 is the base color. */
+    brand: {
+      300: "#94baff",
+      400: "#5b93ff",
+      500: "#4680ff",
+      600: "#3a6de0",
+      700: "#2a5bd7",
+    },
+    green: {
+      400: "#34c793",
+      500: "#2ca87f",
+      bgLight: "#e8f5e9",
+      bgDark: "#1a3a2a",
+    },
+    amber: {
+      400: "#f5a623",
+      500: "#e58a00",
+      bgLight: "#fff3e0",
+      bgDark: "#3a2d1a",
+    },
+    red: {
+      500: "#ef4444",
+      600: "#dc2626",
+    },
+    /** secondary family. */
+    indigo: {
+      300: "#8a9bc8",
+      400: "#5b6a98",
+    },
+    /** light-scheme neutral ramp (warm slate). */
+    neutralWarm: {
+      50: "#f0f2f5",
+      200: "#d0d5dd",
+      500: "#4a5568",
+      700: "#2d3748",
+    },
+    /** dark-scheme neutral ramp (cool slate). */
+    slate: {
+      200: "#e2e8f0",
+      400: "#94a3b8",
+      700: "#334155",
+      800: "#1e293b",
+      900: "#111827",
+    },
+    white: "#ffffff",
+    /** side Drawer background (fixed, scheme-independent). */
+    sidebar: "#1d2630",
+  },
+
+  radius: {
+    sm: 6,
+    md: 8,
+  },
+
+  fontFamily: `'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif`,
+  fontSize: {
+    xs: "0.75rem",
+    sm: "0.8125rem",
+    base: "0.875rem",
+    md: "1rem",
+  },
+  fontWeight: {
+    medium: 500,
+    semibold: 600,
+  },
+
+  /** 8px grid. Matches the current MUI default spacing values. */
+  space: {
+    0: 0,
+    1: 4,
+    2: 8,
+    3: 12,
+    4: 16,
+    5: 20,
+    6: 24,
+    8: 32,
+  },
+
+  shadow: {
+    appbar: "0 1px 0 rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
+    drawer: "2px 0 8px rgba(0,0,0,0.15)",
+    elevation1: "0 1px 4px rgba(0,0,0,0.06), 0 2px 12px rgba(0,0,0,0.03)",
+    elevation2: "0 2px 8px rgba(0,0,0,0.08), 0 4px 16px rgba(0,0,0,0.04)",
+    /** primary button hover glow. */
+    brandGlow: "0 4px 12px rgba(70, 128, 255, 0.35)",
+  },
+
+  layout: {
+    drawerWidth: 240,
+    drawerWidthCollapsed: 64,
+    appbarHeight: 56,
+  },
+} as const;
+
+export type Primitives = typeof primitives;

--- a/packages/hobom-design-system/src/tokens/semantic.ts
+++ b/packages/hobom-design-system/src/tokens/semantic.ts
@@ -1,0 +1,93 @@
+import { primitives as p } from "./primitives";
+
+/**
+ * Semantic tokens — the "role" of each color/value. Components reference only
+ * this layer.
+ *
+ * light and dark each point at different primitives. The shape mirrors the MUI
+ * palette losslessly (main/light/dark/contrast) so that the next PR's MUI
+ * bridge can rebuild `createTheme` from these values while keeping pixels
+ * identical.
+ */
+export interface SemanticIntent {
+  main: string;
+  light: string;
+  dark: string;
+  contrast: string;
+}
+
+export interface SemanticStatus {
+  main: string;
+  /** subtle background (chips/badges, etc.). */
+  subtle: string;
+}
+
+export interface SemanticTokens {
+  color: {
+    brand: SemanticIntent;
+    /** secondary. */
+    neutral: { main: string; contrast: string };
+    success: SemanticStatus;
+    warning: SemanticStatus;
+    danger: { main: string };
+    bg: { canvas: string; surface: string; sidebar: string };
+    text: { primary: string; secondary: string; onAccent: string };
+    border: { default: string };
+  };
+}
+
+const light: SemanticTokens = {
+  color: {
+    brand: {
+      main: p.color.brand[500],
+      light: p.color.brand[300],
+      dark: p.color.brand[700],
+      contrast: p.color.white,
+    },
+    neutral: { main: p.color.indigo[400], contrast: p.color.white },
+    success: { main: p.color.green[500], subtle: p.color.green.bgLight },
+    warning: { main: p.color.amber[500], subtle: p.color.amber.bgLight },
+    danger: { main: p.color.red[600] },
+    bg: {
+      canvas: p.color.neutralWarm[50],
+      surface: p.color.white,
+      sidebar: p.color.sidebar,
+    },
+    text: {
+      primary: p.color.neutralWarm[700],
+      secondary: p.color.neutralWarm[500],
+      onAccent: p.color.white,
+    },
+    border: { default: p.color.neutralWarm[200] },
+  },
+};
+
+const dark: SemanticTokens = {
+  color: {
+    brand: {
+      main: p.color.brand[400],
+      light: p.color.brand[300],
+      dark: p.color.brand[600],
+      contrast: p.color.white,
+    },
+    neutral: { main: p.color.indigo[300], contrast: p.color.white },
+    success: { main: p.color.green[400], subtle: p.color.green.bgDark },
+    warning: { main: p.color.amber[400], subtle: p.color.amber.bgDark },
+    danger: { main: p.color.red[500] },
+    bg: {
+      canvas: p.color.slate[900],
+      surface: p.color.slate[800],
+      sidebar: p.color.sidebar,
+    },
+    text: {
+      primary: p.color.slate[200],
+      secondary: p.color.slate[400],
+      onAccent: p.color.white,
+    },
+    border: { default: p.color.slate[700] },
+  },
+};
+
+export const semantic = { light, dark } as const;
+
+export type ColorScheme = keyof typeof semantic;

--- a/packages/hobom-design-system/src/tokens/tokens.spec.ts
+++ b/packages/hobom-design-system/src/tokens/tokens.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { primitives } from "./primitives";
+import { semantic } from "./semantic";
+
+/**
+ * Zero-pixel lock.
+ *
+ * Pins every semantic token to the exact hex currently used in theme.ts, 1:1.
+ * When the next PR refactors theme.ts to consume these tokens, this test
+ * guarantees the rendered output does not change. To change a value in
+ * theme.ts, this test must be updated deliberately first.
+ */
+describe("semantic ↔ theme.ts palette zero-pixel", () => {
+  it("light", () => {
+    const c = semantic.light.color;
+    expect(c.brand.main).toBe("#4680ff");
+    expect(c.brand.light).toBe("#94baff");
+    expect(c.brand.dark).toBe("#2a5bd7");
+    expect(c.brand.contrast).toBe("#ffffff");
+    expect(c.neutral.main).toBe("#5b6a98");
+    expect(c.neutral.contrast).toBe("#ffffff");
+    expect(c.success.main).toBe("#2ca87f");
+    expect(c.success.subtle).toBe("#e8f5e9");
+    expect(c.warning.main).toBe("#e58a00");
+    expect(c.warning.subtle).toBe("#fff3e0");
+    expect(c.danger.main).toBe("#dc2626");
+    expect(c.bg.canvas).toBe("#f0f2f5");
+    expect(c.bg.surface).toBe("#ffffff");
+    expect(c.text.primary).toBe("#2d3748");
+    expect(c.text.secondary).toBe("#4a5568");
+    expect(c.border.default).toBe("#d0d5dd");
+  });
+
+  it("dark", () => {
+    const c = semantic.dark.color;
+    expect(c.brand.main).toBe("#5b93ff");
+    expect(c.brand.light).toBe("#94baff");
+    expect(c.brand.dark).toBe("#3a6de0");
+    expect(c.brand.contrast).toBe("#ffffff");
+    expect(c.neutral.main).toBe("#8a9bc8");
+    expect(c.neutral.contrast).toBe("#ffffff");
+    expect(c.success.main).toBe("#34c793");
+    expect(c.success.subtle).toBe("#1a3a2a");
+    expect(c.warning.main).toBe("#f5a623");
+    expect(c.warning.subtle).toBe("#3a2d1a");
+    expect(c.danger.main).toBe("#ef4444");
+    expect(c.bg.canvas).toBe("#111827");
+    expect(c.bg.surface).toBe("#1e293b");
+    expect(c.text.primary).toBe("#e2e8f0");
+    expect(c.text.secondary).toBe("#94a3b8");
+    expect(c.border.default).toBe("#334155");
+  });
+
+  it("sidebar is fixed across schemes", () => {
+    expect(semantic.light.color.bg.sidebar).toBe("#1d2630");
+    expect(semantic.dark.color.bg.sidebar).toBe("#1d2630");
+  });
+});
+
+describe("primitives non-color zero-pixel", () => {
+  it("radius / shape", () => {
+    expect(primitives.radius.md).toBe(8); // theme.shape.borderRadius, buttons/inputs
+    expect(primitives.radius.sm).toBe(6); // Chip
+  });
+
+  it("typography", () => {
+    expect(primitives.fontFamily).toBe(
+      "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    );
+    expect(primitives.fontSize.md).toBe("1rem"); // h6
+    expect(primitives.fontSize.base).toBe("0.875rem"); // body1/button
+    expect(primitives.fontSize.sm).toBe("0.8125rem"); // body2
+    expect(primitives.fontSize.xs).toBe("0.75rem"); // caption
+    expect(primitives.fontWeight.semibold).toBe(600); // h6
+    expect(primitives.fontWeight.medium).toBe(500); // button/tab/chip
+  });
+
+  it("layout", () => {
+    expect(primitives.layout.drawerWidth).toBe(240);
+    expect(primitives.layout.drawerWidthCollapsed).toBe(64);
+    expect(primitives.layout.appbarHeight).toBe(56);
+  });
+
+  it("shadow strings preserved", () => {
+    expect(primitives.shadow.brandGlow).toBe(
+      "0 4px 12px rgba(70, 128, 255, 0.35)",
+    );
+    expect(primitives.shadow.elevation1).toBe(
+      "0 1px 4px rgba(0,0,0,0.06), 0 2px 12px rgba(0,0,0,0.03)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Extracts the hardcoded colors/values in `theme.ts` into a primitive → semantic token layer, giving components a stable reference point to consume instead of the MUI theme.

## Changes
- `tokens/primitives.ts` — scheme-independent atomic values (color/radius/font/space/shadow/layout)
- `tokens/semantic.ts` — light/dark role mapping. Corresponds losslessly to the MUI palette (main/light/dark/contrast), so wiring the theme later produces no visual change
- `tokens/index.ts` — exports
- `tokens/tokens.spec.ts` — locks semantic values 1:1 to the current theme.ts hex

## Verification
- `vitest run src/tokens` — 7 pass
- `tsc --noEmit` — clean
- No visual change in this PR (token definitions + tests only)

## Follow-up
- Wire `theme.ts` to consume the semantic tokens (verify no visual diff)
- Whether to unify the light/dark neutral ramps is a separate call, since it changes the visuals