### PR TITLE
refactor: isolate the styling/theming type re-exports into one file

### DIFF
--- a/packages/hobom-design-system/src/foundations/styling.ts
+++ b/packages/hobom-design-system/src/foundations/styling.ts
@@ -1,0 +1,15 @@
+/**
+ * Public styling & theming type surface.
+ *
+ * Re-exports the styling/theme types and helpers that consumers still need to
+ * type against directly: the `sx` prop type, the theme object, a theme
+ * factory, a color-scheme hook, and a couple of component type helpers.
+ *
+ * This is the ONLY file in the package that pulls these from the underlying
+ * styling engine, so when the components move to headless primitives the
+ * change stays contained here. Do not re-export the engine anywhere else on
+ * the public surface.
+ */
+export type { SxProps, Theme, SelectChangeEvent, SvgIconProps } from "@mui/material";
+export { createTheme } from "@mui/material";
+export { useColorScheme } from "@mui/material/styles";

--- a/packages/hobom-design-system/src/index.ts
+++ b/packages/hobom-design-system/src/index.ts
@@ -16,13 +16,9 @@ import { SkeletonList } from "./patterns/SkeletonList";
 export const HoBomSkeleton = { Card: SkeletonCard, List: SkeletonList };
 
 export { theme, DRAWER_WIDTH, DRAWER_WIDTH_COLLAPSED, APPBAR_HEIGHT } from "./foundations/theme";
-export { createTheme } from "@mui/material";
 
 export { Hb } from "./components";
 
-// MUI types re-export
-export type { SxProps, Theme, SelectChangeEvent } from "@mui/material";
-export type { SvgIconProps } from "@mui/material";
-
-// MUI hooks re-export
-export { useColorScheme } from "@mui/material/styles";
+// Styling & theming surface (see foundations/styling.ts).
+export { createTheme, useColorScheme } from "./foundations/styling";
+export type { SxProps, Theme, SelectChangeEvent, SvgIconProps } from "./foundations/styling";


### PR DESCRIPTION
## Summary
The design system is already the sole gateway to the underlying styling engine — the consumer app has **no direct engine imports or dependencies**. The only remaining exposure on the public surface was a handful of type/helper re-exports in the barrel.

This moves them into `foundations/styling.ts`, the single file that touches the engine for the public API. The barrel no longer references it at all.

## Why keep them (for now)
`SxProps`/`Theme`/`createTheme` expose the `sx` styling model, which consumers currently depend on (EditableLabel, scrollbar-styles, DashboardPaper, studio-theme, …). Dropping them needs the styling model that arrives with the Radix migration. Until then, `foundations/styling.ts` is the one place that changes when the engine is swapped.

## Changes
- Add `foundations/styling.ts` — the single styling/theming type surface
- Barrel re-exports from it; no engine reference remains outside that file

## Verification
- `pnpm -r typecheck` — all projects clean, incl. the consumer app
- No consumer or behavior change