### PR TITLE
lint: forbid importing the styling engine outside the design system

### DIFF
--- a/apps/hobom-system/eslint.config.js
+++ b/apps/hobom-system/eslint.config.js
@@ -32,5 +32,22 @@ export default tseslint.config(baseIgnores, {
 
     // ── FSD Architecture ──
     "fsd-boundaries/fsd-boundaries": "error",
+
+    // ── Design system boundary ──
+    // The app must consume UI through hobom-design-system, never the
+    // underlying styling engine directly. This keeps product code decoupled
+    // from the engine so it can be swapped without app changes.
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["@mui", "@mui/*", "@emotion", "@emotion/*"],
+            message:
+              "Import from 'hobom-design-system' instead of the styling engine directly.",
+          },
+        ],
+      },
+    ],
   },
 });

--- a/packages/hobom-design-system/eslint.config.js
+++ b/packages/hobom-design-system/eslint.config.js
@@ -22,4 +22,23 @@ export default tseslint.config(baseIgnores, {
     "react-hooks/refs": "off",
     "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
   },
+}, {
+  // The public barrel must stay engine-free. Components may wrap the engine
+  // internally, but the styling/theme surface is re-exported only through
+  // foundations/styling.ts — the single place that touches it publicly.
+  files: ["src/index.ts"],
+  rules: {
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["@mui", "@mui/*"],
+            message:
+              "Keep the public barrel engine-free. Re-export from foundations/styling.ts instead.",
+          },
+        ],
+      },
+    ],
+  },
 });


### PR DESCRIPTION
## Summary
Adds an ESLint boundary so the underlying styling engine stays an internal detail of the design system, locking in a state the codebase already satisfies.

## Rules
- **App** (`apps/hobom-system`): `@mui` / `@emotion` may not be imported directly — UI must come through `hobom-design-system`.
- **Design system**: the public barrel (`src/index.ts`) may not import the engine. Components wrap it internally; the styling/theme surface is re-exported only via `foundations/styling.ts`.

Both use `@typescript-eslint/no-restricted-imports` (catches type-only imports too).

## Verification
- App lints clean: 71 warnings, **0 errors** (unchanged from baseline)
- Design system lints clean: **0 errors**
- Probe imports are correctly rejected:
  - app importing `@mui/material` → error
  - barrel importing `@mui/material/styles` → error

## Why now
The app already has zero direct engine imports. This guardrail prevents the coupling from creeping back before the Radix migration removes the engine entirely.

## Note
- The per-package `eslint` bin shims were stale (hardcoded a since-removed `eslint@9.39.4`); repaired locally to run the linter. This is a node_modules-only fix and not part of this change — worth a clean `pnpm install` on CI/other machines.