### PR TITLE
feat: reimplement Tooltip in-house with no UI engine dependency

### DIFF
--- a/packages/hobom-design-system/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/hobom-design-system/src/components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Tooltip } from "./Tooltip";
+
+describe("Tooltip", () => {
+  it("renders the trigger element", () => {
+    render(
+      <Tooltip title="hello">
+        <button>trigger</button>
+      </Tooltip>,
+    );
+    expect(screen.getByRole("button", { name: "trigger" })).toBeTruthy();
+  });
+
+  it("renders the child directly with no tooltip when title is empty", () => {
+    render(
+      <Tooltip title="">
+        <button>bare</button>
+      </Tooltip>,
+    );
+    expect(screen.getByRole("button", { name: "bare" })).toBeTruthy();
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("opens on hover after the delay and shows the title", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <Tooltip title="details" enterDelay={100}>
+          <button>trigger</button>
+        </Tooltip>,
+      );
+      const button = screen.getByRole("button", { name: "trigger" });
+
+      expect(screen.queryByRole("tooltip")).toBeNull();
+
+      fireEvent.mouseEnter(button);
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      const tooltip = screen.getByRole("tooltip");
+
+      expect(tooltip.textContent).toBe("details");
+
+      fireEvent.mouseLeave(button);
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/hobom-design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/hobom-design-system/src/components/Tooltip/Tooltip.tsx
@@ -1,1 +1,146 @@
-export { Tooltip } from "@mui/material";
+import {
+  cloneElement,
+  useId,
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { createPortal } from "react-dom";
+import { primitives } from "../../foundations/tokens";
+import { toSideAlign, type Placement, type Side } from "./tooltip-position";
+import { useTooltip } from "./useTooltip";
+
+interface TooltipProps {
+  /** Tooltip content. When empty, the child renders with no tooltip. */
+  title: ReactNode;
+  /** Trigger element. Its ref is merged, so it must accept one. */
+  children: ReactElement;
+  /** Preferred side/alignment. Defaults to `"bottom"`. */
+  placement?: Placement;
+  /** Show a small arrow pointing at the trigger. */
+  arrow?: boolean;
+  /** Delay in ms before the tooltip opens. Defaults to `100`. */
+  enterDelay?: number;
+}
+
+// The tooltip is an inverse surface — intentionally dark in both color schemes,
+// so it reads a fixed primitive rather than a scheme-dependent semantic token.
+const SURFACE = primitives.color.slate[800];
+const ARROW = 8;
+
+const contentBaseStyle: CSSProperties = {
+  position: "fixed",
+  backgroundColor: SURFACE,
+  color: primitives.color.white,
+  fontSize: primitives.fontSize.xs,
+  lineHeight: 1.4,
+  padding: `${primitives.space[1]}px ${primitives.space[2]}px`,
+  borderRadius: primitives.radius.sm,
+  boxShadow: primitives.shadow.elevation2,
+  maxWidth: 300,
+  wordBreak: "break-word",
+  userSelect: "none",
+  pointerEvents: "none",
+  zIndex: 1500,
+};
+
+// An 8px square rotated 45°, tucked half-out of the edge opposite the side.
+function arrowStyle(side: Side): CSSProperties {
+  const base: CSSProperties = {
+    position: "absolute",
+    width: ARROW,
+    height: ARROW,
+    backgroundColor: SURFACE,
+    transform: "rotate(45deg)",
+  };
+  const inset = -ARROW / 2;
+  const centered = `calc(50% - ${ARROW / 2}px)`;
+
+  switch (side) {
+    case "top":
+      return { ...base, bottom: inset, left: centered };
+    case "bottom":
+      return { ...base, top: inset, left: centered };
+    case "left":
+      return { ...base, right: inset, top: centered };
+    case "right":
+      return { ...base, left: inset, top: centered };
+  }
+}
+
+type Handler = ((e: unknown) => void) | undefined;
+const compose = (theirs: Handler, ours: () => void) => (e: unknown) => {
+  theirs?.(e);
+  ours();
+};
+
+function setRef(ref: Ref<HTMLElement> | undefined, node: HTMLElement | null) {
+  if (typeof ref === "function") {
+    ref(node);
+
+    return;
+  }
+  const target = ref as { current: HTMLElement | null } | null | undefined;
+
+  if (target) target.current = node;
+}
+
+export const Tooltip = ({
+  title,
+  children,
+  placement = "bottom",
+  arrow = false,
+  enterDelay = 100,
+}: TooltipProps) => {
+  const id = useId();
+  const { side, align } = toSideAlign(placement);
+  const { open, coords, triggerRef, tooltipRef, show, hide } = useTooltip(
+    side,
+    align,
+    arrow ? ARROW : 6,
+    enterDelay,
+  );
+
+  if (title === "" || title == null) {
+    return children;
+  }
+
+  const childProps = children.props as Record<string, unknown> & { ref?: Ref<HTMLElement> };
+
+  const trigger = cloneElement(children as ReactElement<Record<string, unknown>>, {
+    ref: (node: HTMLElement | null) => {
+      triggerRef.current = node;
+      setRef(childProps.ref, node);
+    },
+    onMouseEnter: compose(childProps.onMouseEnter as Handler, show),
+    onMouseLeave: compose(childProps.onMouseLeave as Handler, hide),
+    onFocus: compose(childProps.onFocus as Handler, show),
+    onBlur: compose(childProps.onBlur as Handler, hide),
+    "aria-describedby": open ? id : childProps["aria-describedby"],
+  });
+
+  return (
+    <>
+      {trigger}
+      {open &&
+        createPortal(
+          <div
+            ref={tooltipRef}
+            id={id}
+            role="tooltip"
+            style={{
+              ...contentBaseStyle,
+              top: coords?.top ?? 0,
+              left: coords?.left ?? 0,
+              visibility: coords ? "visible" : "hidden",
+            }}
+          >
+            {title}
+            {arrow && <span style={arrowStyle(side)} />}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+};

--- a/packages/hobom-design-system/src/components/Tooltip/tooltip-position.spec.ts
+++ b/packages/hobom-design-system/src/components/Tooltip/tooltip-position.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { computeAnchorPosition, toSideAlign } from "./tooltip-position";
+
+const trigger = { top: 100, left: 200, width: 40, height: 20 };
+const floating = { width: 80, height: 30 };
+
+describe("toSideAlign", () => {
+  it("maps a bare side to center alignment", () => {
+    expect(toSideAlign("top")).toEqual({ side: "top", align: "center" });
+  });
+  it("splits side-align placements", () => {
+    expect(toSideAlign("bottom-start")).toEqual({ side: "bottom", align: "start" });
+    expect(toSideAlign("right-end")).toEqual({ side: "right", align: "end" });
+  });
+});
+
+describe("computeAnchorPosition", () => {
+  it("places above and horizontally centered on side=top", () => {
+    // top: 100 - 30 - 6 = 64 ; left: 200 + 40/2 - 80/2 = 180
+    expect(computeAnchorPosition(trigger, floating, "top", "center", 6)).toEqual({
+      top: 64,
+      left: 180,
+    });
+  });
+
+  it("places below on side=bottom", () => {
+    // top: 100 + 20 + 6 = 126
+    expect(computeAnchorPosition(trigger, floating, "bottom", "center", 6).top).toBe(126);
+  });
+
+  it("places to the right, vertically centered", () => {
+    // left: 200 + 40 + 6 = 246 ; top: 100 + 20/2 - 30/2 = 95
+    expect(computeAnchorPosition(trigger, floating, "right", "center", 6)).toEqual({
+      top: 95,
+      left: 246,
+    });
+  });
+
+  it("aligns the near edge on align=start", () => {
+    expect(computeAnchorPosition(trigger, floating, "bottom", "start", 6).left).toBe(200);
+  });
+
+  it("aligns the far edge on align=end", () => {
+    // left: 200 + 40 - 80 = 160
+    expect(computeAnchorPosition(trigger, floating, "bottom", "end", 6).left).toBe(160);
+  });
+
+  it("honors the offset on the main axis", () => {
+    expect(computeAnchorPosition(trigger, floating, "top", "center", 12).top).toBe(58);
+  });
+});

--- a/packages/hobom-design-system/src/components/Tooltip/tooltip-position.ts
+++ b/packages/hobom-design-system/src/components/Tooltip/tooltip-position.ts
@@ -1,0 +1,85 @@
+export type Side = "top" | "right" | "bottom" | "left";
+export type Align = "start" | "center" | "end";
+export type Placement =
+  | Side
+  | "top-start"
+  | "top-end"
+  | "bottom-start"
+  | "bottom-end"
+  | "left-start"
+  | "left-end"
+  | "right-start"
+  | "right-end";
+
+export interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+export interface Size {
+  width: number;
+  height: number;
+}
+export interface Coords {
+  top: number;
+  left: number;
+}
+
+function alignOf(part: string | undefined): Align {
+  if (part === "start") return "start";
+  if (part === "end") return "end";
+
+  return "center";
+}
+
+/** Split a `side` or `side-align` placement into its side and alignment. */
+export function toSideAlign(placement: Placement): { side: Side; align: Align } {
+  const [side, part] = placement.split("-") as [Side, string | undefined];
+
+  return { side, align: alignOf(part) };
+}
+
+function crossAxis(start: number, triggerSize: number, floatingSize: number, align: Align): number {
+  if (align === "start") return start;
+  if (align === "end") return start + triggerSize - floatingSize;
+
+  return start + triggerSize / 2 - floatingSize / 2;
+}
+
+/**
+ * Viewport-space coordinates for a floating element anchored to a trigger.
+ * Pure: given the two boxes, a side, an alignment and a gap, it returns where
+ * the floating element's top-left corner goes (for `position: fixed`).
+ */
+export function computeAnchorPosition(
+  trigger: Rect,
+  floating: Size,
+  side: Side,
+  align: Align,
+  offset: number,
+): Coords {
+  let top = 0;
+  let left = 0;
+
+  switch (side) {
+    case "top":
+      top = trigger.top - floating.height - offset;
+      left = crossAxis(trigger.left, trigger.width, floating.width, align);
+      break;
+    case "bottom":
+      top = trigger.top + trigger.height + offset;
+      left = crossAxis(trigger.left, trigger.width, floating.width, align);
+      break;
+    case "left":
+      left = trigger.left - floating.width - offset;
+      top = crossAxis(trigger.top, trigger.height, floating.height, align);
+      break;
+    case "right":
+      left = trigger.left + trigger.width + offset;
+      top = crossAxis(trigger.top, trigger.height, floating.height, align);
+      break;
+  }
+
+  return { top, left };
+}

--- a/packages/hobom-design-system/src/components/Tooltip/useTooltip.ts
+++ b/packages/hobom-design-system/src/components/Tooltip/useTooltip.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { computeAnchorPosition, type Align, type Coords, type Side } from "./tooltip-position";
+
+/**
+ * Tooltip open/close behavior and positioning.
+ *
+ * Owns the delayed open, viewport-space coordinate computation, reposition on
+ * scroll/resize, and Escape-to-close. The component only renders what this
+ * returns.
+ */
+export function useTooltip(side: Side, align: Align, offset: number, enterDelay: number) {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const timer = useRef<number | undefined>(undefined);
+
+  const show = useCallback(() => {
+    window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => setOpen(true), enterDelay);
+  }, [enterDelay]);
+
+  const hide = useCallback(() => {
+    window.clearTimeout(timer.current);
+    setOpen(false);
+    setCoords(null);
+  }, []);
+
+  const reposition = useCallback(() => {
+    const trigger = triggerRef.current;
+    const tooltip = tooltipRef.current;
+
+    if (!trigger || !tooltip) return;
+    const r = trigger.getBoundingClientRect();
+
+    setCoords(
+      computeAnchorPosition(
+        { top: r.top, left: r.left, width: r.width, height: r.height },
+        { width: tooltip.offsetWidth, height: tooltip.offsetHeight },
+        side,
+        align,
+        offset,
+      ),
+    );
+  }, [side, align, offset]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    reposition();
+
+    const onScrollOrResize = () => reposition();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") hide();
+    };
+
+    // capture=true so the tooltip repositions while any ancestor scrolls.
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, reposition, hide]);
+
+  useEffect(() => () => window.clearTimeout(timer.current), []);
+
+  return { open, coords, triggerRef, tooltipRef, show, hide };
+}


### PR DESCRIPTION
## Summary
First component built entirely in-house — no MUI, no third-party UI library. Proves the design system can own a component's behavior, accessibility, and styling end to end, reading straight from the design tokens.

## Structure (house style: pure fn / hook / view)
- `tooltip-position.ts` — pure anchor-position math, unit-tested
- `useTooltip.ts` — open/close with delay, positioning, reposition on scroll/resize, Escape to close
- `Tooltip.tsx` — rendering only: portal + token-styled surface + arrow, merges the trigger ref, wires `aria-describedby`

## Behavior
- Opens on hover/focus after `enterDelay` (default 100ms), closes on leave/blur/Escape
- Portal to `document.body` so it is never clipped by overflow containers (tables, etc.)
- Positioned in viewport space for the 4 sides × start/center/end alignments

## Compatibility
- Public API unchanged (`title` / `children` / `placement` / `arrow` / `enterDelay`)
- Verified by a full monorepo typecheck — every `Hb.Tooltip` call site still compiles
- 11 unit tests (positioning math + open-on-hover behavior)

## Notes
- Dynamic coordinates are inline (runtime-computed); the static surface reads design tokens
- Deferred (follow-up): collision flipping when a side has no room