### PR TITLE
feat: adopt StyleX as the styling engine

### DIFF
--- a/apps/hobom-system/package.json
+++ b/apps/hobom-system/package.json
@@ -38,6 +38,7 @@
     "recharts": "^3.7.0"
   },
   "devDependencies": {
+    "@stylexjs/unplugin": "^0.19.0",
     "@types/node": "^25.5.0",
     "@vitejs/plugin-react-swc": "^4.3.0",
     "msw": "^2.12.10",

--- a/apps/hobom-system/vite.config.ts
+++ b/apps/hobom-system/vite.config.ts
@@ -1,9 +1,19 @@
 import * as path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import stylex from "@stylexjs/unplugin";
 
 export default defineConfig({
-  plugins: [react()],
+  // StyleX must run before react to preserve Fast Refresh. `unstable_moduleResolution`
+  // in ESM mode lets the plugin resolve StyleX vars imported from the workspace
+  // design-system package.
+  plugins: [
+    stylex.vite({
+      useCSSLayers: true,
+      unstable_moduleResolution: { type: "commonJS", rootDir: path.resolve(__dirname, "../..") },
+    }),
+    react(),
+  ],
   optimizeDeps: {
     include: ["date-fns", "zod", "react-hook-form"],
   },

--- a/apps/hobom-system/vitest.config.ts
+++ b/apps/hobom-system/vitest.config.ts
@@ -1,7 +1,16 @@
 import * as path from "path";
 import { defineConfig } from "vitest/config";
+import stylex from "@stylexjs/unplugin";
 
 export default defineConfig({
+  // StyleX must compile design-system source pulled in by tests too, so the
+  // package is inlined (Vite externalizes node_modules by default) and the
+  // plugin runs over it — otherwise `stylex.defineVars` throws at runtime.
+  plugins: [
+    stylex.vite({
+      unstable_moduleResolution: { type: "commonJS", rootDir: path.resolve(__dirname, "../..") },
+    }),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
@@ -10,6 +19,11 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["src/**/*.{spec,test}.{ts,tsx}"],
+    server: {
+      deps: {
+        inline: ["hobom-design-system"],
+      },
+    },
     typecheck: {
       tsconfig: "./tsconfig.spec.json",
     },

--- a/packages/hobom-design-system/package.json
+++ b/packages/hobom-design-system/package.json
@@ -30,9 +30,9 @@
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@mui/x-date-pickers": "^8.11.2",
+    "@stylexjs/stylex": "^0.19.0",
     "hobom-utils": "workspace:*"
   },
-  "devDependencies": {},
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -41,5 +41,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1"
+  },
+  "devDependencies": {
+    "@stylexjs/unplugin": "^0.19.0"
   }
 }

--- a/packages/hobom-design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/hobom-design-system/src/components/Tooltip/Tooltip.tsx
@@ -1,14 +1,8 @@
-import {
-  cloneElement,
-  useId,
-  type CSSProperties,
-  type ReactElement,
-  type ReactNode,
-  type Ref,
-} from "react";
+import { cloneElement, useId, type ReactElement, type ReactNode, type Ref } from "react";
 import { createPortal } from "react-dom";
-import { primitives } from "../../foundations/tokens";
-import { toSideAlign, type Placement, type Side } from "./tooltip-position";
+import * as stylex from "@stylexjs/stylex";
+import { color, font, radius, shadow } from "../../foundations/tokens/tokens.stylex";
+import { toSideAlign, type Placement } from "./tooltip-position";
 import { useTooltip } from "./useTooltip";
 
 interface TooltipProps {
@@ -24,50 +18,44 @@ interface TooltipProps {
   enterDelay?: number;
 }
 
-// The tooltip is an inverse surface — intentionally dark in both color schemes,
-// so it reads a fixed primitive rather than a scheme-dependent semantic token.
-const SURFACE = primitives.color.slate[800];
 const ARROW = 8;
 
-const contentBaseStyle: CSSProperties = {
-  position: "fixed",
-  backgroundColor: SURFACE,
-  color: primitives.color.white,
-  fontSize: primitives.fontSize.xs,
-  lineHeight: 1.4,
-  padding: `${primitives.space[1]}px ${primitives.space[2]}px`,
-  borderRadius: primitives.radius.sm,
-  boxShadow: primitives.shadow.elevation2,
-  maxWidth: 300,
-  wordBreak: "break-word",
-  userSelect: "none",
-  pointerEvents: "none",
-  zIndex: 1500,
-};
-
-// An 8px square rotated 45°, tucked half-out of the edge opposite the side.
-function arrowStyle(side: Side): CSSProperties {
-  const base: CSSProperties = {
+const styles = stylex.create({
+  surface: {
+    position: "fixed",
+    backgroundColor: color.inverseSurface,
+    color: color.onInverse,
+    fontSize: font.xs,
+    lineHeight: 1.4,
+    paddingBlock: 4,
+    paddingInline: 8,
+    borderRadius: radius.sm,
+    boxShadow: shadow.elevation2,
+    maxWidth: 300,
+    wordBreak: "break-word",
+    userSelect: "none",
+    pointerEvents: "none",
+    zIndex: 1500,
+  },
+  arrow: {
     position: "absolute",
-    width: ARROW,
-    height: ARROW,
-    backgroundColor: SURFACE,
+    width: 8,
+    height: 8,
+    backgroundColor: color.inverseSurface,
     transform: "rotate(45deg)",
-  };
-  const inset = -ARROW / 2;
-  const centered = `calc(50% - ${ARROW / 2}px)`;
+  },
+  arrowTop: { bottom: -4, left: "calc(50% - 4px)" },
+  arrowBottom: { top: -4, left: "calc(50% - 4px)" },
+  arrowLeft: { right: -4, top: "calc(50% - 4px)" },
+  arrowRight: { left: -4, top: "calc(50% - 4px)" },
+});
 
-  switch (side) {
-    case "top":
-      return { ...base, bottom: inset, left: centered };
-    case "bottom":
-      return { ...base, top: inset, left: centered };
-    case "left":
-      return { ...base, right: inset, top: centered };
-    case "right":
-      return { ...base, left: inset, top: centered };
-  }
-}
+const arrowSideStyle = {
+  top: styles.arrowTop,
+  bottom: styles.arrowBottom,
+  left: styles.arrowLeft,
+  right: styles.arrowRight,
+} as const;
 
 type Handler = ((e: unknown) => void) | undefined;
 const compose = (theirs: Handler, ours: () => void) => (e: unknown) => {
@@ -120,6 +108,8 @@ export const Tooltip = ({
     "aria-describedby": open ? id : childProps["aria-describedby"],
   });
 
+  const surface = stylex.props(styles.surface);
+
   return (
     <>
       {trigger}
@@ -129,15 +119,16 @@ export const Tooltip = ({
             ref={tooltipRef}
             id={id}
             role="tooltip"
+            className={surface.className}
             style={{
-              ...contentBaseStyle,
+              ...surface.style,
               top: coords?.top ?? 0,
               left: coords?.left ?? 0,
               visibility: coords ? "visible" : "hidden",
             }}
           >
             {title}
-            {arrow && <span style={arrowStyle(side)} />}
+            {arrow && <span {...stylex.props(styles.arrow, arrowSideStyle[side])} />}
           </div>,
           document.body,
         )}

--- a/packages/hobom-design-system/src/foundations/tokens/tokens.stylex.ts
+++ b/packages/hobom-design-system/src/foundations/tokens/tokens.stylex.ts
@@ -1,0 +1,36 @@
+import * as stylex from "@stylexjs/stylex";
+
+/**
+ * StyleX design-token variables — the single source of truth for StyleX-styled
+ * components.
+ *
+ * Values mirror the primitive token objects in `./primitives` for now: while
+ * the MUI-based theme still needs plain-JS values, the same atoms live in both
+ * places. That duplication goes away once every component is on StyleX.
+ *
+ * Only the tokens currently consumed are defined here; grow the set as more
+ * components adopt StyleX. Scheme-dependent (light/dark) tokens are added when
+ * the first scheme-aware component needs them.
+ */
+
+export const color = stylex.defineVars({
+  /** Dark inverse surface for overlays that stay dark in both schemes. */
+  inverseSurface: "#1e293b", // primitives.color.slate[800]
+  /** Foreground on the inverse surface. */
+  onInverse: "#ffffff", // primitives.color.white
+});
+
+export const radius = stylex.defineVars({
+  sm: "6px", // primitives.radius.sm
+  md: "8px", // primitives.radius.md
+});
+
+export const font = stylex.defineVars({
+  xs: "0.75rem", // primitives.fontSize.xs
+  sm: "0.8125rem", // primitives.fontSize.sm
+  base: "0.875rem", // primitives.fontSize.base
+});
+
+export const shadow = stylex.defineVars({
+  elevation2: "0 2px 8px rgba(0,0,0,0.08), 0 4px 16px rgba(0,0,0,0.04)",
+});

--- a/packages/hobom-design-system/vitest.config.ts
+++ b/packages/hobom-design-system/vitest.config.ts
@@ -1,6 +1,15 @@
+import * as path from "path";
 import { defineConfig } from "vitest/config";
+import stylex from "@stylexjs/unplugin";
 
 export default defineConfig({
+  // StyleX must compile in the test environment too — `stylex.defineVars` throws
+  // at runtime otherwise.
+  plugins: [
+    stylex.vite({
+      unstable_moduleResolution: { type: "commonJS", rootDir: path.resolve(__dirname, "../..") },
+    }),
+  ],
   test: {
     globals: true,
     coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
         specifier: ^3.7.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(redux@5.0.1)
     devDependencies:
+      '@stylexjs/unplugin':
+        specifier: ^0.19.0
+        version: 0.19.0(unplugin@2.3.11)
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -171,6 +174,9 @@ importers:
       '@mui/x-date-pickers':
         specifier: ^8.11.2
         version: 8.27.2(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@mui/material@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mui/system@7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
       hobom-data:
         specifier: workspace:*
         version: link:../hobom-data
@@ -186,6 +192,10 @@ importers:
       react-router-dom:
         specifier: ^7.6.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@stylexjs/unplugin':
+        specifier: ^0.19.0
+        version: 0.19.0(unplugin@2.3.11)
 
   packages/hobom-schema: {}
 
@@ -231,6 +241,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -251,6 +265,24 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-syntax-flow@7.29.7':
+    resolution: {integrity: sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -293,6 +325,9 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@dual-bundle/import-meta-resolve@4.2.1':
+    resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -1030,6 +1065,20 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@stylexjs/babel-plugin@0.19.0':
+    resolution: {integrity: sha512-2SnVZIl047TtqKW0nRTn7Irz0kmoot1bxdGDE/HwfwfF7dJYHqwkIFg92s87v3hj7zxJobrHWwDx1p3qvQXW4g==}
+
+  '@stylexjs/shared@0.19.0':
+    resolution: {integrity: sha512-7Yym70cQH5sPzJHgzJX3FkL9ZCptbC3IbiRijN9YLYU/5OywB/3c519Xv1DOzvxqjv8urSxh98/9HxLaPG7sDg==}
+
+  '@stylexjs/stylex@0.19.0':
+    resolution: {integrity: sha512-CnUFp7YMaDLDeemsWOfJgoC/gKM5P/yBNMcpJaE6ChJmXr7s0DJwSeGTTlHJcqqwN9OW1qGtmARWLFhGZN1pTA==}
+
+  '@stylexjs/unplugin@0.19.0':
+    resolution: {integrity: sha512-2QwNYovSwarC/M8DLD78857F6MEi4eQ3UYzgdmyg/K7562M/rV1KWptiATxcKgujlUT6ToNy778SOXf4bGK+Bw==}
+    peerDependencies:
+      unplugin: ^2.3.11
+
   '@stylistic/eslint-plugin@5.10.0':
     resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1698,6 +1747,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-mediaquery@0.1.2:
+    resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2056,6 +2108,9 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -2371,6 +2426,9 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2649,6 +2707,9 @@ packages:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
 
+  styleq@0.2.1:
+    resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
+
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
@@ -2738,6 +2799,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2846,6 +2911,9 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -2990,6 +3058,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -3004,6 +3074,21 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.28.6': {}
 
@@ -3056,6 +3141,8 @@ snapshots:
     dependencies:
       react: 19.2.4
       tslib: 2.8.1
+
+  '@dual-bundle/import-meta-resolve@4.2.1': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -3647,6 +3734,40 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stylexjs/babel-plugin@0.19.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@dual-bundle/import-meta-resolve': 4.2.1
+      '@stylexjs/shared': 0.19.0
+      '@stylexjs/stylex': 0.19.0
+      postcss-value-parser: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@stylexjs/shared@0.19.0': {}
+
+  '@stylexjs/stylex@0.19.0':
+    dependencies:
+      css-mediaquery: 0.1.2
+      invariant: 2.2.4
+      styleq: 0.2.1
+
+  '@stylexjs/unplugin@0.19.0(unplugin@2.3.11)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.0)
+      '@stylexjs/babel-plugin': 0.19.0
+      browserslist: 4.28.1
+      lightningcss: 1.32.0
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - supports-color
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.0.3(jiti@2.6.1))':
     dependencies:
@@ -4323,6 +4444,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-mediaquery@0.1.2: {}
+
   csstype@3.2.3: {}
 
   d3-array@3.2.4:
@@ -4688,6 +4811,10 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
+
   is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
@@ -4988,6 +5115,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.8:
     dependencies:
@@ -5292,6 +5421,8 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  styleq@0.2.1: {}
+
   stylis@4.2.0: {}
 
   supports-color@7.2.0:
@@ -5363,6 +5494,13 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -5467,6 +5605,8 @@ snapshots:
   w3c-keyname@2.2.8: {}
 
   walk-up-path@4.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
 


### PR DESCRIPTION
## Summary
Adopts StyleX as the design system's styling engine (the stack Astryx itself uses). Wires it into the build/test pipeline, expresses design tokens as StyleX vars, and restyles Tooltip — the first in-house component — to read those tokens.

## Changes
- **Build wiring**: `@stylexjs/unplugin` in the app Vite config (before react, to preserve Fast Refresh) and in the DS vitest config (`defineVars` throws unless compiled)
- **Tokens**: `foundations/tokens/tokens.stylex.ts` — token vars grouped by category. Values mirror the primitive tokens for now (see transition note)
- **Tooltip**: static surface + arrow styled via `stylex.create`; dynamic coordinates stay inline

## Verification
- App build emits StyleX atomic CSS from the DS workspace source (`#1e293b`, `@layer`) — proves the monorepo compilation works
- `pnpm -r typecheck` clean; DS suite 33 tests pass; DS lint clean on the new files

## Deliberate scope
- **Scheme-dependent tokens + dark-mode switching deferred.** StyleX themes dark via a class while the app currently toggles `data-mui-color-scheme`; rewiring that is a focused follow-up. These tokens are scheme-independent (covers the tooltip). Scheme-aware compilation was already proven in the spike.
- **Transitional token duplication**: while MUI's theme still needs plain-JS values, the same atoms live in both `primitives.ts` and `tokens.stylex.ts`. This resolves once every component is on StyleX; the StyleX set is kept minimal (only what's used).

## Known friction
- vitest hangs ~10s on close with the StyleX plugin (times out, non-fatal). To be tidied in a follow-up.