### PR TITLE
feat: reimplement Divider in-house on StyleX + scheme tokens

### DIFF
--- a/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
@@ -14,7 +14,12 @@ export const IssueChildrenSection = () => {
 
   return (
     <>
-      <Hb.Divider sx={{ my: 2 }} />
+      <Hb.Divider
+        style={{
+          marginTop: 16,
+          marginBottom: 16,
+        }}
+      />
       <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
         <Hb.Text variant="subtitle2" fontWeight={600} sx={{ fontSize: 13 }}>
           하위 이슈 ({childIssues.length})

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueCommentsSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueCommentsSection.tsx
@@ -49,13 +49,16 @@ export const IssueCommentsSection = () => {
 
   return (
     <>
-      <Hb.Divider sx={{ my: 2 }} />
+      <Hb.Divider
+        style={{
+          marginTop: 16,
+          marginBottom: 16,
+        }}
+      />
       <Hb.Text variant="subtitle2" fontWeight={600} sx={{ mb: 1.5, fontSize: 13 }}>
         댓글 {comments.length > 0 && `(${comments.length})`}
       </Hb.Text>
-
       <IssueCommentInput onSubmit={handleCreate} loading={createComment.isPending} />
-
       {comments.length > 0 && (
         <Hb.Box sx={{ mt: 1 }}>
           {comments.map((comment) => (

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -73,13 +73,21 @@ export const IssueDetailDialog = ({
                 <Hb.Text variant="h6" fontWeight={700} sx={{ mb: 2 }}>
                   {issue.title}
                 </Hb.Text>
-                <Hb.Divider sx={{ mb: 2 }} />
+                <Hb.Divider
+                  style={{
+                    marginBottom: 16,
+                  }}
+                />
 
                 <IssueMetaSection />
 
                 {issue.description && (
                   <>
-                    <Hb.Divider sx={{ mb: 2 }} />
+                    <Hb.Divider
+                      style={{
+                        marginBottom: 16,
+                      }}
+                    />
                     <Hb.Text variant="subtitle2" fontWeight={600} sx={{ mb: 1, fontSize: 13 }}>
                       설명
                     </Hb.Text>
@@ -103,7 +111,6 @@ export const IssueDetailDialog = ({
           </IssueDetailContext.Provider>
         )}
       </Hb.Dialog.Root>
-
       {/* Status Menu */}
       <Hb.Menu.Root
         anchorEl={actions.statusMenu.anchor?.el}
@@ -134,7 +141,6 @@ export const IssueDetailDialog = ({
           </Hb.Menu.Item>
         ))}
       </Hb.Menu.Root>
-
       {/* Priority Menu */}
       <Hb.Menu.Root
         anchorEl={actions.priorityMenu.anchor}
@@ -166,7 +172,6 @@ export const IssueDetailDialog = ({
           </Hb.Menu.Item>
         ))}
       </Hb.Menu.Root>
-
       {/* Assignee Menu */}
       <Hb.Menu.Root
         anchorEl={actions.assigneeMenu.anchor}

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
@@ -140,7 +140,11 @@ export const LawDiffViewer = ({ diffId }: Props) => {
           variant="outlined"
         />
       </Hb.Stack>
-      <Hb.Divider sx={{ mb: 2 }} />
+      <Hb.Divider
+        style={{
+          marginBottom: 16,
+        }}
+      />
       <Hb.Stack spacing={2}>
         {diff.changes.map((change, i) => (
           <ChangeCard key={`${change.articleNo}-${i}`} change={change} />

--- a/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
@@ -22,11 +22,14 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
           {material.summary}
         </Hb.Text>
       </Hb.Paper>
-
       <Hb.Text variant="h6" gutterBottom>
         핵심 포인트
       </Hb.Text>
-      <Hb.Divider sx={{ mb: 1 }} />
+      <Hb.Divider
+        style={{
+          marginBottom: 8,
+        }}
+      />
       <Hb.List.Root disablePadding>
         {material.keyPoints.map((point, i) => (
           <Hb.List.Item key={i} disableGutters>
@@ -39,7 +42,6 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
           </Hb.List.Item>
         ))}
       </Hb.List.Root>
-
       {material.quizzes.length > 0 && (
         <Hb.Stack direction="row" alignItems="center" spacing={1} mt={3}>
           <CheckCircleOutline color="primary" fontSize="small" />

--- a/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
@@ -21,9 +21,12 @@ export const ProjectDashboardContent = () => {
         이슈 개요
       </Hb.Text>
       <IssueDashboardSection data={issueData.items} />
-
-      <Hb.Divider sx={{ my: 3 }} />
-
+      <Hb.Divider
+        style={{
+          marginTop: 24,
+          marginBottom: 24,
+        }}
+      />
       <Hb.Box
         sx={{
           display: "flex",
@@ -50,7 +53,6 @@ export const ProjectDashboardContent = () => {
           </Hb.Form.Select>
         </Hb.Form.Control>
       </Hb.Box>
-
       {selectedSprintId ? (
         <SprintDashboardSection projectId={projectId} sprintId={selectedSprintId} />
       ) : (

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
@@ -137,7 +137,14 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
           </Hb.Tooltip>
         ))}
 
-        <Hb.Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+        <Hb.Divider
+          orientation="vertical"
+          flexItem
+          style={{
+            marginLeft: 4,
+            marginRight: 4,
+          }}
+        />
 
         {headingItems.map((item) => (
           <Hb.Tooltip key={item.label} title={`제목 ${item.label}`}>
@@ -158,7 +165,14 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
           </Hb.Tooltip>
         ))}
 
-        <Hb.Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+        <Hb.Divider
+          orientation="vertical"
+          flexItem
+          style={{
+            marginLeft: 4,
+            marginRight: 4,
+          }}
+        />
 
         {blockItems.map((item) => (
           <Hb.Tooltip key={item.label} title={item.label}>
@@ -173,7 +187,14 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
           </Hb.Tooltip>
         ))}
 
-        <Hb.Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+        <Hb.Divider
+          orientation="vertical"
+          flexItem
+          style={{
+            marginLeft: 4,
+            marginRight: 4,
+          }}
+        />
 
         <Hb.Tooltip title="링크 추가">
           <Hb.Button.Icon
@@ -199,7 +220,6 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
           </Hb.Tooltip>
         )}
       </Hb.Box>
-
       <Hb.Dialog.Root open={linkDialogOpen} onClose={() => setLinkDialogOpen(false)} size="xs">
         <Hb.Dialog.Title>링크 추가</Hb.Dialog.Title>
         <Hb.Dialog.Content>

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -86,7 +86,12 @@ export default function WorkspacePage() {
                 onRemove={() => removeFavorite(favorite.id)}
               />
             ))}
-            <Hb.Divider sx={{ my: 1 }} />
+            <Hb.Divider
+              style={{
+                marginTop: 8,
+                marginBottom: 8,
+              }}
+            />
           </>
         )}
 
@@ -135,7 +140,6 @@ export default function WorkspacePage() {
           </Hb.Stack>
         ))}
       </Hb.Stack>
-
       <Hb.Box sx={{ flex: 1, minWidth: 0, p: 3, overflow: "auto" }}>
         <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
           <Hb.Text variant="h6">{activeFolder?.name ?? "워크스페이스"}</Hb.Text>

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -29,12 +29,7 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
 
   return (
     <Hb.Box sx={{ p: 1.5 }}>
-      <Hb.Stack
-        direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ mb: 1.5 }}
-      >
+      <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
         <Hb.Text sx={{ fontSize: 13, fontWeight: 600 }}>{node.type}</Hb.Text>
         <Hb.Button.Icon
           size="small"
@@ -45,11 +40,8 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
           <DeleteOutline sx={{ fontSize: 16 }} />
         </Hb.Button.Icon>
       </Hb.Stack>
-
       {!manifest ? (
-        <Hb.Text sx={{ fontSize: 12, color: "error.main" }}>
-          미등록 컴포넌트: {node.type}
-        </Hb.Text>
+        <Hb.Text sx={{ fontSize: 12, color: "error.main" }}>미등록 컴포넌트: {node.type}</Hb.Text>
       ) : (
         <Hb.Stack gap={1.25}>
           {Object.entries(manifest.props).map(([name, spec]) => (
@@ -63,9 +55,12 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
           ))}
         </Hb.Stack>
       )}
-
-      <Hb.Divider sx={{ my: 1.5 }} />
-
+      <Hb.Divider
+        style={{
+          marginTop: 12,
+          marginBottom: 12,
+        }}
+      />
       <Hb.Text
         sx={{
           fontSize: 11,
@@ -79,7 +74,11 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
         사이징
       </Hb.Text>
       <Hb.Stack gap={1.25}>
-        <SizeField label="W" value={node.style?.width} onChange={(v) => onStyleChange("width", v)} />
+        <SizeField
+          label="W"
+          value={node.style?.width}
+          onChange={(v) => onStyleChange("width", v)}
+        />
         <SizeField
           label="H"
           value={node.style?.height}

--- a/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
+++ b/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
@@ -142,7 +142,11 @@ export const ProjectLayout = () => {
           )}
         </Hb.Box>
 
-        <Hb.Divider sx={{ mb: 2.5 }} />
+        <Hb.Divider
+          style={{
+            marginBottom: 20,
+          }}
+        />
 
         <Outlet
           context={{

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
@@ -148,11 +148,17 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
           </Hb.Box>
         </Hb.Box>
 
-        <Hb.Divider sx={{ mx: 3.5, my: 1.5 }} />
+        <Hb.Divider
+          style={{
+            marginLeft: 28,
+            marginRight: 28,
+            marginTop: 12,
+            marginBottom: 12,
+          }}
+        />
 
         <PageViewer content={page.content} />
       </Hb.Paper>
-
       <Hb.Paper
         elevation={0}
         sx={{
@@ -172,7 +178,6 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
           <CommentsSection spaceKey={spaceKey} pageId={pageId} userInfo={userInfo} />
         </Suspense>
       </Hb.Paper>
-
       <VersionHistoryDrawer
         open={versionDrawerOpen}
         onClose={() => setVersionDrawerOpen(false)}
@@ -196,7 +201,6 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
           </Hb.Button>
         </Hb.Dialog.Actions>
       </Hb.Dialog.Root>
-
       <MovePageDialog
         open={moveDialogOpen}
         onClose={() => setMoveDialogOpen(false)}
@@ -205,7 +209,6 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
         currentSpaceKey={spaceKey}
         currentPageId={pageId}
       />
-
       <CopyPageDialog
         open={copyDialogOpen}
         onClose={() => setCopyDialogOpen(false)}

--- a/apps/hobom-system/src/widgets/wiki-space-layout/ui/WikiSpaceLayout.tsx
+++ b/apps/hobom-system/src/widgets/wiki-space-layout/ui/WikiSpaceLayout.tsx
@@ -170,7 +170,6 @@ export const WikiSpaceLayout = () => {
           {space.name}
         </Hb.Text>
       </Hb.Box>
-
       <Hb.Box
         sx={{
           display: "flex",
@@ -184,9 +183,11 @@ export const WikiSpaceLayout = () => {
         </Hb.Text>
         <WikiSearchField spaceKey={spaceKey} />
       </Hb.Box>
-
-      <Hb.Divider sx={{ mb: 0 }} />
-
+      <Hb.Divider
+        style={{
+          marginBottom: 0,
+        }}
+      />
       <Hb.Box sx={{ display: "flex", minHeight: "calc(100vh - 200px)" }}>
         <Hb.Box
           sx={{
@@ -270,7 +271,6 @@ export const WikiSpaceLayout = () => {
           <Outlet context={{ spaceKey }} />
         </Hb.Box>
       </Hb.Box>
-
       <CreatePageDialog
         open={createDialog.open}
         onClose={handleCloseDialog}
@@ -278,7 +278,6 @@ export const WikiSpaceLayout = () => {
         loading={isCreating}
         parentTitle={createDialog.parentTitle}
       />
-
       <TrashDrawer
         open={trashDrawerOpen}
         onClose={() => setTrashDrawerOpen(false)}

--- a/packages/hobom-design-system/src/components/Divider/Divider.stories.tsx
+++ b/packages/hobom-design-system/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,31 @@
+import { Divider } from "./Divider";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Divider",
+  component: Divider,
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  render: () => (
+    <div style={{ width: 220 }}>
+      <div>Above</div>
+      <Divider style={{ marginTop: 12, marginBottom: 12 }} />
+      <div>Below</div>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", height: 40, gap: 12 }}>
+      <span>Left</span>
+      <Divider orientation="vertical" flexItem />
+      <span>Right</span>
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Divider/Divider.tsx
+++ b/packages/hobom-design-system/src/components/Divider/Divider.tsx
@@ -1,1 +1,46 @@
-export { Divider } from "@mui/material";
+import type { CSSProperties } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { scheme } from "../../foundations/tokens/theme.stylex";
+
+interface DividerProps {
+  /** Line direction. Defaults to `"horizontal"`. */
+  orientation?: "horizontal" | "vertical";
+  /** For a vertical divider inside a flex row, stretch to the row's height. */
+  flexItem?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const styles = stylex.create({
+  base: {
+    border: "none",
+    backgroundColor: scheme.border,
+    flexShrink: 0,
+  },
+  horizontal: { width: "100%", height: 1 },
+  vertical: { width: 1, height: "100%" },
+  flexItem: { alignSelf: "stretch", height: "auto" },
+});
+
+export const Divider = ({
+  orientation = "horizontal",
+  flexItem = false,
+  className,
+  style,
+}: DividerProps) => {
+  const isVertical = orientation === "vertical";
+  const sx = stylex.props(
+    styles.base,
+    isVertical ? styles.vertical : styles.horizontal,
+    flexItem && styles.flexItem,
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      className={[sx.className, className].filter(Boolean).join(" ")}
+      style={{ ...sx.style, ...style }}
+    />
+  );
+};

--- a/scripts/codemods/divider-sx-to-style.cjs
+++ b/scripts/codemods/divider-sx-to-style.cjs
@@ -1,0 +1,70 @@
+/**
+ * Codemod: convert MUI spacing `sx` shorthands on <Hb.Divider> to `style`.
+ *
+ * Only handles margin shorthands with numeric values (m/mt/mb/ml/mr/mx/my),
+ * expanded at MUI's default 8px spacing unit. A tag whose `sx` has any other
+ * key (or a non-numeric value) is left untouched so it can be handled by hand.
+ *
+ *   pnpm dlx jscodeshift -t scripts/codemods/divider-sx-to-style.cjs \
+ *     --parser tsx --extensions tsx apps/hobom-system/src
+ *
+ * Reusable for other components: change COMPONENT below.
+ */
+const SPACING = {
+  m: ["margin"],
+  mt: ["marginTop"],
+  mb: ["marginBottom"],
+  ml: ["marginLeft"],
+  mr: ["marginRight"],
+  mx: ["marginLeft", "marginRight"],
+  my: ["marginTop", "marginBottom"],
+};
+const UNIT = 8;
+const COMPONENT = { object: "Hb", property: "Divider" };
+
+module.exports = function transformer(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let changed = false;
+
+  root
+    .find(j.JSXOpeningElement)
+    .filter((p) => {
+      const n = p.node.name;
+      return (
+        n.type === "JSXMemberExpression" &&
+        n.object.type === "JSXIdentifier" &&
+        n.object.name === COMPONENT.object &&
+        n.property.name === COMPONENT.property
+      );
+    })
+    .forEach((p) => {
+      const attrs = p.node.attributes || [];
+      const sxAttr = attrs.find((a) => a.type === "JSXAttribute" && a.name.name === "sx");
+      if (!sxAttr || !sxAttr.value || sxAttr.value.type !== "JSXExpressionContainer") return;
+
+      const obj = sxAttr.value.expression;
+      if (obj.type !== "ObjectExpression") return;
+
+      const styleProps = [];
+      for (const prop of obj.properties) {
+        if (prop.type !== "ObjectProperty" && prop.type !== "Property") return;
+        const key = prop.key.name != null ? prop.key.name : prop.key.value;
+        const targets = SPACING[key];
+        if (!targets || prop.value.type !== "NumericLiteral") return;
+        for (const target of targets) {
+          styleProps.push(j.objectProperty(j.identifier(target), j.numericLiteral(prop.value.value * UNIT)));
+        }
+      }
+      if (styleProps.length === 0) return;
+
+      const styleAttr = j.jsxAttribute(
+        j.jsxIdentifier("style"),
+        j.jsxExpressionContainer(j.objectExpression(styleProps)),
+      );
+      attrs.splice(attrs.indexOf(sxAttr), 1, styleAttr);
+      changed = true;
+    });
+
+  return changed ? root.toSource({ quote: "double" }) : null;
+};


### PR DESCRIPTION
## Summary
First MUI passthrough migrated to a fully in-house component. Divider is now a token-styled separator whose color comes from the scheme-dependent `border` var, so it flips in dark mode — the first real component to consume the dark-mode wiring.

## Component
- `role="separator"` + `aria-orientation`, styled with StyleX
- Props: `orientation` (`horizontal`/`vertical`), `flexItem`, plus `style`/`className` passthrough
- No MUI, no `sx`

## Codemod
Consumers styled the divider only with margin `sx` shorthands (`mb`, `mx`, `my`, …). A reusable codemod converts them to `style`, expanding MUI's 8px spacing:

```
scripts/codemods/divider-sx-to-style.cjs
<Hb.Divider sx={{ my: 2 }} />  →  <Hb.Divider style={{ marginTop: 16, marginBottom: 16 }} />
```

Applied across 12 files; a tag with any non-margin `sx` key is left untouched.

## Verification
- `pnpm test:coverage` (full monorepo) passes — no `Hb.Divider` prop breakage (typecheck enforces the contract at every call site)
- Divider stories run as browser a11y tests (`role=separator` passes axe), previewable in light/dark via the Scheme toolbar

## Pattern established
This is the template for migrating the remaining passthroughs: in-house on StyleX + scheme tokens, with a codemod handling the consumer `sx`. Next candidates: Paper, Badge, then the positioning family (Popover → Menu).