### PR TITLE
feat: reimplement Paper in-house with a general sx->style codemod

### DIFF
--- a/apps/hobom-system/src/entities/dashboard/ui/DashboardPaper.tsx
+++ b/apps/hobom-system/src/entities/dashboard/ui/DashboardPaper.tsx
@@ -1,22 +1,13 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { Hb } from "@/shared/ui";
-import type { SxProps, Theme } from "@/shared/ui";
 
 interface Props {
   children: ReactNode;
-  sx?: SxProps<Theme>;
+  style?: CSSProperties;
 }
 
-export const DashboardPaper = ({ children, sx }: Props) => (
-  <Hb.Paper
-    elevation={0}
-    sx={{
-      p: 2.5,
-      border: "1px solid",
-      borderColor: "divider",
-      ...sx,
-    }}
-  >
+export const DashboardPaper = ({ children, style }: Props) => (
+  <Hb.Paper variant="outlined" style={{ padding: 20, ...style }}>
     {children}
   </Hb.Paper>
 );

--- a/apps/hobom-system/src/entities/dashboard/ui/KpiCard.tsx
+++ b/apps/hobom-system/src/entities/dashboard/ui/KpiCard.tsx
@@ -13,7 +13,7 @@ interface KpiCardProps {
 
 export const KpiCard = ({ label, value, suffix, trend, icon }: KpiCardProps) => {
   return (
-    <DashboardPaper sx={{ height: "100%" }}>
+    <DashboardPaper style={{ height: "100%" }}>
       <Hb.Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
         <Hb.Text variant="body2" color="text.secondary">
           {label}

--- a/apps/hobom-system/src/features/backlog-board/ui/BacklogBoard.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/BacklogBoard.tsx
@@ -47,7 +47,13 @@ export const BacklogBoard = ({
           <SprintSection key={sprint.id} sprint={sprint} issues={issues} />
         ))}
 
-        <Hb.Paper variant="outlined" sx={{ borderRadius: 2.5, overflow: "hidden" }}>
+        <Hb.Paper
+          variant="outlined"
+          style={{
+            borderRadius: 20,
+            overflow: "hidden",
+          }}
+        >
           <Hb.Box
             sx={{
               display: "flex",

--- a/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
@@ -23,10 +23,10 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
   return (
     <Hb.Paper
       variant="outlined"
-      sx={{
-        borderRadius: 2.5,
+      style={{
+        borderRadius: 20,
         overflow: "hidden",
-        borderColor: sprint.status === "ACTIVE" ? "#4680ff40" : "divider",
+        borderColor: sprint.status === "ACTIVE" ? "#4680ff40" : "var(--hb-color-border)",
       }}
     >
       <Hb.Box

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogDashboardContent.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogDashboardContent.tsx
@@ -95,12 +95,12 @@ export const LogDashboardContent = ({ period }: LogDashboardContentProps) => {
       </Hb.Grid>
 
       <Hb.Grid size={{ xs: 12, md: 7 }}>
-        <DashboardPaper sx={{ height: "100%" }}>
+        <DashboardPaper style={{ height: "100%" }}>
           <EndpointErrorTable data={endpointData.items} />
         </DashboardPaper>
       </Hb.Grid>
       <Hb.Grid size={{ xs: 12, md: 5 }}>
-        <DashboardPaper sx={{ height: "100%" }}>
+        <DashboardPaper style={{ height: "100%" }}>
           <StatusCodeChart data={statusData.items} />
         </DashboardPaper>
       </Hb.Grid>

--- a/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
+++ b/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
@@ -56,16 +56,16 @@ export const PendingUsersTable = () => {
           />
         </Hb.Stack>
       </Hb.Stack>
-
       {users.length === 0 ? (
         <Hb.Paper
           variant="outlined"
-          sx={{
-            py: 8,
+          style={{
+            paddingTop: 64,
+            paddingBottom: 64,
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
-            gap: 1.5,
+            gap: 12,
             borderStyle: "dashed",
           }}
         >

--- a/apps/hobom-system/src/features/note/ui/NoteCreateBar.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteCreateBar.tsx
@@ -1,33 +1,35 @@
 import { CheckBoxOutlined, BrushOutlined } from "hobom-design-system/icons";
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
 
 interface NoteCreateBarProps {
   onClick: () => void;
 }
 
+const styles = stylex.create({
+  bar: {
+    display: "flex",
+    alignItems: "center",
+    paddingInline: 16,
+    paddingBlock: 10,
+    maxWidth: 600,
+    marginInline: "auto",
+    marginBottom: 32,
+    cursor: "text",
+    borderRadius: 16,
+    backgroundColor: "var(--hb-color-surface)",
+    border: "1px solid #e0e0e0",
+    transition: "box-shadow 0.08s linear",
+    boxShadow: {
+      default: "0 1px 2px 0 rgba(60,64,67,.3), 0 1px 3px 1px rgba(60,64,67,.15)",
+      ":hover": "0 1px 2px 0 rgba(60,64,67,.3), 0 2px 6px 2px rgba(60,64,67,.15)",
+    },
+  },
+});
+
 export const NoteCreateBar = ({ onClick }: NoteCreateBarProps) => {
   return (
-    <Hb.Paper
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        px: 2,
-        py: 1.25,
-        maxWidth: 600,
-        mx: "auto",
-        mb: 4,
-        cursor: "text",
-        borderRadius: 2,
-        border: "1px solid #e0e0e0",
-        boxShadow: "0 1px 2px 0 rgba(60,64,67,.3), 0 1px 3px 1px rgba(60,64,67,.15)",
-        transition: "box-shadow 0.08s linear",
-        "&:hover": {
-          boxShadow: "0 1px 2px 0 rgba(60,64,67,.3), 0 2px 6px 2px rgba(60,64,67,.15)",
-        },
-      }}
-      onClick={onClick}
-      elevation={0}
-    >
+    <div {...stylex.props(styles.bar)} onClick={onClick}>
       <Hb.Text
         sx={{
           flex: 1,
@@ -61,6 +63,6 @@ export const NoteCreateBar = ({ onClick }: NoteCreateBarProps) => {
           </Hb.Button.Icon>
         </Hb.Tooltip>
       </Hb.Box>
-    </Hb.Paper>
+    </div>
   );
 };

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -8,7 +8,7 @@ import {
   AddOutlined,
   CloseOutlined,
 } from "hobom-design-system/icons";
-import type { NoteItemType } from "@/entities/note";
+import { NOTE_COLORS, type NoteItemType } from "@/entities/note";
 import { Hb } from "@/shared/ui";
 import { useNoteEditForm } from "../model/useNoteEditForm";
 import { useNoteMemberShare } from "../model/useNoteMemberShare";
@@ -66,7 +66,11 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
       onClose={handleSave}
       size="sm"
       PaperProps={{
-        sx: { backgroundColor: form.color, borderRadius: 2 },
+        sx: {
+          backgroundColor:
+            form.color === NOTE_COLORS.DEFAULT ? "var(--hb-color-surface)" : form.color,
+          borderRadius: 2,
+        },
       }}
     >
       <Hb.Dialog.Content sx={{ pb: 1 }}>

--- a/apps/hobom-system/src/features/pick-menu/ui/PickMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/PickMenuContent.tsx
@@ -126,11 +126,13 @@ const Inner = ({ onNextCallback }: Props) => {
 PickMenuContent.Layout = ({ children }: { children: ReactNode }) => (
   <Hb.Paper
     elevation={0}
-    sx={{
+    style={{
       flexGrow: 1,
       overflowY: "auto",
-      px: 3,
-      py: 1,
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingTop: 8,
+      paddingBottom: 8,
     }}
   >
     {children}

--- a/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
@@ -98,11 +98,13 @@ const Inner = () => {
 SelectedMenuContent.Layout = ({ children }: { children: ReactNode }) => (
   <Hb.Paper
     elevation={0}
-    sx={{
+    style={{
       flexGrow: 1,
       overflowY: "auto",
-      px: 3,
-      py: 1,
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingTop: 8,
+      paddingBottom: 8,
     }}
   >
     {children}

--- a/apps/hobom-system/src/features/privacy-law-chat/ui/ChatMessageList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-chat/ui/ChatMessageList.tsx
@@ -57,13 +57,14 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
           </Hb.Avatar>
           <Hb.Paper
             elevation={0}
-            sx={{
-              p: 2,
+            style={{
+              padding: 16,
               maxWidth: "70%",
-              bgcolor: msg.role === "user" ? "primary.50" : "background.paper",
-              border: 1,
-              borderColor: msg.role === "user" ? "primary.200" : "divider",
-              borderRadius: 2,
+              backgroundColor: msg.role === "user" ? "#eef3ff" : "var(--hb-color-surface)",
+              borderWidth: 1,
+              borderStyle: "solid",
+              borderColor: msg.role === "user" ? "#94baff" : "var(--hb-color-border)",
+              borderRadius: 16,
             }}
           >
             <Hb.Text variant="body2" sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
@@ -75,7 +76,6 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
           </Hb.Paper>
         </Hb.Stack>
       ))}
-
       {isPending && (
         <Hb.Stack direction="row" spacing={1.5} alignItems="flex-start">
           <Hb.Avatar sx={{ width: 32, height: 32, bgcolor: "grey.700" }}>
@@ -83,11 +83,12 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
           </Hb.Avatar>
           <Hb.Paper
             elevation={0}
-            sx={{
-              p: 2,
-              border: 1,
-              borderColor: "divider",
-              borderRadius: 2,
+            style={{
+              padding: 16,
+              borderWidth: 1,
+              borderStyle: "solid",
+              borderColor: "var(--hb-color-border)",
+              borderRadius: 16,
             }}
           >
             <Hb.Stack direction="row" spacing={1} alignItems="center">
@@ -99,7 +100,6 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
           </Hb.Paper>
         </Hb.Stack>
       )}
-
       <div ref={bottomRef} />
     </Hb.Stack>
   );

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
@@ -38,7 +38,12 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
   const config = CHANGE_CONFIG[change.changeType];
 
   return (
-    <Hb.Paper variant="outlined" sx={{ p: 2 }}>
+    <Hb.Paper
+      variant="outlined"
+      style={{
+        padding: 16,
+      }}
+    >
       <Hb.Stack direction="row" alignItems="center" spacing={1} mb={1.5}>
         <Hb.Chip label={change.articleNo} size="small" color="primary" sx={{ fontWeight: 600 }} />
         <Hb.Chip
@@ -49,7 +54,6 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
           variant="outlined"
         />
       </Hb.Stack>
-
       {change.changeType === "MODIFIED" && (
         <Hb.Stack spacing={1}>
           <Hb.Box
@@ -86,7 +90,6 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
           </Hb.Box>
         </Hb.Stack>
       )}
-
       {change.changeType === "ADDED" && change.after && (
         <Hb.Box
           sx={{
@@ -102,7 +105,6 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
           </Hb.Text>
         </Hb.Box>
       )}
-
       {change.changeType === "DELETED" && change.before && (
         <Hb.Box
           sx={{

--- a/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
@@ -13,7 +13,13 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
 
   return (
     <Hb.Box>
-      <Hb.Paper variant="outlined" sx={{ p: 3, mb: 3 }}>
+      <Hb.Paper
+        variant="outlined"
+        style={{
+          padding: 24,
+          marginBottom: 24,
+        }}
+      >
         <Hb.Stack direction="row" alignItems="center" spacing={1} mb={2}>
           <LightbulbOutlined color="warning" />
           <Hb.Text variant="h6">요약</Hb.Text>

--- a/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
@@ -49,7 +49,13 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
   };
 
   return (
-    <Hb.Paper variant="outlined" sx={{ borderRadius: 2, overflow: "hidden" }}>
+    <Hb.Paper
+      variant="outlined"
+      style={{
+        borderRadius: 16,
+        overflow: "hidden",
+      }}
+    >
       <Hb.Box
         sx={{
           px: 3,
@@ -81,7 +87,6 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
           />
         </Hb.Box>
       </Hb.Box>
-
       <Hb.Box sx={{ p: 3 }}>
         {/* 보드 생성 */}
         <Hb.Box sx={{ display: "flex", gap: 1, mb: boards.length > 0 ? 2 : 0 }}>

--- a/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
@@ -51,10 +51,10 @@ export const DangerZoneSection = ({ projectId }: DangerZoneSectionProps) => {
   return (
     <Hb.Paper
       variant="outlined"
-      sx={{
-        borderRadius: 2,
+      style={{
+        borderRadius: 16,
         overflow: "hidden",
-        borderColor: "error.light",
+        borderColor: "var(--hb-color-danger)",
       }}
     >
       <Hb.Box

--- a/apps/hobom-system/src/features/project-settings/ui/GeneralSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/GeneralSettingsSection.tsx
@@ -30,7 +30,13 @@ export const GeneralSettingsSection = ({ projectId }: GeneralSettingsSectionProp
     (description || undefined) !== (project.description || undefined);
 
   return (
-    <Hb.Paper variant="outlined" sx={{ borderRadius: 2, overflow: "hidden" }}>
+    <Hb.Paper
+      variant="outlined"
+      style={{
+        borderRadius: 16,
+        overflow: "hidden",
+      }}
+    >
       <Hb.Box
         sx={{
           px: 3,

--- a/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
@@ -65,7 +65,13 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
   };
 
   return (
-    <Hb.Paper variant="outlined" sx={{ borderRadius: 2, overflow: "hidden" }}>
+    <Hb.Paper
+      variant="outlined"
+      style={{
+        borderRadius: 16,
+        overflow: "hidden",
+      }}
+    >
       <Hb.Box
         sx={{
           px: 3,

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
@@ -19,16 +19,17 @@ export const MenuRecommendationTab = () => {
   return (
     <Hb.Paper
       elevation={0}
-      sx={{
+      style={{
         flex: 1,
-        mx: 3,
-        mb: 3,
+        marginLeft: 24,
+        marginRight: 24,
+        marginBottom: 24,
         display: "flex",
         flexDirection: "column",
         overflow: "hidden",
         border: "1px solid",
-        borderColor: "divider",
-        borderRadius: 2,
+        borderColor: "var(--hb-color-border)",
+        borderRadius: 16,
       }}
     >
       <Hb.Box
@@ -60,7 +61,6 @@ export const MenuRecommendationTab = () => {
         </Hb.Tabs.Root>
         {tab === "list" && <MenuRecommendationSpeedDial />}
       </Hb.Box>
-
       <Hb.Box sx={{ flex: 1, overflow: "auto" }}>
         <TabPanel visible={tab === "recommendation"}>
           <MenuRecommendationContent />

--- a/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
+++ b/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
@@ -41,11 +41,11 @@ export default function FutureMessageSendPage() {
 const Layout = ({ children }: { children: ReactNode }) => (
   <Hb.Paper
     elevation={2}
-    sx={{
+    style={{
       width: "100%",
       maxWidth: 520,
-      p: 4,
-      borderRadius: 3,
+      padding: 32,
+      borderRadius: 24,
     }}
   >
     {children}

--- a/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
+++ b/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
@@ -66,11 +66,13 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
         >
           <Hb.Paper
             variant="outlined"
-            sx={{
+            style={{
               textAlign: "center",
-              px: 5,
-              py: 4,
-              borderRadius: 2,
+              paddingLeft: 40,
+              paddingRight: 40,
+              paddingTop: 32,
+              paddingBottom: 32,
+              borderRadius: 16,
               maxWidth: 420,
               width: "100%",
             }}

--- a/apps/hobom-system/src/widgets/daily-todo-workspace/ui/DailyTodoWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/daily-todo-workspace/ui/DailyTodoWorkspace.tsx
@@ -44,13 +44,13 @@ export const DailyTodoWorkspace = () => {
     >
       <Hb.Paper
         elevation={0}
-        sx={{
+        style={{
           overflow: "hidden",
           flexShrink: 0,
           alignSelf: "flex-start",
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 2,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 16,
         }}
       >
         <Calendar.WithSuspense>
@@ -59,7 +59,7 @@ export const DailyTodoWorkspace = () => {
       </Hb.Paper>
       <Hb.Paper
         elevation={0}
-        sx={{
+        style={{
           flexGrow: 1,
           overflow: "hidden",
           display: "flex",
@@ -67,8 +67,8 @@ export const DailyTodoWorkspace = () => {
           minHeight: 0,
           height: "100%",
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 2,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 16,
         }}
       >
         <DateHeader />

--- a/apps/hobom-system/src/widgets/future-message-workspace/ui/FutureMessageWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/future-message-workspace/ui/FutureMessageWorkspace.tsx
@@ -18,17 +18,16 @@ export const FutureMessageWorkspace = () => {
       }}
     >
       <FutureMessageHeader />
-
       <Hb.Paper
         elevation={0}
-        sx={{
+        style={{
           flex: 1,
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 2,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 16,
         }}
       >
         <FutureMessageStatusTab />

--- a/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
+++ b/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
@@ -25,7 +25,13 @@ export const NotificationCenter = () => {
           알림
         </Hb.Text>
       </Hb.Box>
-      <Hb.Paper elevation={1} sx={{ borderRadius: 2, overflow: "hidden" }}>
+      <Hb.Paper
+        elevation={1}
+        style={{
+          borderRadius: 16,
+          overflow: "hidden",
+        }}
+      >
         <Hb.Box sx={{ px: 2 }}>
           <Hb.Tabs.Root
             value={tab}

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
@@ -53,10 +53,10 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
     <Hb.Box sx={{ p: 2 }}>
       <Hb.Paper
         elevation={0}
-        sx={{
+        style={{
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 2,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 16,
           overflow: "hidden",
         }}
       >
@@ -161,11 +161,11 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
       </Hb.Paper>
       <Hb.Paper
         elevation={0}
-        sx={{
-          mt: 2,
+        style={{
+          marginTop: 16,
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 2,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 16,
         }}
       >
         <Suspense

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageEditor.tsx
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageEditor.tsx
@@ -47,11 +47,11 @@ export const PageEditor = ({
   return (
     <Hb.Paper
       elevation={0}
-      sx={{
-        m: 2,
+      style={{
+        margin: 16,
         border: "1px solid",
-        borderColor: "divider",
-        borderRadius: 2,
+        borderColor: "var(--hb-color-border)",
+        borderRadius: 16,
         display: "flex",
         flexDirection: "column",
         minHeight: "calc(100vh - 280px)",

--- a/packages/hobom-design-system/src/components/Paper/Paper.stories.tsx
+++ b/packages/hobom-design-system/src/components/Paper/Paper.stories.tsx
@@ -1,0 +1,27 @@
+import { Paper } from "./Paper";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Paper",
+  component: Paper,
+  args: {
+    children: <div style={{ padding: 24, minWidth: 160 }}>Paper content</div>,
+  },
+  argTypes: {
+    variant: { control: "inline-radio", options: ["elevation", "outlined"] },
+    elevation: { control: { type: "number", min: 0, max: 4 } },
+  },
+} satisfies Meta<typeof Paper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Elevation: Story = {};
+
+export const Outlined: Story = {
+  args: { variant: "outlined" },
+};
+
+export const Flat: Story = {
+  args: { elevation: 0 },
+};

--- a/packages/hobom-design-system/src/components/Paper/Paper.tsx
+++ b/packages/hobom-design-system/src/components/Paper/Paper.tsx
@@ -1,1 +1,56 @@
-export { Paper } from "@mui/material";
+import type { HTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+interface PaperProps extends HTMLAttributes<HTMLDivElement> {
+  /** `"elevation"` (shadow) or `"outlined"` (border). Defaults to `"elevation"`. */
+  variant?: "elevation" | "outlined";
+  /** Shadow depth for the elevation variant. `0` is flat. Defaults to `1`. */
+  elevation?: number;
+}
+
+const styles = stylex.create({
+  base: {
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    borderRadius: 8,
+    boxSizing: "border-box",
+  },
+  outlined: {
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+  },
+  elev0: { boxShadow: "none" },
+  elev1: { boxShadow: "0 1px 4px rgba(0,0,0,0.06), 0 2px 12px rgba(0,0,0,0.03)" },
+  elev2: { boxShadow: "0 2px 8px rgba(0,0,0,0.08), 0 4px 16px rgba(0,0,0,0.04)" },
+});
+
+function elevationStyle(elevation: number) {
+  if (elevation <= 0) return styles.elev0;
+  if (elevation === 1) return styles.elev1;
+  return styles.elev2;
+}
+
+export const Paper = ({
+  variant = "elevation",
+  elevation = 1,
+  children,
+  className,
+  style,
+  ...rest
+}: PaperProps) => {
+  const sx = stylex.props(
+    styles.base,
+    variant === "outlined" ? styles.outlined : elevationStyle(elevation),
+  );
+
+  return (
+    <div
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ")}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/scripts/codemods/sx-to-style.cjs
+++ b/scripts/codemods/sx-to-style.cjs
@@ -1,0 +1,129 @@
+/**
+ * Codemod: convert MUI `sx` on a target component to plain `style`.
+ *
+ * Handles the common, statically-analyzable cases:
+ *   - spacing shorthands (m/p family, gap) → expanded at MUI's 8px unit
+ *   - borderRadius → ×8 (MUI shape multiplier)
+ *   - `border: N` → borderWidth/borderStyle; `border: "1px solid"` → passthrough
+ *   - theme color refs on color keys → var(--hb-color-*) (keeps dark adaptivity)
+ *   - other keys (overflow, display, flex, width, …) → value copied as-is
+ *
+ * A tag is left UNTOUCHED (for manual handling) if its `sx` has a spread, a
+ * dynamic/non-literal value, an unknown theme color, a numeric boxShadow, or if
+ * a `style` prop is already present.
+ *
+ *   pnpm dlx jscodeshift -t scripts/codemods/sx-to-style.cjs \
+ *     --parser tsx --extensions tsx apps/hobom-system/src
+ *
+ * Change COMPONENT to target a different component.
+ */
+const COMPONENT = { object: "Hb", property: "Paper" };
+const UNIT = 8;
+
+const SPACING = {
+  m: ["margin"], mt: ["marginTop"], mb: ["marginBottom"], ml: ["marginLeft"], mr: ["marginRight"],
+  mx: ["marginLeft", "marginRight"], my: ["marginTop", "marginBottom"],
+  p: ["padding"], pt: ["paddingTop"], pb: ["paddingBottom"], pl: ["paddingLeft"], pr: ["paddingRight"],
+  px: ["paddingLeft", "paddingRight"], py: ["paddingTop", "paddingBottom"],
+  gap: ["gap"], rowGap: ["rowGap"], columnGap: ["columnGap"],
+};
+const COLOR_KEYS = new Set(["color", "bgcolor", "backgroundColor", "borderColor", "background"]);
+const KEY_RENAME = { bgcolor: "backgroundColor" };
+const THEME_COLOR = {
+  divider: "var(--hb-color-border)",
+  "background.paper": "var(--hb-color-surface)",
+  "background.default": "var(--hb-color-canvas)",
+  "text.primary": "var(--hb-color-text-primary)",
+  "text.secondary": "var(--hb-color-text-secondary)",
+  "primary.main": "var(--hb-color-accent)",
+  "error.main": "var(--hb-color-danger)",
+  "error.light": "var(--hb-color-danger)",
+  "success.main": "var(--hb-color-success)",
+  "warning.main": "var(--hb-color-warning)",
+};
+
+module.exports = function transformer(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let changed = false;
+
+  const numNode = (n) =>
+    n < 0 ? j.unaryExpression("-", j.numericLiteral(-n), true) : j.numericLiteral(n);
+  const prop = (k, v) => j.objectProperty(j.identifier(k), v);
+
+  const staticValue = (node) => {
+    if (node.type === "NumericLiteral") return { num: node.value };
+    if (node.type === "StringLiteral") return { str: node.value };
+    if (node.type === "UnaryExpression" && node.operator === "-" && node.argument.type === "NumericLiteral")
+      return { num: -node.argument.value };
+    return null;
+  };
+
+  // returns an array of ObjectProperty, or null to bail the whole tag
+  const convert = (key, valueNode) => {
+    const sv = staticValue(valueNode);
+
+    if (SPACING[key]) {
+      if (!sv || sv.num == null) return null;
+      return SPACING[key].map((t) => prop(t, numNode(sv.num * UNIT)));
+    }
+    if (key === "borderRadius") {
+      if (!sv || sv.num == null) return null;
+      return [prop(key, numNode(sv.num * UNIT))];
+    }
+    if (key === "border") {
+      if (sv && sv.num != null) return [prop("borderWidth", numNode(sv.num)), prop("borderStyle", j.stringLiteral("solid"))];
+      if (sv && sv.str != null) return [prop("border", j.stringLiteral(sv.str))];
+      return null;
+    }
+    if (COLOR_KEYS.has(key)) {
+      if (!sv || sv.str == null) return null;
+      let v = sv.str;
+      if (THEME_COLOR[v]) v = THEME_COLOR[v];
+      else if (!/^(#|rgb|hsl|[a-z]+$)/.test(v)) return null;
+      return [prop(KEY_RENAME[key] || key, j.stringLiteral(v))];
+    }
+    if (key === "boxShadow") return null;
+    if (!sv) return null;
+    return [prop(key, sv.num != null ? numNode(sv.num) : j.stringLiteral(sv.str))];
+  };
+
+  root
+    .find(j.JSXOpeningElement)
+    .filter((p) => {
+      const n = p.node.name;
+      return (
+        n.type === "JSXMemberExpression" &&
+        n.object.type === "JSXIdentifier" &&
+        n.object.name === COMPONENT.object &&
+        n.property.name === COMPONENT.property
+      );
+    })
+    .forEach((p) => {
+      const attrs = p.node.attributes || [];
+      if (attrs.some((a) => a.type === "JSXAttribute" && a.name.name === "style")) return;
+      const sxAttr = attrs.find((a) => a.type === "JSXAttribute" && a.name.name === "sx");
+      if (!sxAttr || !sxAttr.value || sxAttr.value.type !== "JSXExpressionContainer") return;
+      const obj = sxAttr.value.expression;
+      if (obj.type !== "ObjectExpression") return;
+
+      const out = [];
+      for (const property of obj.properties) {
+        if (property.type !== "ObjectProperty" && property.type !== "Property") return; // spread → bail
+        const key = property.key.name != null ? property.key.name : property.key.value;
+        const converted = convert(key, property.value);
+        if (!converted) return; // bail whole tag
+        out.push(...converted);
+      }
+      if (out.length === 0) return;
+
+      const styleAttr = j.jsxAttribute(
+        j.jsxIdentifier("style"),
+        j.jsxExpressionContainer(j.objectExpression(out)),
+      );
+      attrs.splice(attrs.indexOf(sxAttr), 1, styleAttr);
+      changed = true;
+    });
+
+  return changed ? root.toSource({ quote: "double" }) : null;
+};


### PR DESCRIPTION
## Summary
Migrates `Paper` — a heavily-used, heavily-customized surface — off MUI. Surface/border/text read from the `--hb-*` vars, so Papers flip in dark mode; `elevation` and `outlined` variants supported; rest props (`onClick`, …) pass through.

## Codemod (reusable)
`scripts/codemods/sx-to-style.cjs` converts consumer `sx` on a target component to plain `style`:
- spacing shorthands + `borderRadius` (×8), `border` shorthand
- theme color refs → `var(--hb-color-*)` (e.g. `borderColor: "divider"` → `var(--hb-color-border)`), keeping dark adaptivity
- bails on dynamic/spread/unknown so those are handled by hand

**19 files auto-converted.** Manual cases: `NoteCreateBar` (has `:hover`) now uses app-side StyleX; `ChatMessageList`/`SprintSection` (conditional colors); `DashboardPaper`'s `sx` prop → `style` (+ its 3 consumers).

## Also
- Default (white) note-edit modal is now scheme-aware — it was showing white in dark mode because a new note's color is `#ffffff` (pre-existing note-color behavior, not the migration). Colored notes keep their color.

## Verification
- `pnpm test:coverage` (full monorepo) passes; typecheck clean
- **Dark-mode flip confirmed at runtime**: `--hb-color-surface` resolves `#ffffff` (light) → `#1e293b` (dark) when `data-hb-scheme` is set; the bridge syncs it from MUI's color scheme
- Paper stories run as browser a11y tests