### PR TITLE
feat: reimplement Badge in-house; Divider rest-prop passthrough

### DIFF
--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -216,17 +216,7 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
                 aria-label="멤버 공유"
                 onClick={(e) => setMemberAnchor(e.currentTarget)}
               >
-                <Hb.Badge
-                  badgeContent={noteMembers.length || undefined}
-                  color="primary"
-                  sx={{
-                    "& .MuiBadge-badge": {
-                      fontSize: 10,
-                      height: 16,
-                      minWidth: 16,
-                    },
-                  }}
-                >
+                <Hb.Badge badgeContent={noteMembers.length || undefined} color="primary">
                   <PersonAddOutlined fontSize="small" />
                 </Hb.Badge>
               </Hb.Button.Icon>

--- a/apps/hobom-system/src/features/notification/ui/NotificationBell.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationBell.tsx
@@ -19,19 +19,7 @@ export const NotificationBell = () => {
           "&:hover": { bgcolor: "rgba(0,0,0,0.04)" },
         }}
       >
-        <Hb.Badge
-          badgeContent={unreadCount}
-          max={99}
-          color="error"
-          sx={{
-            "& .MuiBadge-badge": {
-              fontSize: "0.625rem",
-              height: 16,
-              minWidth: 16,
-              px: 0.5,
-            },
-          }}
-        >
+        <Hb.Badge badgeContent={unreadCount} max={99} color="error">
           <NotificationsNoneOutlined sx={{ fontSize: 22 }} />
         </Hb.Badge>
       </Hb.Button.Icon>

--- a/packages/hobom-design-system/src/components/Badge/Badge.stories.tsx
+++ b/packages/hobom-design-system/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,24 @@
+import { Badge } from "./Badge";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const Anchor = () => (
+  <div style={{ width: 24, height: 24, borderRadius: 6, background: "var(--hb-color-border)" }} />
+);
+
+const meta = {
+  title: "Components/Badge",
+  component: Badge,
+  args: { children: <Anchor /> },
+  argTypes: {
+    color: { control: "inline-radio", options: ["primary", "error"] },
+    badgeContent: { control: "number" },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = { args: { badgeContent: 3 } };
+
+export const Error: Story = { args: { badgeContent: 128, max: 99, color: "error" } };

--- a/packages/hobom-design-system/src/components/Badge/Badge.tsx
+++ b/packages/hobom-design-system/src/components/Badge/Badge.tsx
@@ -1,1 +1,62 @@
-export { Badge } from "@mui/material";
+import type { ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+interface BadgeProps {
+  /** Content of the badge bubble (a count or short text). Hidden when 0/empty. */
+  badgeContent?: ReactNode;
+  /** Bubble color. Defaults to `"primary"`. */
+  color?: "primary" | "error";
+  /** Cap a numeric count, e.g. `max={99}` shows `99+`. */
+  max?: number;
+  /** The element the badge is anchored to. */
+  children: ReactNode;
+}
+
+const styles = stylex.create({
+  root: {
+    position: "relative",
+    display: "inline-flex",
+    verticalAlign: "middle",
+  },
+  badge: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    transform: "translate(50%, -50%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: 16,
+    minWidth: 16,
+    paddingInline: 4,
+    borderRadius: 8,
+    fontSize: 10,
+    fontWeight: 500,
+    lineHeight: 1,
+    color: "var(--hb-color-accent-contrast)",
+    boxSizing: "border-box",
+  },
+  primary: { backgroundColor: "var(--hb-color-accent)" },
+  error: { backgroundColor: "var(--hb-color-danger)" },
+});
+
+function display(content: ReactNode, max?: number): ReactNode {
+  if (typeof content === "number" && max != null && content > max) return `${max}+`;
+
+  return content;
+}
+
+export const Badge = ({ badgeContent, color = "primary", max, children }: BadgeProps) => {
+  const show = badgeContent != null && badgeContent !== 0 && badgeContent !== false;
+
+  return (
+    <span {...stylex.props(styles.root)}>
+      {children}
+      {show && (
+        <span {...stylex.props(styles.badge, color === "error" ? styles.error : styles.primary)}>
+          {display(badgeContent, max)}
+        </span>
+      )}
+    </span>
+  );
+};

--- a/packages/hobom-design-system/src/components/Divider/Divider.tsx
+++ b/packages/hobom-design-system/src/components/Divider/Divider.tsx
@@ -1,13 +1,11 @@
-import type { CSSProperties } from "react";
+import type { HTMLAttributes } from "react";
 import * as stylex from "@stylexjs/stylex";
 
-interface DividerProps {
+interface DividerProps extends HTMLAttributes<HTMLDivElement> {
   /** Line direction. Defaults to `"horizontal"`. */
   orientation?: "horizontal" | "vertical";
   /** For a vertical divider inside a flex row, stretch to the row's height. */
   flexItem?: boolean;
-  className?: string;
-  style?: CSSProperties;
 }
 
 const styles = stylex.create({
@@ -26,6 +24,7 @@ export const Divider = ({
   flexItem = false,
   className,
   style,
+  ...rest
 }: DividerProps) => {
   const isVertical = orientation === "vertical";
   const sx = stylex.props(
@@ -38,6 +37,7 @@ export const Divider = ({
     <div
       role="separator"
       aria-orientation={orientation}
+      {...rest}
       className={[sx.className, className].filter(Boolean).join(" ")}
       style={{ ...sx.style, ...style }}
     />


### PR DESCRIPTION
## Summary
- **Badge** migrated off MUI: a token-styled bubble (accent/danger vars → flips in dark) anchored to its child, with `badgeContent` and a `max` cap. The two call sites dropped their `.MuiBadge-badge` `sx` (MUI-internal) since the bubble styling is now baked into the component.
- **Divider** retroactive fix: spreads `...rest` so `onClick`/`id`/`aria-*` pass through — closing the same contract gap that the Paper migration surfaced.

## Verification
- `pnpm test:coverage` (full monorepo) passes; typecheck clean
- Badge/Divider stories run as browser a11y tests

Chip (78 uses, 49 `sx`) is large and will follow as its own PR.