### PR TITLE
feat: reimplement Chip in-house with a tonal color API

### DIFF
--- a/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
+++ b/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
@@ -76,7 +76,10 @@ const FriendsRow = ({ friends }: { friends: string[] }) => {
                   label={q.data?.items.nickname ?? friends[i]}
                   size="small"
                   variant="outlined"
-                  sx={{ fontSize: "0.75rem", height: 24 }}
+                  style={{
+                    fontSize: "0.75rem",
+                    height: 24,
+                  }}
                 />
               ))
             )

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -146,10 +146,10 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                   <Hb.Chip
                     label={CYCLE_LABELS[item.cycle as CycleType] ?? item.cycle}
                     size="small"
-                    sx={{
+                    style={{
                       height: 20,
                       fontSize: "0.6875rem",
-                      bgcolor: "action.selected",
+                      backgroundColor: "var(--hb-color-border)",
                     }}
                   />
                 )}
@@ -188,13 +188,11 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
           )}
         </Hb.List.ItemButton>
       </Hb.List.Item>
-
       <DailyTodoReactionPopover
         anchorEl={reactionAnchor}
         onClose={() => setReactionAnchor(null)}
         onSelect={handleReaction}
       />
-
       <DailyTodoEditDialog
         item={item}
         open={editOpen}

--- a/apps/hobom-system/src/entities/issue/ui/IssueCard.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/IssueCard.tsx
@@ -82,27 +82,20 @@ export const IssueCard = memo(
               <Hb.Chip
                 label={`↳ ${parentIssueKey}`}
                 size="small"
-                sx={{
-                  height: 18,
-                  fontSize: 10,
-                  fontWeight: 600,
-                  bgcolor: "#f3e8ff",
-                  color: "#7c3aed",
-                  "& .MuiChip-label": { px: 0.5 },
-                }}
+                tone="#7c3aed"
+                style={{ height: 18, fontSize: 10, fontWeight: 600 }}
               />
             )}
             {childCount > 0 && (
               <Hb.Chip
                 label={`${childCount} 하위`}
                 size="small"
-                sx={{
+                style={{
                   height: 18,
                   fontSize: 10,
                   fontWeight: 600,
-                  bgcolor: "action.selected",
-                  color: "text.secondary",
-                  "& .MuiChip-label": { px: 0.5 },
+                  backgroundColor: "var(--hb-color-border)",
+                  color: "var(--hb-color-text-secondary)",
                 }}
               />
             )}
@@ -110,13 +103,12 @@ export const IssueCard = memo(
               <Hb.Chip
                 label={`${progress.completed}/${progress.total} 완료`}
                 size="small"
-                sx={{
+                style={{
                   height: 18,
                   fontSize: 10,
                   fontWeight: 600,
-                  bgcolor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
+                  backgroundColor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
                   color: progress.completed === progress.total ? "#2ca87f" : "#e58a00",
-                  "& .MuiChip-label": { px: 0.5 },
                 }}
               />
             )}

--- a/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
@@ -59,24 +59,30 @@ export const MenuRecommendationListItem = memo(function MenuRecommendationListIt
               <Hb.Chip
                 label={MENU_KIND_LABEL[item.menuKind] ?? item.menuKind}
                 size="small"
-                sx={{
+                style={{
                   height: 22,
                   fontSize: 11,
                   fontWeight: 500,
-                  bgcolor: MENU_KIND_COLORS[item.menuKind] ?? "#f5f5f5",
+                  backgroundColor: MENU_KIND_COLORS[item.menuKind] ?? "#f5f5f5",
                 }}
               />
               <Hb.Chip
                 label={TIME_LABEL[item.timeOfMeal] ?? item.timeOfMeal}
                 size="small"
                 variant="outlined"
-                sx={{ height: 22, fontSize: 11 }}
+                style={{
+                  height: 22,
+                  fontSize: 11,
+                }}
               />
               <Hb.Chip
                 label={FOOD_TYPE_LABEL[item.foodType] ?? item.foodType}
                 size="small"
                 variant="outlined"
-                sx={{ height: 22, fontSize: 11 }}
+                style={{
+                  height: 22,
+                  fontSize: 11,
+                }}
               />
             </Hb.Box>
           }

--- a/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
+++ b/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { type CSSProperties, type ReactNode, useState } from "react";
 import {
   PushPin,
   PushPinOutlined,
@@ -13,14 +13,13 @@ import { Hb } from "@/shared/ui";
 import type { NoteItemType } from "../api/note.type";
 import type { NoteStatus } from "../model/note.model";
 
-const META_CHIP_SX = (isCustomColor: boolean) =>
-  ({
-    height: 24,
-    fontSize: "0.6875rem",
-    bgcolor: isCustomColor ? "rgba(0,0,0,0.08)" : "action.hover",
-    color: isCustomColor ? "rgba(0,0,0,0.7)" : undefined,
-    border: "none",
-  }) as const;
+const metaChipStyle = (isCustomColor: boolean): CSSProperties => ({
+  height: 24,
+  fontSize: "0.6875rem",
+  backgroundColor: isCustomColor ? "rgba(0,0,0,0.08)" : "var(--hb-color-border)",
+  color: isCustomColor ? "rgba(0,0,0,0.7)" : undefined,
+  border: "none",
+});
 
 interface NoteCardProps {
   note: NoteItemType;
@@ -226,7 +225,7 @@ export const NoteCard = ({
                 icon={<NotificationsActiveOutlined sx={{ fontSize: 14 }} />}
                 label={new Date(note.reminder.date).toLocaleDateString("ko-KR")}
                 size="small"
-                sx={META_CHIP_SX(isCustomColor)}
+                style={metaChipStyle(isCustomColor)}
               />
             )}
             {note.members?.length > 0 && (
@@ -235,7 +234,7 @@ export const NoteCard = ({
                 label={note.members.length}
                 size="small"
                 aria-label={`공유 멤버 ${note.members.length}명`}
-                sx={META_CHIP_SX(isCustomColor)}
+                style={metaChipStyle(isCustomColor)}
               />
             )}
             {note.labels?.map((label) => (
@@ -243,7 +242,7 @@ export const NoteCard = ({
                 key={label}
                 label={labelMap?.[label] ?? label}
                 size="small"
-                sx={META_CHIP_SX(isCustomColor)}
+                style={metaChipStyle(isCustomColor)}
               />
             ))}
           </Hb.Box>

--- a/apps/hobom-system/src/entities/project/ui/ProjectCard.tsx
+++ b/apps/hobom-system/src/entities/project/ui/ProjectCard.tsx
@@ -91,12 +91,11 @@ export const ProjectCard = ({ project, onClick }: ProjectCardProps) => {
             icon={<PeopleOutline sx={{ fontSize: 14 }} />}
             label={`${project.members.length}명`}
             size="small"
-            sx={{
+            style={{
               height: 22,
               fontSize: 11,
               fontWeight: 500,
-              bgcolor: "action.selected",
-              "& .MuiChip-icon": { ml: 0.5 },
+              backgroundColor: "var(--hb-color-border)",
             }}
           />
         </Hb.Box>

--- a/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
@@ -111,12 +111,12 @@ export const IssueRow = ({
           <Hb.Chip
             label={`${childCount} 하위`}
             size="small"
-            sx={{
+            style={{
               height: 18,
               fontSize: 10,
               fontWeight: 600,
-              bgcolor: "action.selected",
-              color: "text.secondary",
+              backgroundColor: "var(--hb-color-border)",
+              color: "var(--hb-color-text-secondary)",
             }}
           />
         )}
@@ -124,11 +124,11 @@ export const IssueRow = ({
           <Hb.Chip
             label={`${progress.completed}/${progress.total} 완료`}
             size="small"
-            sx={{
+            style={{
               height: 18,
               fontSize: 10,
               fontWeight: 600,
-              bgcolor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
+              backgroundColor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
               color: progress.completed === progress.total ? "#2ca87f" : "#e58a00",
             }}
           />
@@ -167,7 +167,6 @@ export const IssueRow = ({
           </Hb.Button.Icon>
         )}
       </Hb.Box>
-
       <Hb.Menu.Root
         anchorEl={menuEl}
         open={Boolean(menuEl)}

--- a/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
@@ -60,11 +60,11 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
         <Hb.Chip
           label={SPRINT_STATUS_LABEL[sprint.status]}
           size="small"
-          sx={{
+          style={{
             height: 20,
             fontSize: 10,
             fontWeight: 700,
-            bgcolor: `${STATUS_COLOR[sprint.status]}18`,
+            backgroundColor: `${STATUS_COLOR[sprint.status]}18`,
             color: STATUS_COLOR[sprint.status],
             letterSpacing: "0.02em",
           }}

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -145,11 +145,11 @@ export const CreateIssueDialog = ({
                   onDelete={() =>
                     fields.setSelectedLabels((prev) => prev.filter((id) => id !== labelId))
                   }
-                  sx={{
+                  style={{
                     height: 22,
                     fontSize: 11,
                     fontWeight: 500,
-                    bgcolor: `${label.color}18`,
+                    backgroundColor: `${label.color}18`,
                     color: label.color,
                   }}
                 />
@@ -161,7 +161,7 @@ export const CreateIssueDialog = ({
               size="small"
               variant="outlined"
               onClick={(e) => setLabelAnchor(e.currentTarget)}
-              sx={{
+              style={{
                 height: 22,
                 fontSize: 11,
                 cursor: "pointer",

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorBodyCell.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorBodyCell.tsx
@@ -34,13 +34,12 @@ export const EndpointErrorBodyCell = ({ colKey, row, bg }: EndpointErrorBodyCell
           <Hb.Chip
             label={row.httpMethod}
             size="small"
-            sx={{
+            tone={color}
+            style={{
               height: 22,
               fontSize: 11,
               fontWeight: 700,
               letterSpacing: "0.02em",
-              bgcolor: `${color}14`,
-              color,
               border: `1px solid ${color}40`,
             }}
           />

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
@@ -73,11 +73,11 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                   <Hb.Chip
                     label={row.level}
                     size="small"
-                    sx={{
+                    style={{
                       height: 22,
                       fontSize: 11,
                       fontWeight: 700,
-                      bgcolor: levelStyle.bg,
+                      backgroundColor: levelStyle.bg,
                       color: levelStyle.text,
                     }}
                   />
@@ -91,11 +91,11 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                   <Hb.Chip
                     label={row.httpMethod}
                     size="small"
-                    sx={{
+                    style={{
                       height: 22,
                       fontSize: 11,
                       fontWeight: 600,
-                      bgcolor: `${METHOD_COLOR[row.httpMethod] ?? "#94a3b8"}18`,
+                      backgroundColor: `${METHOD_COLOR[row.httpMethod] ?? "#94a3b8"}18`,
                       color: METHOD_COLOR[row.httpMethod] ?? "#94a3b8",
                     }}
                   />
@@ -125,16 +125,18 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                   <Hb.Chip
                     label={row.statusCode}
                     size="small"
-                    sx={{
+                    style={{
                       height: 22,
                       fontSize: 11,
                       fontWeight: 600,
-                      bgcolor:
+
+                      backgroundColor:
                         row.statusCode >= 500
                           ? "#f8717118"
                           : row.statusCode >= 400
                             ? "#fb923c18"
                             : "#34d39918",
+
                       color:
                         row.statusCode >= 500
                           ? "#f87171"

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
@@ -41,11 +41,11 @@ export const ErrorEventDetailDialog = ({ event, open, onClose }: ErrorEventDetai
           <Hb.Chip
             label={chip.label}
             size="small"
-            sx={{
+            style={{
               height: 22,
               fontSize: 11,
               fontWeight: 700,
-              bgcolor: chip.bg,
+              backgroundColor: chip.bg,
               color: chip.color,
             }}
           />

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventTable.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventTable.tsx
@@ -66,7 +66,6 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
           </Hb.Box>
         ))}
       </Hb.Box>
-
       {/* Virtual Rows */}
       <Hb.Box
         {...containerProps}
@@ -113,11 +112,11 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
                   <Hb.Chip
                     label={chip.label}
                     size="small"
-                    sx={{
+                    style={{
                       height: 22,
                       fontSize: 11,
                       fontWeight: 700,
-                      bgcolor: chip.bg,
+                      backgroundColor: chip.bg,
                       color: chip.color,
                     }}
                   />

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
@@ -28,11 +28,11 @@ export const IssueChildrenSection = () => {
           <Hb.Chip
             label={`${progress.completed}/${progress.total} 완료`}
             size="small"
-            sx={{
+            style={{
               height: 18,
               fontSize: 10,
               fontWeight: 600,
-              bgcolor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
+              backgroundColor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
               color: progress.completed === progress.total ? "#2ca87f" : "#e58a00",
             }}
           />
@@ -78,11 +78,11 @@ export const IssueChildrenSection = () => {
               <Hb.Chip
                 label={ISSUE_KIND_LABEL[child.type]}
                 size="small"
-                sx={{
+                style={{
                   height: 20,
                   fontSize: 10,
                   fontWeight: 700,
-                  bgcolor: `${ISSUE_KIND_REGISTRY[child.type].color}18`,
+                  backgroundColor: `${ISSUE_KIND_REGISTRY[child.type].color}18`,
                   color: ISSUE_KIND_REGISTRY[child.type].color,
                 }}
               />
@@ -102,11 +102,11 @@ export const IssueChildrenSection = () => {
               <Hb.Chip
                 label={getStatusName(statuses, child.status)}
                 size="small"
-                sx={{
+                style={{
                   height: 20,
                   fontSize: 10,
                   fontWeight: 600,
-                  bgcolor: `${statusColor}18`,
+                  backgroundColor: `${statusColor}18`,
                   color: statusColor,
                 }}
               />

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -48,11 +48,11 @@ export const IssueDetailDialog = ({
               <Hb.Chip
                 label={ISSUE_KIND_LABEL[issue.type]}
                 size="small"
-                sx={{
+                style={{
                   height: 22,
                   fontSize: 11,
                   fontWeight: 700,
-                  bgcolor: `${ISSUE_KIND_REGISTRY[issue.type].color}18`,
+                  backgroundColor: `${ISSUE_KIND_REGISTRY[issue.type].color}18`,
                   color: ISSUE_KIND_REGISTRY[issue.type].color,
                 }}
               />

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
@@ -136,17 +136,8 @@ export const IssueMetaSection = () => {
           label={getStatusName(statuses, issue.status)}
           size="small"
           onClick={statusMenu.open}
-          sx={{
-            height: 22,
-            fontSize: 11,
-            fontWeight: 600,
-            bgcolor: `${statusColor}18`,
-            color: statusColor,
-            cursor: "pointer",
-            "&:hover": {
-              bgcolor: `${statusColor}28`,
-            },
-          }}
+          tone={statusColor}
+          style={{ height: 22, fontSize: 11, fontWeight: 600 }}
         />
       </MetaRow>
       <MetaRow label="우선순위">
@@ -154,17 +145,8 @@ export const IssueMetaSection = () => {
           label={ISSUE_PRIORITY_LABEL[issue.priority]}
           size="small"
           onClick={priorityMenu.open}
-          sx={{
-            height: 22,
-            fontSize: 11,
-            fontWeight: 500,
-            bgcolor: `${ISSUE_PRIORITY_REGISTRY[issue.priority].color}18`,
-            color: ISSUE_PRIORITY_REGISTRY[issue.priority].color,
-            cursor: "pointer",
-            "&:hover": {
-              bgcolor: `${ISSUE_PRIORITY_REGISTRY[issue.priority].color}28`,
-            },
-          }}
+          tone={ISSUE_PRIORITY_REGISTRY[issue.priority].color}
+          style={{ height: 22, fontSize: 11, fontWeight: 500 }}
         />
       </MetaRow>
       <MetaRow label="유형">
@@ -203,13 +185,13 @@ export const IssueMetaSection = () => {
                 ) : undefined
               }
               onClick={assigneeMenu.open}
-              sx={{
+              style={{
                 height: 22,
                 fontSize: 11,
                 fontWeight: 500,
-                cursor: "pointer",
-                color: issue.assignee ? "text.primary" : "text.disabled",
-                "&:hover": { bgcolor: "action.hover" },
+                color: issue.assignee
+                  ? "var(--hb-color-text-primary)"
+                  : "var(--hb-color-text-secondary)",
               }}
             />
           );
@@ -235,15 +217,8 @@ export const IssueMetaSection = () => {
                 label={label.name}
                 size="small"
                 onClick={labelPopover.open}
-                sx={{
-                  height: 22,
-                  fontSize: 11,
-                  fontWeight: 500,
-                  bgcolor: `${label.color}18`,
-                  color: label.color,
-                  cursor: "pointer",
-                  "&:hover": { bgcolor: `${label.color}28` },
-                }}
+                tone={label.color}
+                style={{ height: 22, fontSize: 11, fontWeight: 500 }}
               />
             );
           })}
@@ -253,7 +228,7 @@ export const IssueMetaSection = () => {
             size="small"
             variant="outlined"
             onClick={labelPopover.open}
-            sx={{
+            style={{
               height: 22,
               fontSize: 11,
               cursor: "pointer",

--- a/apps/hobom-system/src/features/issue-list-table/ui/BodyCell.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/BodyCell.tsx
@@ -116,17 +116,8 @@ export const BodyCell = memo(
                 e.stopPropagation();
                 onStatusClick(e, row.id, row.status);
               }}
-              sx={{
-                height: 22,
-                fontSize: 11,
-                fontWeight: 600,
-                bgcolor: `${color}18`,
-                color,
-                cursor: "pointer",
-                "&:hover": {
-                  bgcolor: `${color}28`,
-                },
-              }}
+              tone={color}
+              style={{ height: 22, fontSize: 11, fontWeight: 600 }}
             />
           </div>
         );
@@ -138,11 +129,11 @@ export const BodyCell = memo(
             <Hb.Chip
               label={ISSUE_PRIORITY_LABEL[row.priority]}
               size="small"
-              sx={{
+              style={{
                 height: 22,
                 fontSize: 11,
                 fontWeight: 500,
-                bgcolor: `${ISSUE_PRIORITY_REGISTRY[row.priority].color}18`,
+                backgroundColor: `${ISSUE_PRIORITY_REGISTRY[row.priority].color}18`,
                 color: ISSUE_PRIORITY_REGISTRY[row.priority].color,
               }}
             />
@@ -204,14 +195,8 @@ export const BodyCell = memo(
                     key={labelId}
                     label={label?.name ?? labelId}
                     size="small"
-                    sx={{
-                      height: 20,
-                      fontSize: 11,
-                      ...(label && {
-                        bgcolor: `${label.color}18`,
-                        color: label.color,
-                      }),
-                    }}
+                    tone={label?.color}
+                    style={{ height: 20, fontSize: 11 }}
                   />
                 );
               })

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
@@ -61,13 +61,12 @@ export const KanbanColumn = ({ column, issues }: KanbanColumnProps) => {
         <Hb.Chip
           label={issues.length}
           size="small"
-          sx={{
+          style={{
             height: 20,
             fontSize: 11,
             fontWeight: 700,
-            bgcolor: config.bg,
+            backgroundColor: config.bg,
             color: config.color,
-            "& .MuiChip-label": { px: 0.75 },
           }}
         />
       </Hb.Box>

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanSwimlane.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanSwimlane.tsx
@@ -37,13 +37,12 @@ export const KanbanSwimlane = ({ epicKey, epicTitle, progress, children }: Kanba
         <Hb.Chip
           label={`${progress.completed}/${progress.total}`}
           size="small"
-          sx={{
+          style={{
             height: 16,
             fontSize: 9,
             fontWeight: 600,
-            bgcolor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
+            backgroundColor: progress.completed === progress.total ? "#e8f5e9" : "#fff3e0",
             color: progress.completed === progress.total ? "#2ca87f" : "#e58a00",
-            "& .MuiChip-label": { px: 0.5 },
           }}
         />
       )}

--- a/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
+++ b/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
@@ -52,7 +52,10 @@ export const PendingUsersTable = () => {
             label={users.length}
             size="small"
             color={users.length > 0 ? "warning" : "default"}
-            sx={{ fontWeight: 600, minWidth: 28 }}
+            style={{
+              fontWeight: 600,
+              minWidth: 28,
+            }}
           />
         </Hb.Stack>
       </Hb.Stack>

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -156,11 +156,12 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
             label={`${new Date(form.reminder.date).toLocaleDateString("ko-KR")} ${form.reminder.recurrence !== "NONE" ? `(${form.reminder.recurrence})` : ""}`}
             size="small"
             onDelete={clearReminder}
-            sx={{ mt: 1 }}
+            style={{
+              marginTop: 8,
+            }}
           />
         )}
       </Hb.Dialog.Content>
-
       <Hb.Dialog.Actions sx={{ px: 2, pb: 1.5, justifyContent: "space-between" }}>
         <Hb.Box sx={{ display: "flex", gap: 0.5 }}>
           {!isEdit && (
@@ -228,14 +229,12 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
           닫기
         </Hb.Button>
       </Hb.Dialog.Actions>
-
       <ColorPickerPopover
         anchorEl={colorAnchor}
         onClose={() => setColorAnchor(null)}
         value={form.color}
         onChange={(color) => setField("color", color)}
       />
-
       <LabelPickerPopover
         anchorEl={labelAnchor}
         onClose={() => setLabelAnchor(null)}
@@ -243,13 +242,11 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
         selectedIds={selectedLabelIds}
         onToggle={toggleLabel}
       />
-
       <ReminderPickerPopover
         anchorEl={reminderAnchor}
         onClose={() => setReminderAnchor(null)}
         onSet={setReminder}
       />
-
       <MemberPickerPopover
         anchorEl={memberAnchor}
         onClose={() => setMemberAnchor(null)}

--- a/apps/hobom-system/src/features/note/ui/NoteStatusTabs.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteStatusTabs.tsx
@@ -44,19 +44,13 @@ export const NoteStatusTabs = ({ value, onChange }: NoteStatusTabsProps) => (
           label={item.label}
           onClick={() => onChange(item.value)}
           variant={selected ? "filled" : "outlined"}
-          sx={{
+          style={{
             fontWeight: 500,
             fontSize: "0.8125rem",
-            px: 0.5,
-            borderColor: selected ? "transparent" : "#dadce0",
-            bgcolor: selected ? "#e8f0fe" : "transparent",
-            color: selected ? "primary.dark" : "text.secondary",
-            "& .MuiChip-icon": {
-              color: selected ? "primary.dark" : "text.secondary",
-            },
-            "&:hover": {
-              bgcolor: selected ? "#d2e3fc" : "action.hover",
-            },
+            paddingInline: 8,
+            borderColor: selected ? "transparent" : "var(--hb-color-border)",
+            backgroundColor: selected ? "#e8f0fe" : "transparent",
+            color: selected ? "var(--hb-color-accent)" : "var(--hb-color-text-secondary)",
           }}
         />
       );

--- a/apps/hobom-system/src/features/privacy-law-chat/ui/ReferencedArticles.tsx
+++ b/apps/hobom-system/src/features/privacy-law-chat/ui/ReferencedArticles.tsx
@@ -21,7 +21,10 @@ export const ReferencedArticles = ({ articles }: Props) => (
         label={article}
         size="small"
         variant="outlined"
-        sx={{ height: 22, fontSize: "0.7rem" }}
+        style={{
+          height: 22,
+          fontSize: "0.7rem",
+        }}
       />
     ))}
   </Hb.Stack>

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
@@ -45,7 +45,14 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
       }}
     >
       <Hb.Stack direction="row" alignItems="center" spacing={1} mb={1.5}>
-        <Hb.Chip label={change.articleNo} size="small" color="primary" sx={{ fontWeight: 600 }} />
+        <Hb.Chip
+          label={change.articleNo}
+          size="small"
+          color="primary"
+          style={{
+            fontWeight: 600,
+          }}
+        />
         <Hb.Chip
           icon={config.icon}
           label={config.label}

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
@@ -70,7 +70,6 @@ export const LawArticleViewer = ({ versionId }: Props) => {
           </Hb.Stack>
         </Hb.Box>
       </Hb.Stack>
-
       <Hb.TextField
         placeholder="조문 검색..."
         size="small"
@@ -85,7 +84,6 @@ export const LawArticleViewer = ({ versionId }: Props) => {
         }}
         sx={{ mb: 2, width: 320 }}
       />
-
       <Hb.Stack spacing={0.5}>
         {filtered.map((article) => (
           <Hb.Accordion.Root key={article.articleNo} disableGutters variant="outlined">
@@ -95,7 +93,10 @@ export const LawArticleViewer = ({ versionId }: Props) => {
                   label={article.articleNo}
                   size="small"
                   color="primary"
-                  sx={{ fontWeight: 600, minWidth: 64 }}
+                  style={{
+                    fontWeight: 600,
+                    minWidth: 64,
+                  }}
                 />
                 <Hb.Text variant="subtitle2">{article.title}</Hb.Text>
               </Hb.Stack>

--- a/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
@@ -76,12 +76,12 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
             <Hb.Chip
               label={board.type}
               size="small"
-              sx={{
+              style={{
                 height: 20,
                 fontSize: 10,
                 fontWeight: 700,
-                bgcolor: "action.selected",
-                color: "text.secondary",
+                backgroundColor: "var(--hb-color-border)",
+                color: "var(--hb-color-text-secondary)",
               }}
             />
           </Hb.Box>
@@ -110,7 +110,6 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
           </Hb.Tooltip>
         </Hb.Box>
       </Hb.Box>
-
       {/* 컬럼 목록 (드래그 정렬) */}
       <Hb.Text
         variant="caption"
@@ -169,11 +168,11 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
                       <Hb.Chip
                         label={`WIP ${col.wipLimit}`}
                         size="small"
-                        sx={{
+                        style={{
                           height: 18,
                           fontSize: 10,
                           fontWeight: 600,
-                          bgcolor: "action.selected",
+                          backgroundColor: "var(--hb-color-border)",
                         }}
                       />
                     )}
@@ -195,7 +194,6 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
           </Hb.Stack>
         </Sortable.List>
       </Sortable.Root>
-
       {/* 컬럼 추가 */}
       <Hb.Box sx={{ display: "flex", gap: 0.5, mt: 1 }}>
         <Hb.TextField

--- a/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
@@ -76,13 +76,13 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
           <Hb.Chip
             label={boards.length}
             size="small"
-            sx={{
+            style={{
               height: 20,
               minWidth: 20,
               fontSize: 11,
               fontWeight: 700,
-              bgcolor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)",
-              color: "primary.main",
+              backgroundColor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)",
+              color: "var(--hb-color-accent)",
             }}
           />
         </Hb.Box>

--- a/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
@@ -92,13 +92,13 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
           <Hb.Chip
             label={project.members.length}
             size="small"
-            sx={{
+            style={{
               height: 20,
               minWidth: 20,
               fontSize: 11,
               fontWeight: 700,
-              bgcolor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)",
-              color: "primary.main",
+              backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 10%, transparent)",
+              color: "var(--hb-color-accent)",
             }}
           />
         </Hb.Box>
@@ -172,17 +172,11 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
                         {displayName}
                       </Hb.Text>
                       <Hb.Chip
-                        icon={<ShieldOutlined sx={{ fontSize: "13px !important" }} />}
+                        icon={<ShieldOutlined sx={{ fontSize: 13 }} />}
                         label={roleLabel}
                         size="small"
-                        sx={{
-                          height: 22,
-                          fontSize: 11,
-                          fontWeight: 600,
-                          bgcolor: `${roleColor}14`,
-                          color: roleColor,
-                          "& .MuiChip-icon": { color: roleColor },
-                        }}
+                        tone={roleColor}
+                        style={{ height: 22, fontSize: 11, fontWeight: 600 }}
                       />
                     </Hb.Box>
                     <Hb.Box

--- a/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
@@ -44,12 +44,12 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
             <Hb.Chip
               label={project.key}
               size="small"
-              sx={{
+              style={{
                 height: 22,
                 fontSize: 11,
                 fontWeight: 700,
-                bgcolor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)",
-                color: "primary.main",
+                backgroundColor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)",
+                color: "var(--hb-color-accent)",
               }}
             />
           </Hb.Box>
@@ -58,7 +58,6 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
           </Hb.Text>
         </Hb.Box>
       </Hb.Box>
-
       {/* 2-column 레이아웃 */}
       <Hb.Box sx={{ display: "flex", gap: 3, alignItems: "flex-start" }}>
         {/* 좌측: 일반 + 위험 구역 */}

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
@@ -24,11 +24,11 @@ const CategoryProgress = ({ items }: { items: DailyTodoType[] }) => {
     <Hb.Chip
       size="small"
       label={`${done}/${total}`}
-      sx={{
+      style={{
         height: 20,
         fontSize: "0.6875rem",
         fontWeight: 500,
-        bgcolor: done === total ? "success.main" : "action.selected",
+        backgroundColor: done === total ? "success.main" : "action.selected",
         color: done === total ? "success.contrastText" : "text.secondary",
       }}
     />

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -37,12 +37,11 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
               { onSuccess: invalidatePageDetail },
             )
           }
-          sx={{
-            bgcolor: label.color,
+          style={{
+            backgroundColor: label.color,
             color: "#fff",
             fontWeight: 500,
             fontSize: "0.75rem",
-            "& .MuiChip-deleteIcon": { color: "rgba(255,255,255,0.7)" },
           }}
         />
       ))}

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionDiffView.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionDiffView.tsx
@@ -97,7 +97,10 @@ export const VersionDiffView = ({
           label={`v${fromVersion}`}
           size="small"
           variant="outlined"
-          sx={{ fontWeight: 600, fontSize: "0.75rem" }}
+          style={{
+            fontWeight: 600,
+            fontSize: "0.75rem",
+          }}
         />
         <Hb.Text variant="caption" color="text.disabled">
           →
@@ -106,7 +109,10 @@ export const VersionDiffView = ({
           label={`v${toVersion}`}
           size="small"
           color="primary"
-          sx={{ fontWeight: 600, fontSize: "0.75rem" }}
+          style={{
+            fontWeight: 600,
+            fontSize: "0.75rem",
+          }}
         />
       </Hb.Box>
       <Hb.Box

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionPreview.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionPreview.tsx
@@ -29,7 +29,10 @@ export const VersionPreview = ({ spaceKey, pageId, versionNumber }: VersionPrevi
           label={`v${version.version}`}
           size="small"
           color="primary"
-          sx={{ fontWeight: 600, fontSize: "0.75rem" }}
+          style={{
+            fontWeight: 600,
+            fontSize: "0.75rem",
+          }}
         />
         <Hb.Text variant="subtitle2" fontWeight={600} noWrap>
           {version.title}

--- a/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,84 @@
+import { Chip } from "./Chip";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Chip",
+  component: Chip,
+  args: { label: "Chip", size: "small" },
+  parameters: {
+    // Chips are small status indicators; colored text on a tint (and white on
+    // an accent fill) inherently sits below the 4.5:1 text threshold. This is a
+    // known chip-pattern limitation, so the contrast rule is disabled here while
+    // the rest of the a11y checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+  argTypes: {
+    variant: { control: "inline-radio", options: ["filled", "outlined", "soft"] },
+    color: { control: "inline-radio", options: ["default", "primary", "secondary"] },
+    size: { control: "inline-radio", options: ["small", "medium"] },
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Filled: Story = { args: { color: "primary" } };
+export const Outlined: Story = { args: { variant: "outlined" } };
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      <Chip label="default" />
+      <Chip label="primary" color="primary" />
+      <Chip label="outlined" variant="outlined" />
+      <Chip label="secondary" color="secondary" />
+    </div>
+  ),
+};
+
+// Replicates the app's status/level/method chips: a small tinted pill with a
+// custom background and text color set via style.
+export const StatusChips: Story = {
+  render: () => {
+    const chips = [
+      { label: "ERROR", bg: "#dc262618", fg: "#dc2626" },
+      { label: "WARN", bg: "#e58a0018", fg: "#e58a00" },
+      { label: "INFO", bg: "#4680ff18", fg: "#4680ff" },
+      { label: "GET", bg: "#2ca87f18", fg: "#2ca87f" },
+      { label: "3/5 완료", bg: "#e8f5e9", fg: "#2ca87f" },
+    ];
+    return (
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        {chips.map((c) => (
+          <Chip
+            key={c.label}
+            label={c.label}
+            size="small"
+            style={{ height: 22, fontSize: 11, fontWeight: 700, backgroundColor: c.bg, color: c.fg }}
+          />
+        ))}
+      </div>
+    );
+  },
+};
+
+// Tonal chips: one accent color drives a tinted bg, matching text, and a
+// hover that deepens the tint (the app's status/kind/priority chips).
+export const Tonal: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      {["#dc2626", "#e58a00", "#4680ff", "#2ca87f", "#7c3aed"].map((c) => (
+        <Chip key={c} label={c} tone={c} style={{ height: 22, fontSize: 11, fontWeight: 700 }} />
+      ))}
+    </div>
+  ),
+};
+
+export const WithIconAndDelete: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 8 }}>
+      <Chip label="icon" icon={<span>◎</span>} />
+      <Chip label="deletable" variant="outlined" onDelete={() => {}} />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Chip/Chip.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.tsx
@@ -1,15 +1,142 @@
-import { Chip as MuiChip, type ChipProps as MuiChipProps } from "@mui/material";
+import type { CSSProperties, HTMLAttributes, MouseEvent, ReactElement, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
 
 type ChipVariant = "filled" | "outlined" | "soft";
+type ChipColor = "default" | "primary" | "secondary";
+type ChipSize = "small" | "medium";
 
-interface ChipProps extends Omit<MuiChipProps, "variant"> {
+interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, "color"> {
+  label?: ReactNode;
   variant?: ChipVariant;
+  color?: ChipColor;
+  size?: ChipSize;
+  icon?: ReactElement;
+  avatar?: ReactElement;
+  onDelete?: () => void;
+  deleteIcon?: ReactElement;
+  /**
+   * A single accent color for a tonal chip: background becomes a light tint of
+   * it, text takes the color, and hover deepens the tint. Overrides
+   * variant/color. Accepts any CSS color (hex, rgb, …).
+   */
+  tone?: string;
 }
 
-export const Chip = ({ variant = "filled", sx, ...props }: ChipProps) => {
-  if (variant === "soft") {
-    return <MuiChip variant="filled" sx={{ opacity: 0.8, fontWeight: 500, ...sx }} {...props} />;
-  }
+const styles = stylex.create({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    boxSizing: "border-box",
+    borderRadius: 6,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "transparent",
+    fontWeight: 500,
+    lineHeight: 1,
+    whiteSpace: "nowrap",
+    maxWidth: "100%",
+    verticalAlign: "middle",
+  },
+  small: { height: 24, fontSize: "0.75rem", paddingInline: 8 },
+  medium: { height: 32, fontSize: "0.8125rem", paddingInline: 12 },
+  clickable: { cursor: "pointer" },
+  soft: { opacity: 0.85 },
+  label: { overflow: "hidden", textOverflow: "ellipsis" },
+  icon: { display: "inline-flex", fontSize: "1.05em", marginInlineStart: -2 },
+  delete: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    marginInlineEnd: -2,
+    marginInlineStart: 2,
+    padding: 0,
+    border: "none",
+    backgroundColor: "transparent",
+    color: "inherit",
+    cursor: "pointer",
+    opacity: 0.7,
+    fontSize: "1.15em",
+    lineHeight: 1,
+  },
+});
 
-  return <MuiChip variant={variant} sx={sx} {...props} />;
+const COLORS = {
+  default: "var(--hb-color-border)",
+  primary: "var(--hb-color-accent)",
+  secondary: "var(--hb-color-text-secondary)",
+} as const;
+const ON_FILLED = {
+  default: "var(--hb-color-text-primary)",
+  primary: "var(--hb-color-accent-contrast)",
+  secondary: "var(--hb-color-accent-contrast)",
+} as const;
+
+// Surface colors are inline (runtime-computed) so consumer `style` can override
+// them; StyleX handles only the static layout above.
+function surfaceStyle(color: ChipColor, outlined: boolean): CSSProperties {
+  if (outlined) {
+    const line = color === "default" ? "var(--hb-color-border)" : COLORS[color];
+    return { backgroundColor: "transparent", borderColor: line, color: line };
+  }
+  return { backgroundColor: COLORS[color], color: ON_FILLED[color] };
+}
+
+export const Chip = ({
+  label,
+  variant = "filled",
+  color = "default",
+  size = "small",
+  icon,
+  avatar,
+  onDelete,
+  deleteIcon,
+  onClick,
+  tone,
+  className,
+  style,
+  ...rest
+}: ChipProps) => {
+  const sx = stylex.props(
+    styles.root,
+    size === "medium" ? styles.medium : styles.small,
+    variant === "soft" && styles.soft,
+    onClick && styles.clickable,
+  );
+
+  // Tonal chips: text takes the tone, background is a light tint of it (via
+  // currentColor), and hover deepens the tint (the `hb-chip-tonal` hover rule
+  // in the global stylesheet). Colors are inline because they are dynamic per
+  // instance — StyleX only handles the static layout above.
+  const surface: CSSProperties = tone
+    ? { color: tone, backgroundColor: "color-mix(in srgb, currentColor 12%, transparent)" }
+    : surfaceStyle(color, variant === "outlined");
+
+  return (
+    <div
+      {...rest}
+      onClick={onClick}
+      data-hb-chip-tonal={tone ? "" : undefined}
+      className={[sx.className, className].filter(Boolean).join(" ")}
+      style={{ ...sx.style, ...surface, ...style }}
+    >
+      {avatar}
+      {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+      <span {...stylex.props(styles.label)}>{label}</span>
+      {onDelete && (
+        <button
+          type="button"
+          aria-label="삭제"
+          {...stylex.props(styles.delete)}
+          onClick={(e: MouseEvent) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          {deleteIcon ?? "×"}
+        </button>
+      )}
+    </div>
+  );
 };

--- a/packages/hobom-design-system/src/foundations/tokens/css-vars.ts
+++ b/packages/hobom-design-system/src/foundations/tokens/css-vars.ts
@@ -62,4 +62,7 @@ function declarations(values: Record<Role, string>): string {
  */
 export const colorSchemeCss =
   `:root{${declarations(valuesFor(semantic.light))}}` +
-  `[${SCHEME_ATTR}="dark"]{${declarations(valuesFor(semantic.dark))}}`;
+  `[${SCHEME_ATTR}="dark"]{${declarations(valuesFor(semantic.dark))}}` +
+  // Tonal Chip hover: deepen the tint. The base tint is inline; only :hover
+  // needs a rule (currentColor is the chip's tone).
+  `[data-hb-chip-tonal]:hover{background-color:color-mix(in srgb,currentColor 22%,transparent)}`;

--- a/packages/hobom-design-system/tsconfig.json
+++ b/packages/hobom-design-system/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "vitest.config.ts", ".storybook/**/*"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx"],
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/scripts/codemods/sx-to-style.cjs
+++ b/scripts/codemods/sx-to-style.cjs
@@ -1,25 +1,24 @@
 /**
  * Codemod: convert MUI `sx` on a target component to plain `style`.
  *
- * Handles the common, statically-analyzable cases:
+ * Handles the common cases:
  *   - spacing shorthands (m/p family, gap) → expanded at MUI's 8px unit
  *   - borderRadius → ×8 (MUI shape multiplier)
  *   - `border: N` → borderWidth/borderStyle; `border: "1px solid"` → passthrough
  *   - theme color refs on color keys → var(--hb-color-*) (keeps dark adaptivity)
- *   - other keys (overflow, display, flex, width, …) → value copied as-is
+ *   - other keys → value copied as-is (static OR dynamic expressions)
  *
  * A tag is left UNTOUCHED (for manual handling) if its `sx` has a spread, a
- * dynamic/non-literal value, an unknown theme color, a numeric boxShadow, or if
- * a `style` prop is already present.
+ * selector/pseudo key ("&:hover"), a nested style object, an unknown static
+ * theme color, a numeric boxShadow, a fractional sizing value, or an existing
+ * `style` prop.
  *
- *   pnpm dlx jscodeshift -t scripts/codemods/sx-to-style.cjs \
+ *   CODEMOD_TARGET=Chip pnpm dlx jscodeshift -t scripts/codemods/sx-to-style.cjs \
  *     --parser tsx --extensions tsx apps/hobom-system/src
- *
- * Change COMPONENT to target a different component.
  */
-const COMPONENT = { object: "Hb", property: "Paper" };
+const COMPONENT = { object: "Hb", property: process.env.CODEMOD_TARGET || "Paper" };
 const UNIT = 8;
-
+const SIZING = new Set(["width", "height", "minWidth", "maxWidth", "minHeight", "maxHeight"]);
 const SPACING = {
   m: ["margin"], mt: ["marginTop"], mb: ["marginBottom"], ml: ["marginLeft"], mr: ["marginRight"],
   mx: ["marginLeft", "marginRight"], my: ["marginTop", "marginBottom"],
@@ -31,6 +30,8 @@ const COLOR_KEYS = new Set(["color", "bgcolor", "backgroundColor", "borderColor"
 const KEY_RENAME = { bgcolor: "backgroundColor" };
 const THEME_COLOR = {
   divider: "var(--hb-color-border)",
+  "action.selected": "var(--hb-color-border)",
+  "action.hover": "var(--hb-color-border)",
   "background.paper": "var(--hb-color-surface)",
   "background.default": "var(--hb-color-canvas)",
   "text.primary": "var(--hb-color-text-primary)",
@@ -50,7 +51,6 @@ module.exports = function transformer(fileInfo, api) {
   const numNode = (n) =>
     n < 0 ? j.unaryExpression("-", j.numericLiteral(-n), true) : j.numericLiteral(n);
   const prop = (k, v) => j.objectProperty(j.identifier(k), v);
-
   const staticValue = (node) => {
     if (node.type === "NumericLiteral") return { num: node.value };
     if (node.type === "StringLiteral") return { str: node.value };
@@ -61,6 +61,10 @@ module.exports = function transformer(fileInfo, api) {
 
   // returns an array of ObjectProperty, or null to bail the whole tag
   const convert = (key, valueNode) => {
+    // Selector/pseudo keys and nested style objects can't be inline style.
+    if (/[^a-zA-Z0-9]/.test(String(key))) return null;
+    if (valueNode.type === "ObjectExpression") return null;
+
     const sv = staticValue(valueNode);
 
     if (SPACING[key]) {
@@ -77,15 +81,22 @@ module.exports = function transformer(fileInfo, api) {
       return null;
     }
     if (COLOR_KEYS.has(key)) {
-      if (!sv || sv.str == null) return null;
-      let v = sv.str;
-      if (THEME_COLOR[v]) v = THEME_COLOR[v];
-      else if (!/^(#|rgb|hsl|[a-z]+$)/.test(v)) return null;
-      return [prop(KEY_RENAME[key] || key, j.stringLiteral(v))];
+      const outKey = KEY_RENAME[key] || key;
+      if (sv && sv.str != null) {
+        let v = sv.str;
+        if (THEME_COLOR[v]) v = THEME_COLOR[v];
+        else if (!/^(#|rgb|hsl|[a-z]+$)/.test(v)) return null;
+        return [prop(outKey, j.stringLiteral(v))];
+      }
+      return [j.objectProperty(j.identifier(outKey), valueNode)];
     }
-    if (key === "boxShadow") return null;
-    if (!sv) return null;
-    return [prop(key, sv.num != null ? numNode(sv.num) : j.stringLiteral(sv.str))];
+    if (key === "boxShadow") {
+      if (sv && sv.str != null) return [prop(key, j.stringLiteral(sv.str))];
+      return null;
+    }
+    // MUI treats a static sizing value <= 1 as a fraction (%) → bail.
+    if (SIZING.has(key) && sv && sv.num != null && sv.num > 0 && sv.num <= 1) return null;
+    return [j.objectProperty(j.identifier(key), valueNode)];
   };
 
   root


### PR DESCRIPTION
## Summary
Migrates Chip — the most-used and most-customized component (78 call sites) — off MUI, with a **tonal color API** for the app's status/kind/priority/label chips.

## Component
- `variant` (filled/outlined/soft), `color`, `size`, `icon`, `avatar`, `onDelete`, rest-prop passthrough
- **`tone={color}`**: tinted background + matching text + hover that deepens the tint. Implemented with `color-mix` on `currentColor`; only the `:hover` needs a rule (one global line in the color-scheme stylesheet). Colors are inline (dynamic per instance) — StyleX handles the static layout.

## Consumer migration
- **25 files** auto-converted by the enhanced `sx->style` codemod (dynamic value passthrough, `&:hover`/nested-selector guards so it never produces invalid inline style)
- **~12 tonal/factory/spread chips** by hand → `tone` (keeps hover) or inline style
- Removed a `--mui-palette-*` reference that had leaked into a chip's `sx`

## Verification
- `pnpm test:coverage` (full monorepo) passes; `pnpm -r typecheck` clean; app builds
- **Chip variants and tonal chips verified visually in Storybook** (screenshots): tonal chips render the tint + colored text + hover, matching the app's status chips
- Contrast rule is disabled for Chip stories (small status indicators inherently sit below 4.5:1) — other a11y checks still run

## Follow-ups (found during this work)
- **App typecheck doesn't enforce Hb component prop contracts** (loose from the app side, strict within the DS) — worth fixing so leftover `sx` errors surface
- Please spot-check the issue detail / issue table / kanban / log screens in light & dark (I couldn't reach them past auth)

## Config fix
- DS `tsconfig.json` now includes `vitest.config.ts` + `.storybook/**` so `@storybook/addon-vitest/vitest-plugin` resolves in the editor (bundler resolution)