### PR TITLE
fix: 앱 typecheck 계약 안전망 복구 (tsc -b)

### DIFF
--- a/apps/hobom-system/package.json
+++ b/apps/hobom-system/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "lint": "eslint",
     "format": "prettier . --write",
     "test": "vitest",
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hobom-grid/core": "^0.2.0",
+    "@stylexjs/stylex": "^0.19.0",
     "@hobom-grid/react": "^0.2.0",
     "@tiptap/extension-link": "^3.20.0",
     "@tiptap/extension-placeholder": "^3.20.0",

--- a/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
@@ -65,13 +65,18 @@ vi.mock("../api/daily-todo.mutations", () => ({
 
 const { useChangeDailyTodoCompleteStatus } = await import("./useChangeDailyTodoCompleteStatus");
 
+// The mock `useMutation` exposes the passed options as `_opts`; the real hook's
+// return type does not, so this typed accessor bridges the test-only shape.
+type MutationOpts = Record<string, (...args: unknown[]) => unknown>;
+const optsOf = (current: unknown): MutationOpts => (current as { _opts: MutationOpts })._opts;
+
 const makeTodo = (overrides: Partial<DailyTodoType> = {}): DailyTodoType =>
   ({
     id: "todo-1",
     title: "테스트 할일",
     date: "2026-03-08",
     reaction: null,
-    progress: "NOT_STARTED",
+    progress: "PROGRESS",
     cycle: "DAILY",
     owner: { id: "user-1", username: "test", nickname: "테스트" },
     category: { id: "cat-1", title: "기본", ownerId: "user-1" },
@@ -93,7 +98,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     it("이전 데이터를 저장하고 캐시를 업데이트한다", async () => {
       const todo = makeTodo();
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       const previous = { items: [makeTodo()] };
 
@@ -107,20 +112,20 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     });
 
     it("캐시의 progress를 새 status로 업데이트한다", async () => {
-      const todo = makeTodo({ id: "todo-1", progress: "NOT_STARTED" });
+      const todo = makeTodo({ id: "todo-1", progress: "PROGRESS" });
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       cancelQueriesMock.mockResolvedValue(undefined);
       getQueryDataMock.mockReturnValue({
-        items: [makeTodo({ id: "todo-1", progress: "NOT_STARTED" })],
+        items: [makeTodo({ id: "todo-1", progress: "PROGRESS" })],
       });
 
       await opts.onMutate({ status: "DONE" });
 
       const updater = setQueryDataMock.mock.calls[0][1];
       const updated = updater({
-        items: [makeTodo({ id: "todo-1", progress: "NOT_STARTED" })],
+        items: [makeTodo({ id: "todo-1", progress: "PROGRESS" })],
       });
 
       expect(updated.items[0].progress).toBe("DONE");
@@ -129,7 +134,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     it("old가 null이면 캐시를 변경하지 않는다", async () => {
       const todo = makeTodo();
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       cancelQueriesMock.mockResolvedValue(undefined);
       getQueryDataMock.mockReturnValue(null);
@@ -146,7 +151,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     it("이전 데이터로 롤백하고 에러 토스트를 표시한다", () => {
       const todo = makeTodo();
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
       const previousData = { items: [makeTodo()] };
 
       opts.onError(new Error("fail"), {}, { previousData });
@@ -162,7 +167,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     it("성공 토스트를 표시한다", () => {
       const todo = makeTodo();
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       opts.onSuccess();
 
@@ -176,7 +181,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
     it("쿼리를 invalidate한다", async () => {
       const todo = makeTodo();
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       await opts.onSettled();
 

--- a/apps/hobom-system/src/entities/daily-todo/model/useDeleteDailyTodo.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useDeleteDailyTodo.ts
@@ -20,7 +20,7 @@ export const useDeleteDailyTodo = () => {
   const dataLot = useDataLot();
   const { openUndoToast, openErrorToast } = useToast();
 
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const rollbackRef = useRef<(() => void) | null>(null);
 
   const date = Bom.pipe(getSelectedDate(query, now), formatDate);

--- a/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
+++ b/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
@@ -1,7 +1,6 @@
 // @vitest-environment happy-dom
 import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { HttpResponseType } from "@/shared/api";
 import type { IssueType } from "../api/issue.type";
 
 const mutateFnMock = vi.fn();
@@ -49,6 +48,11 @@ vi.mock("../api/issue.mutations", () => ({
 
 const { useTransitionIssue } = await import("./useTransitionIssue");
 
+// The mock `useMutation` exposes the passed options as `_opts`; the real hook's
+// return type does not, so this typed accessor bridges the test-only shape.
+type MutationOpts = Record<string, (...args: unknown[]) => unknown>;
+const optsOf = (current: unknown): MutationOpts => (current as { _opts: MutationOpts })._opts;
+
 const makeIssue = (overrides: Partial<IssueType> = {}): IssueType =>
   ({
     id: "issue-1",
@@ -77,18 +81,18 @@ describe("useTransitionIssue", () => {
   it("useMutation에 올바른 queryOption을 설정한다", () => {
     const { result } = renderHook(() => useTransitionIssue("proj-1"));
 
-    expect(result.current._opts).toBeDefined();
-    expect(result.current._opts.onMutate).toBeTypeOf("function");
-    expect(result.current._opts.onError).toBeTypeOf("function");
-    expect(result.current._opts.onSettled).toBeTypeOf("function");
+    expect(optsOf(result.current)).toBeDefined();
+    expect(optsOf(result.current).onMutate).toBeTypeOf("function");
+    expect(optsOf(result.current).onError).toBeTypeOf("function");
+    expect(optsOf(result.current).onSettled).toBeTypeOf("function");
   });
 
   describe("onMutate (optimistic update)", () => {
     it("쿼리를 취소하고 이전 데이터를 반환한다", async () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
-      const previous: HttpResponseType<IssueType[]> = {
+      const previous = {
         items: [makeIssue()],
       };
 
@@ -108,9 +112,9 @@ describe("useTransitionIssue", () => {
 
     it("캐시에 새 status를 즉시 반영한다", async () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
-      const original: HttpResponseType<IssueType[]> = {
+      const original = {
         items: [makeIssue({ id: "issue-1", status: "todo" })],
       };
 
@@ -127,7 +131,7 @@ describe("useTransitionIssue", () => {
 
     it("old가 없으면 캐시를 변경하지 않는다", async () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       getQueryDataMock.mockReturnValue(undefined);
       cancelQueriesMock.mockResolvedValue(undefined);
@@ -143,7 +147,7 @@ describe("useTransitionIssue", () => {
   describe("onError (rollback)", () => {
     it("이전 데이터로 롤백하고 에러 토스트를 띄운다", () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
       const previous = { items: [makeIssue()] };
 
       opts.onError(new Error("fail"), {}, { previous });
@@ -156,7 +160,7 @@ describe("useTransitionIssue", () => {
 
     it("context가 없으면 rollback을 건너뛴다", () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       opts.onError(new Error("fail"), {}, undefined);
 
@@ -168,7 +172,7 @@ describe("useTransitionIssue", () => {
   describe("onSettled", () => {
     it("issues 쿼리를 invalidate한다", async () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
-      const opts = result.current._opts;
+      const opts = optsOf(result.current);
 
       await opts.onSettled();
 

--- a/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
@@ -88,7 +88,11 @@ export const MenuRecommendationListItem = memo(function MenuRecommendationListIt
           }
         />
       </Hb.List.Item>
-      {showDivider && <Hb.Divider component="li" />}
+      {showDivider && (
+        <li>
+          <Hb.Divider />
+        </li>
+      )}
     </>
   );
 });

--- a/apps/hobom-system/src/entities/user/api/user.queries.ts
+++ b/apps/hobom-system/src/entities/user/api/user.queries.ts
@@ -3,7 +3,8 @@ import { CACHE_PROFILE } from "@/shared/config";
 import { fetchMe, fetchUsers, fetchUserById } from "./user.api";
 
 export const userQueries = {
-  users: () => queryOptions({ queryKey: ["users"] }),
+  // Key-only namespace (no fetch); consumed solely via `.queryKey`.
+  users: () => ({ queryKey: ["users"] }),
   me: () =>
     queryOptions({
       queryKey: [...userQueries.users().queryKey, "me"],

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorBodyCell.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorBodyCell.tsx
@@ -48,24 +48,7 @@ export const EndpointErrorBodyCell = ({ colKey, row, bg }: EndpointErrorBodyCell
     }
     case "path":
       return (
-        <Hb.Tooltip
-          title={row.path}
-          placement="bottom-start"
-          enterDelay={100}
-          slotProps={{
-            popper: {
-              modifiers: [{ name: "offset", options: { offset: [0, -8] } }],
-            },
-            tooltip: {
-              sx: {
-                fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
-                fontSize: 12,
-                maxWidth: 480,
-                wordBreak: "break-all",
-              },
-            },
-          }}
-        >
+        <Hb.Tooltip title={row.path} placement="bottom-start" enterDelay={100}>
           <div style={base}>
             <span
               style={{

--- a/apps/hobom-system/src/features/note/lib/note-form.lib.spec.ts
+++ b/apps/hobom-system/src/features/note/lib/note-form.lib.spec.ts
@@ -124,6 +124,7 @@ describe("fromNote", () => {
     checklistItems: [],
     color: "#fff475",
     labels: ["label-1", "label-2"],
+    members: [],
     reminder: null,
     isPinned: false,
     status: "ACTIVE",

--- a/apps/hobom-system/src/test/create-wrapper.tsx
+++ b/apps/hobom-system/src/test/create-wrapper.tsx
@@ -5,7 +5,6 @@ export const createTestDataLot = () =>
   new DataLot({
     defaultOptions: {
       queries: { retry: false },
-      mutations: { retry: false },
     },
   });
 

--- a/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.spec.ts
+++ b/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.spec.ts
@@ -24,16 +24,16 @@ vi.mock("@/entities/project", () => ({
       queryKey: ["projects", "detail", projectId],
     }),
   },
-  buildStatusesFromColumns: (cols: unknown[]) =>
-    cols.map((c: Record<string, unknown>, i: number) => ({
+  buildStatusesFromColumns: (cols: Record<string, unknown>[]) =>
+    cols.map((c, i) => ({
       id: c.statusId,
       name: c.name,
       isDone: false,
       order: i,
     })),
-  buildTransitionsFromColumns: (cols: unknown[]) =>
-    cols.flatMap((c: Record<string, unknown>) =>
-      (cols as Record<string, unknown>[])
+  buildTransitionsFromColumns: (cols: Record<string, unknown>[]) =>
+    cols.flatMap((c) =>
+      cols
         .filter((t) => t.statusId !== c.statusId)
         .map((t) => ({ from: c.statusId, to: t.statusId, name: "" })),
     ),

--- a/packages/hobom-data/src/core/data-lot.ts
+++ b/packages/hobom-data/src/core/data-lot.ts
@@ -22,20 +22,23 @@ export class DataLot {
     return this.queryCache.get<TData>(queryKey)?.getState().data;
   }
 
-  setQueryData<TData>(queryKey: QueryKey, updater: Updater<TData | undefined, TData>): TData {
+  setQueryData<TData>(
+    queryKey: QueryKey,
+    updater: Updater<TData | undefined, TData | undefined>,
+  ): TData | undefined {
     let query = this.queryCache.get<TData>(queryKey);
     const prevData = query?.getState().data;
 
     const newData =
       typeof updater === "function"
-        ? (updater as (old: TData | undefined) => TData)(prevData)
+        ? (updater as (old: TData | undefined) => TData | undefined)(prevData)
         : updater;
 
     if (!query) {
       query = this.queryCache.build<TData>(
         {
           queryKey,
-          queryFn: () => Promise.resolve(newData),
+          queryFn: () => Promise.resolve(newData as TData),
           staleTime: this.defaultOptions.queries?.staleTime,
           gcTime: this.defaultOptions.queries?.gcTime,
         },
@@ -44,7 +47,7 @@ export class DataLot {
       );
     }
 
-    query.setData(newData);
+    query.setData(newData as TData);
 
     return newData;
   }

--- a/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
@@ -14,7 +14,10 @@ const meta = {
   },
   argTypes: {
     variant: { control: "inline-radio", options: ["filled", "outlined", "soft"] },
-    color: { control: "inline-radio", options: ["default", "primary", "secondary"] },
+    color: {
+      control: "inline-radio",
+      options: ["default", "primary", "secondary", "success", "warning", "error"],
+    },
     size: { control: "inline-radio", options: ["small", "medium"] },
   },
 } satisfies Meta<typeof Chip>;
@@ -54,7 +57,13 @@ export const StatusChips: Story = {
             key={c.label}
             label={c.label}
             size="small"
-            style={{ height: 22, fontSize: 11, fontWeight: 700, backgroundColor: c.bg, color: c.fg }}
+            style={{
+              height: 22,
+              fontSize: 11,
+              fontWeight: 700,
+              backgroundColor: c.bg,
+              color: c.fg,
+            }}
           />
         ))}
       </div>

--- a/packages/hobom-design-system/src/components/Chip/Chip.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties, HTMLAttributes, MouseEvent, ReactElement, ReactNode
 import * as stylex from "@stylexjs/stylex";
 
 type ChipVariant = "filled" | "outlined" | "soft";
-type ChipColor = "default" | "primary" | "secondary";
+type ChipColor = "default" | "primary" | "secondary" | "success" | "warning" | "error";
 type ChipSize = "small" | "medium";
 
 interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, "color"> {
@@ -66,11 +66,17 @@ const COLORS = {
   default: "var(--hb-color-border)",
   primary: "var(--hb-color-accent)",
   secondary: "var(--hb-color-text-secondary)",
+  success: "var(--hb-color-success)",
+  warning: "var(--hb-color-warning)",
+  error: "var(--hb-color-danger)",
 } as const;
 const ON_FILLED = {
   default: "var(--hb-color-text-primary)",
   primary: "var(--hb-color-accent-contrast)",
   secondary: "var(--hb-color-accent-contrast)",
+  success: "var(--hb-color-accent-contrast)",
+  warning: "var(--hb-color-accent-contrast)",
+  error: "var(--hb-color-accent-contrast)",
 } as const;
 
 // Surface colors are inline (runtime-computed) so consumer `style` can override

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@hobom-grid/react':
         specifier: ^0.2.0
         version: 0.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@tiptap/extension-link':
         specifier: ^3.20.0
         version: 3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1)

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## 문제

`apps/hobom-system`의 `typecheck` 스크립트가 `tsc --noEmit`이었는데, 이 앱의 `tsconfig.json`은 solution 파일(`files: []`, `references: [...]`)이라 **비-build 모드의 `tsc --noEmit`은 아무 파일도 검사하지 않는 no-op**이었습니다.

그 결과 이관된 in-house 컴포넌트의 prop 계약 위반(예: 남은 `sx`, 잘못된 `Hb.Chip` color)이 CI에서 전혀 걸리지 않았고, 런타임에서야 발견됐습니다. (DS 패키지 내부는 strict, 앱 소비 지점은 loose)

## 수정

`typecheck`를 `tsc -b`로 교체 → 참조 프로젝트(app/node/spec)를 실제로 타입체크. 나머지 패키지들은 `include: ["src"]`라 기존 `tsc --noEmit`가 정상 동작하므로 그대로 둠 (no-op은 app 뿐이었음).

복구 후 드러난 잠재 타입 오류(누적 68건)를 정리:

| 클러스터 | 건수 | 조치 |
|---|---|---|
| `setQueryData` Updater 출력 타입 | 18 | undefined 반환 허용 (정상 optimistic 패턴) |
| spec `_opts` 접근 | 16 | mock 전용 타입 접근자 도입 |
| `Hb.Chip` color 계약 | 6 | success/warning/error 토큰 색 추가 |
| 불완전 fixture / 무효 enum / useRef 초기값 / Divider(li) / Tooltip 이관 / stylex 의존성 등 | 나머지 | 개별 보정 |

`Array.prototype.at` 등을 위해 `tsconfig.base` lib를 ES2022로 상향.

## 검증

- app / hobom-data / hobom-design-system 타입체크 **0 에러**
- 의도적 타입 오류 삽입 시 이제 정상적으로 검출됨(sanity 확인)
- hobom-data 82 tests, 영향 spec 49 tests 통과
- 변경 파일 lint 신규 경고 0