### PR TITLE
chore: eliminate all eslint warnings and enforce no-explicit-any

### DIFF
--- a/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
+++ b/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
@@ -49,6 +49,32 @@ const FriendsRow = ({ friends }: { friends: string[] }) => {
 
   const isLoading = friendQueries.some((q) => q.isLoading);
 
+  const renderFriends = () => {
+    if (friends.length === 0) {
+      return (
+        <Hb.Text variant="body2" sx={{ color: "text.disabled", fontSize: "0.8125rem" }}>
+          없음
+        </Hb.Text>
+      );
+    }
+    if (isLoading) {
+      return <Hb.Progress.Circular size={16} />;
+    }
+
+    return friendQueries.map((q, i) => (
+      <Hb.Chip
+        key={friends[i]}
+        label={q.data?.items.nickname ?? friends[i]}
+        size="small"
+        variant="outlined"
+        style={{
+          fontSize: "0.75rem",
+          height: 24,
+        }}
+      />
+    ));
+  };
+
   return (
     <Hb.Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
       <Hb.Box sx={{ color: "text.secondary", pt: 0.25 }}>
@@ -66,28 +92,7 @@ const FriendsRow = ({ friends }: { friends: string[] }) => {
           친구
         </Hb.Text>
         <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.25 }}>
-          {friends.length > 0 ? (
-            isLoading ? (
-              <Hb.Progress.Circular size={16} />
-            ) : (
-              friendQueries.map((q, i) => (
-                <Hb.Chip
-                  key={friends[i]}
-                  label={q.data?.items.nickname ?? friends[i]}
-                  size="small"
-                  variant="outlined"
-                  style={{
-                    fontSize: "0.75rem",
-                    height: 24,
-                  }}
-                />
-              ))
-            )
-          ) : (
-            <Hb.Text variant="body2" sx={{ color: "text.disabled", fontSize: "0.8125rem" }}>
-              없음
-            </Hb.Text>
-          )}
+          {renderFriends()}
         </Hb.Box>
       </Hb.Box>
     </Hb.Box>

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { AddCircle } from "hobom-design-system/icons";
 import { Bom } from "hobom-utils";
 import { Hb } from "@/shared/ui";
@@ -29,13 +29,14 @@ const AddTodoDialog = ({
   isOpen: boolean;
   onClose: () => void;
 }) => {
-  const { register, watch, reset, setValue } = useForm<{
+  const { register, getValues, control, reset, setValue } = useForm<{
     title: string;
     cycle: CycleType;
   }>({
     mode: "onChange",
     defaultValues: { cycle: "EVERYDAY" },
   });
+  const cycle = useWatch({ control, name: "cycle" });
   const { openWarnToast } = useToast();
   const { query } = useRouterQuery();
   const { mutate, isPending } = useCreateDailyTodo();
@@ -46,7 +47,7 @@ const AddTodoDialog = ({
   };
 
   const handleSubmit = () => {
-    const title = watch("title");
+    const title = getValues("title");
 
     Bom.pipe(
       title.trim(),
@@ -64,7 +65,7 @@ const AddTodoDialog = ({
         const now = getNow();
         const date = Bom.pipe(getSelectedDate(query, now), formatDate);
         const categoryId = Bom.prop("categoryId")(item);
-        const cycle = watch("cycle");
+        const cycle = getValues("cycle");
 
         mutate({
           title: t,
@@ -100,7 +101,7 @@ const AddTodoDialog = ({
           select
           label="반복 주기"
           size="small"
-          value={watch("cycle")}
+          value={cycle}
           onChange={(e) => setValue("cycle", e.target.value as CycleType)}
         >
           {CYCLE_OPTIONS.map((key) => (

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
-  const { register, watch } = useForm<{ title: string }>({
+  const { register, getValues } = useForm<{ title: string }>({
     defaultValues: { title: item.title },
   });
   const [editCategory, setEditCategory] = useState(item.category.id);
@@ -23,7 +23,7 @@ export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
   });
 
   const handleSubmit = () => {
-    const title = watch("title").trim();
+    const title = getValues("title").trim();
 
     if (Bom.isEmpty(title)) return;
     mutate({ id: item.id, title, category: editCategory }, { onSuccess: onClose });

--- a/apps/hobom-system/src/entities/issue/lib/issue-tree.lib.ts
+++ b/apps/hobom-system/src/entities/issue/lib/issue-tree.lib.ts
@@ -23,20 +23,31 @@ export const buildIssueTree = (issues: IssueType[]): IssueTreeResult => {
 
   const [children, roots] = Bom.pipe(issues, Bom.partition(hasParent));
 
+  // `children` is partitioned by `hasParent`, so every item has a parent present in `issueById`.
+  const childWithParent = children.flatMap((issue) => {
+    const parentId = issue.parent;
+
+    if (!parentId) return [];
+    const parent = issueById.get(parentId);
+
+    if (!parent) return [];
+
+    return [{ issue, parentId, parent }];
+  });
+
   const childrenMap = new Map(
     Bom.pipe(
-      children,
-      Bom.groupBy((i) => i.parent!),
+      childWithParent,
+      Bom.groupBy((c) => c.parentId),
       Object.entries,
+      Bom.map(
+        ([parentId, group]: [string, typeof childWithParent]) =>
+          [parentId, group.map((c) => c.issue)] as const,
+      ),
     ),
   );
 
-  const parentMap = new Map(
-    Bom.pipe(
-      children,
-      Bom.map((i) => [i.id, issueById.get(i.parent!)!] as const),
-    ),
-  );
+  const parentMap = new Map(childWithParent.map((c) => [c.issue.id, c.parent] as const));
 
   return { roots, childrenMap, parentMap };
 };

--- a/apps/hobom-system/src/entities/menu-recommendation/model/useTodayMenuIdContext.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/model/useTodayMenuIdContext.tsx
@@ -17,6 +17,9 @@ export const TodayMenuIdContextProvider = ({ children }: { children: ReactNode }
   );
 };
 
+// Context, provider, and hook are intentionally colocated; Fast Refresh is an
+// HMR heuristic that doesn't apply to this consumer hook export.
+// eslint-disable-next-line react-refresh/only-export-components
 export const useTodayMenuId = () => {
   const ctx = useContext(TodayMenuIdContext);
 

--- a/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
+++ b/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
@@ -13,6 +13,22 @@ import { Hb } from "@/shared/ui";
 import type { NoteItemType } from "../api/note.type";
 import type { NoteStatus } from "../model/note.model";
 
+const noteBorderColor = (hovered: boolean, isCustomColor: boolean): string => {
+  if (hovered) {
+    return isCustomColor ? "rgba(0,0,0,0.08)" : "transparent";
+  }
+
+  return isCustomColor ? "rgba(0,0,0,0.06)" : "divider";
+};
+
+const checklistTextColor = (isCustomColor: boolean, checked: boolean): string => {
+  if (isCustomColor) {
+    return checked ? "rgba(0,0,0,0.35)" : "rgba(0,0,0,0.65)";
+  }
+
+  return checked ? "text.disabled" : "text.secondary";
+};
+
 const metaChipStyle = (isCustomColor: boolean): CSSProperties => ({
   height: 24,
   fontSize: "0.6875rem",
@@ -57,13 +73,7 @@ export const NoteCard = ({
         backgroundColor: isCustomColor ? color : undefined,
         cursor: "pointer",
         border: "1px solid",
-        borderColor: hovered
-          ? isCustomColor
-            ? "rgba(0,0,0,0.08)"
-            : "transparent"
-          : isCustomColor
-            ? "rgba(0,0,0,0.06)"
-            : "divider",
+        borderColor: noteBorderColor(hovered, isCustomColor),
         borderRadius: 2,
         position: "relative",
         transition: "box-shadow 0.08s linear, border-color 0.08s linear",
@@ -188,13 +198,7 @@ export const NoteCard = ({
                     sx={{
                       fontSize: "0.8125rem",
                       textDecoration: item.checked ? "line-through" : "none",
-                      color: isCustomColor
-                        ? item.checked
-                          ? "rgba(0,0,0,0.35)"
-                          : "rgba(0,0,0,0.65)"
-                        : item.checked
-                          ? "text.disabled"
-                          : "text.secondary",
+                      color: checklistTextColor(isCustomColor, item.checked),
                       lineHeight: 1.4,
                     }}
                   >

--- a/apps/hobom-system/src/features/backlog-board/lib/backlog-group.lib.ts
+++ b/apps/hobom-system/src/features/backlog-board/lib/backlog-group.lib.ts
@@ -13,14 +13,14 @@ export const groupIssuesBySprint = (
 ): { sprintGroups: SprintGroup[]; backlogIssues: IssueType[] } => {
   const sprintIds = new Set(sprints.map((s) => s.id));
 
-  const [sprintIssues, backlogIssues] = Bom.pipe(
-    issues,
-    Bom.partition((issue: IssueType) => !!issue.sprint && sprintIds.has(issue.sprint)),
-  );
+  const isSprintIssue = (issue: IssueType): issue is IssueType & { sprint: string } =>
+    !!issue.sprint && sprintIds.has(issue.sprint);
+
+  const [sprintIssues, backlogIssues] = Bom.pipe(issues, Bom.partition(isSprintIssue));
 
   const grouped = Bom.pipe(
     sprintIssues,
-    Bom.groupBy((i: IssueType) => i.sprint!),
+    Bom.groupBy((i) => i.sprint),
   );
 
   const sprintGroups = sprints.map((sprint) => ({

--- a/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
@@ -55,6 +55,34 @@ export const IssueRow = ({
   const canAddChild = PARENT_ISSUE_KINDS.has(issue.type) && onCreateChildIssue;
   const showMenu = moveTargets.length > 0 || canAddChild;
 
+  const renderLeadingCell = () => {
+    if (childCount > 0 && onToggleCollapse) {
+      return (
+        <Hb.Button.Icon
+          size="small"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse(issue.id);
+          }}
+          sx={{ p: 0, ml: -0.5, color: "text.disabled" }}
+        >
+          {isCollapsed ? (
+            <ChevronRightOutlined sx={{ fontSize: 16 }} />
+          ) : (
+            <ExpandMoreOutlined sx={{ fontSize: 16 }} />
+          )}
+        </Hb.Button.Icon>
+      );
+    }
+    if (depth > 0) {
+      return (
+        <SubdirectoryArrowRightOutlined sx={{ fontSize: 14, color: "text.disabled", ml: -1.5 }} />
+      );
+    }
+
+    return null;
+  };
+
   return (
     <>
       <Hb.Box
@@ -74,24 +102,7 @@ export const IssueRow = ({
         }}
         onClick={() => onIssueClick?.(issue.id)}
       >
-        {childCount > 0 && onToggleCollapse ? (
-          <Hb.Button.Icon
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleCollapse(issue.id);
-            }}
-            sx={{ p: 0, ml: -0.5, color: "text.disabled" }}
-          >
-            {isCollapsed ? (
-              <ChevronRightOutlined sx={{ fontSize: 16 }} />
-            ) : (
-              <ExpandMoreOutlined sx={{ fontSize: 16 }} />
-            )}
-          </Hb.Button.Icon>
-        ) : depth > 0 ? (
-          <SubdirectoryArrowRightOutlined sx={{ fontSize: 14, color: "text.disabled", ml: -1.5 }} />
-        ) : null}
+        {renderLeadingCell()}
         <kind.Icon sx={{ fontSize: 16, color: kind.color }} />
         <Hb.Text
           variant="caption"

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
@@ -19,6 +19,17 @@ const LEVEL_COLOR: Record<string, { bg: string; text: string }> = {
   FATAL: { bg: "#f472b618", text: "#f472b6" },
 };
 
+const statusChipStyle = (statusCode: number): { bg: string; text: string } => {
+  if (statusCode >= 500) {
+    return { bg: "#f8717118", text: "#f87171" };
+  }
+  if (statusCode >= 400) {
+    return { bg: "#fb923c18", text: "#fb923c" };
+  }
+
+  return { bg: "#34d39918", text: "#34d399" };
+};
+
 interface LogEntryTableProps {
   data: LogEntry[];
 }
@@ -66,6 +77,7 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
               bg: "#f3f4f6",
               text: "#6b7280",
             };
+            const statusStyle = statusChipStyle(row.statusCode);
 
             return (
               <Hb.Table.Row key={row.id} hover>
@@ -130,19 +142,9 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                       fontSize: 11,
                       fontWeight: 600,
 
-                      backgroundColor:
-                        row.statusCode >= 500
-                          ? "#f8717118"
-                          : row.statusCode >= 400
-                            ? "#fb923c18"
-                            : "#34d39918",
+                      backgroundColor: statusStyle.bg,
 
-                      color:
-                        row.statusCode >= 500
-                          ? "#f87171"
-                          : row.statusCode >= 400
-                            ? "#fb923c"
-                            : "#34d399",
+                      color: statusStyle.text,
                     }}
                   />
                 </Hb.Table.Cell>

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
@@ -19,11 +19,63 @@ export const DlqDetailDialog = ({
   isRetrying,
 }: DlqDetailDialogProps) => {
   const { data, isLoading } = useQuery({
-    ...dlqQueries.detail(dlqKey!),
+    ...dlqQueries.detail(dlqKey ?? ""),
     enabled: open && dlqKey !== null,
   });
 
   const detail = data?.items;
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <Hb.Progress.Circular size={28} />
+        </Hb.Box>
+      );
+    }
+
+    if (!detail) return null;
+
+    return (
+      <>
+        <Hb.Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+          <Hb.Text variant="body2" sx={{ fontWeight: 600, minWidth: 40, color: "text.secondary" }}>
+            Key
+          </Hb.Text>
+          <Hb.Text
+            variant="body2"
+            sx={{
+              wordBreak: "break-all",
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: 12,
+            }}
+          >
+            {detail.key}
+          </Hb.Text>
+        </Hb.Box>
+
+        <Hb.Text variant="body2" sx={{ fontWeight: 600, color: "text.secondary", mb: 1 }}>
+          Payload
+        </Hb.Text>
+        <Hb.Box
+          component="pre"
+          sx={{
+            p: 2,
+            borderRadius: 1,
+            bgcolor: "action.hover",
+            fontSize: 12,
+            fontFamily: "'JetBrains Mono', monospace",
+            overflow: "auto",
+            maxHeight: 400,
+            whiteSpace: "pre",
+            m: 0,
+          }}
+        >
+          {JSON.stringify(detail.payload, null, 2)}
+        </Hb.Box>
+      </>
+    );
+  };
 
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="md">
@@ -42,54 +94,7 @@ export const DlqDetailDialog = ({
         </Hb.Button.Icon>
       </Hb.Dialog.Title>
 
-      <Hb.Dialog.Content dividers>
-        {isLoading ? (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-            <Hb.Progress.Circular size={28} />
-          </Hb.Box>
-        ) : detail ? (
-          <>
-            <Hb.Box sx={{ display: "flex", gap: 1, mb: 2 }}>
-              <Hb.Text
-                variant="body2"
-                sx={{ fontWeight: 600, minWidth: 40, color: "text.secondary" }}
-              >
-                Key
-              </Hb.Text>
-              <Hb.Text
-                variant="body2"
-                sx={{
-                  wordBreak: "break-all",
-                  fontFamily: "'JetBrains Mono', monospace",
-                  fontSize: 12,
-                }}
-              >
-                {detail.key}
-              </Hb.Text>
-            </Hb.Box>
-
-            <Hb.Text variant="body2" sx={{ fontWeight: 600, color: "text.secondary", mb: 1 }}>
-              Payload
-            </Hb.Text>
-            <Hb.Box
-              component="pre"
-              sx={{
-                p: 2,
-                borderRadius: 1,
-                bgcolor: "action.hover",
-                fontSize: 12,
-                fontFamily: "'JetBrains Mono', monospace",
-                overflow: "auto",
-                maxHeight: 400,
-                whiteSpace: "pre",
-                m: 0,
-              }}
-            >
-              {JSON.stringify(detail.payload, null, 2)}
-            </Hb.Box>
-          </>
-        ) : null}
-      </Hb.Dialog.Content>
+      <Hb.Dialog.Content dividers>{renderContent()}</Hb.Dialog.Content>
 
       <Hb.Dialog.Actions>
         <Hb.Button variant="secondary" onClick={onClose}>

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
@@ -16,6 +16,82 @@ export const DlqManagementContent = () => {
     });
   };
 
+  const renderTable = () => {
+    if (isLoading) {
+      return (
+        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <Hb.Progress.Circular size={28} />
+        </Hb.Box>
+      );
+    }
+
+    if (items.length === 0) {
+      return (
+        <Hb.Text variant="body2" color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
+          DLQ 항목이 없습니다
+        </Hb.Text>
+      );
+    }
+
+    return (
+      <Hb.Table.Container sx={{ maxHeight: "calc(100vh - 280px)", overflow: "auto" }}>
+        <Hb.Table.Root stickyHeader size="small">
+          <Hb.Table.Head>
+            <Hb.Table.Row>
+              <Hb.Table.Cell
+                sx={{
+                  fontWeight: 600,
+                  fontSize: 11,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.04em",
+                }}
+              >
+                Key
+              </Hb.Table.Cell>
+              <Hb.Table.Cell sx={{ width: 100 }} align="center">
+                액션
+              </Hb.Table.Cell>
+            </Hb.Table.Row>
+          </Hb.Table.Head>
+          <Hb.Table.Body>
+            {items.map((key) => (
+              <Hb.Table.Row
+                key={key}
+                hover
+                sx={{ cursor: "pointer" }}
+                onClick={() => setSelectedKey(key)}
+              >
+                <Hb.Table.Cell
+                  sx={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 12,
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {key}
+                </Hb.Table.Cell>
+                <Hb.Table.Cell align="center">
+                  <Hb.Tooltip title="재시도 처리">
+                    <Hb.Button.Icon
+                      size="small"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRetry(key);
+                      }}
+                      disabled={retryMutation.isPending}
+                    >
+                      <Replay sx={{ fontSize: 16 }} />
+                    </Hb.Button.Icon>
+                  </Hb.Tooltip>
+                </Hb.Table.Cell>
+              </Hb.Table.Row>
+            ))}
+          </Hb.Table.Body>
+        </Hb.Table.Root>
+      </Hb.Table.Container>
+    );
+  };
+
   return (
     <Hb.Box sx={{ p: 3 }}>
       {/* Header */}
@@ -59,71 +135,7 @@ export const DlqManagementContent = () => {
       </Hb.Box>
 
       {/* Table */}
-      {isLoading ? (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-          <Hb.Progress.Circular size={28} />
-        </Hb.Box>
-      ) : items.length === 0 ? (
-        <Hb.Text variant="body2" color="text.secondary" sx={{ py: 4, textAlign: "center" }}>
-          DLQ 항목이 없습니다
-        </Hb.Text>
-      ) : (
-        <Hb.Table.Container sx={{ maxHeight: "calc(100vh - 280px)", overflow: "auto" }}>
-          <Hb.Table.Root stickyHeader size="small">
-            <Hb.Table.Head>
-              <Hb.Table.Row>
-                <Hb.Table.Cell
-                  sx={{
-                    fontWeight: 600,
-                    fontSize: 11,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.04em",
-                  }}
-                >
-                  Key
-                </Hb.Table.Cell>
-                <Hb.Table.Cell sx={{ width: 100 }} align="center">
-                  액션
-                </Hb.Table.Cell>
-              </Hb.Table.Row>
-            </Hb.Table.Head>
-            <Hb.Table.Body>
-              {items.map((key) => (
-                <Hb.Table.Row
-                  key={key}
-                  hover
-                  sx={{ cursor: "pointer" }}
-                  onClick={() => setSelectedKey(key)}
-                >
-                  <Hb.Table.Cell
-                    sx={{
-                      fontFamily: "'JetBrains Mono', monospace",
-                      fontSize: 12,
-                      wordBreak: "break-all",
-                    }}
-                  >
-                    {key}
-                  </Hb.Table.Cell>
-                  <Hb.Table.Cell align="center">
-                    <Hb.Tooltip title="재시도 처리">
-                      <Hb.Button.Icon
-                        size="small"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleRetry(key);
-                        }}
-                        disabled={retryMutation.isPending}
-                      >
-                        <Replay sx={{ fontSize: 16 }} />
-                      </Hb.Button.Icon>
-                    </Hb.Tooltip>
-                  </Hb.Table.Cell>
-                </Hb.Table.Row>
-              ))}
-            </Hb.Table.Body>
-          </Hb.Table.Root>
-        </Hb.Table.Container>
-      )}
+      {renderTable()}
 
       {/* Detail Dialog */}
       <DlqDetailDialog

--- a/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
@@ -3,6 +3,11 @@ import { COLUMNS, type ColKey, HEADER_BG, HEADER_TEXT } from "./issue-list-const
 import type { useColumnResize } from "@hobom-grid/react";
 import type { CellVM } from "@hobom-grid/core";
 
+const ALIGN_JUSTIFY: Record<string, string | undefined> = {
+  right: "flex-end",
+  center: "center",
+};
+
 interface HeaderCellProps {
   cell: CellVM;
   sortKey: ColKey | null;
@@ -21,6 +26,18 @@ export const HeaderCell = ({
   const col = COLUMNS[cell.colIndex];
   const isSorted = sortKey === col.key;
 
+  const renderSortIcon = () => {
+    if (!isSorted) {
+      return <UnfoldMore sx={{ fontSize: 14 }} />;
+    }
+
+    return sortDir === "asc" ? (
+      <ArrowUpward sx={{ fontSize: 14 }} />
+    ) : (
+      <ArrowDownward sx={{ fontSize: 14 }} />
+    );
+  };
+
   return (
     <div
       style={{
@@ -37,8 +54,7 @@ export const HeaderCell = ({
         boxSizing: "border-box",
         userSelect: "none",
         cursor: col.sortable ? "pointer" : "default",
-        justifyContent:
-          col.align === "right" ? "flex-end" : col.align === "center" ? "center" : undefined,
+        justifyContent: ALIGN_JUSTIFY[col.align],
         gap: 4,
       }}
       onPointerDown={(e) => {
@@ -51,15 +67,7 @@ export const HeaderCell = ({
       <span>{col.label}</span>
       {col.sortable && (
         <span style={{ display: "inline-flex", opacity: isSorted ? 1 : 0.3 }}>
-          {isSorted ? (
-            sortDir === "asc" ? (
-              <ArrowUpward sx={{ fontSize: 14 }} />
-            ) : (
-              <ArrowDownward sx={{ fontSize: 14 }} />
-            )
-          ) : (
-            <UnfoldMore sx={{ fontSize: 14 }} />
-          )}
+          {renderSortIcon()}
         </span>
       )}
       <div

--- a/apps/hobom-system/src/features/note/lib/note-form.lib.spec.ts
+++ b/apps/hobom-system/src/features/note/lib/note-form.lib.spec.ts
@@ -41,8 +41,8 @@ describe("textToChecklist", () => {
     const result = textToChecklist("사과\n\n\n바나나");
 
     expect(result).toHaveLength(2);
-    expect(result[0]!.text).toBe("사과");
-    expect(result[1]!.text).toBe("바나나");
+    expect(result[0]?.text).toBe("사과");
+    expect(result[1]?.text).toBe("바나나");
   });
 
   it("공백만 있는 줄을 필터링한다", () => {

--- a/apps/hobom-system/src/features/note/lib/partition-notes.lib.spec.ts
+++ b/apps/hobom-system/src/features/note/lib/partition-notes.lib.spec.ts
@@ -86,7 +86,7 @@ describe("partitionNotes", () => {
 
     partitionNotesLib(notes);
 
-    expect(notes[0]!.id).toBe(original[0]!.id);
-    expect(notes[1]!.id).toBe(original[1]!.id);
+    expect(notes[0]?.id).toBe(original[0]?.id);
+    expect(notes[1]?.id).toBe(original[1]?.id);
   });
 });

--- a/apps/hobom-system/src/features/note/model/useNoteForm.spec.ts
+++ b/apps/hobom-system/src/features/note/model/useNoteForm.spec.ts
@@ -105,8 +105,8 @@ describe("useNoteForm", () => {
 
       expect(result.current.form.type).toBe("CHECKLIST");
       expect(result.current.form.checklistItems).toHaveLength(2);
-      expect(result.current.form.checklistItems[0]!.text).toBe("사과");
-      expect(result.current.form.checklistItems[1]!.text).toBe("바나나");
+      expect(result.current.form.checklistItems[0]?.text).toBe("사과");
+      expect(result.current.form.checklistItems[1]?.text).toBe("바나나");
       expect(result.current.form.content).toBe("");
     });
 
@@ -117,7 +117,7 @@ describe("useNoteForm", () => {
 
       expect(result.current.form.type).toBe("CHECKLIST");
       expect(result.current.form.checklistItems).toHaveLength(1);
-      expect(result.current.form.checklistItems[0]!.text).toBe("");
+      expect(result.current.form.checklistItems[0]?.text).toBe("");
     });
 
     it("CHECKLIST → TEXT: 체크리스트를 텍스트로 변환한다", () => {
@@ -151,7 +151,7 @@ describe("useNoteForm", () => {
       act(() => result.current.toggleType());
       act(() => result.current.updateChecklistItem(0, "text", "할 일"));
 
-      expect(result.current.form.checklistItems[0]!.text).toBe("할 일");
+      expect(result.current.form.checklistItems[0]?.text).toBe("할 일");
     });
 
     it("updateChecklistItem: 특정 아이템의 checked를 업데이트한다", () => {
@@ -160,7 +160,7 @@ describe("useNoteForm", () => {
       act(() => result.current.toggleType());
       act(() => result.current.updateChecklistItem(0, "checked", true));
 
-      expect(result.current.form.checklistItems[0]!.checked).toBe(true);
+      expect(result.current.form.checklistItems[0]?.checked).toBe(true);
     });
 
     it("removeChecklistItem: 특정 인덱스의 아이템을 제거한다", () => {
@@ -174,8 +174,8 @@ describe("useNoteForm", () => {
       act(() => result.current.removeChecklistItem(1));
 
       expect(result.current.form.checklistItems).toHaveLength(2);
-      expect(result.current.form.checklistItems[0]!.text).toBe("A");
-      expect(result.current.form.checklistItems[1]!.text).toBe("C");
+      expect(result.current.form.checklistItems[0]?.text).toBe("A");
+      expect(result.current.form.checklistItems[1]?.text).toBe("C");
     });
   });
 
@@ -216,7 +216,7 @@ describe("useNoteForm", () => {
       act(() => result.current.setReminder("2026-03-01", "WEEKLY"));
 
       expect(result.current.form.reminder).not.toBeNull();
-      expect(result.current.form.reminder!.recurrence).toBe("WEEKLY");
+      expect(result.current.form.reminder?.recurrence).toBe("WEEKLY");
     });
 
     it("clearReminder: 리마인더를 제거한다", () => {
@@ -286,7 +286,7 @@ describe("useNoteForm", () => {
       // index 1은 빈 텍스트
 
       expect(result.current.filteredChecklist).toHaveLength(1);
-      expect(result.current.filteredChecklist![0]!.text).toBe("유효");
+      expect(result.current.filteredChecklist?.[0]?.text).toBe("유효");
     });
 
     it("필터링 후 order가 재인덱싱된다", () => {
@@ -297,7 +297,7 @@ describe("useNoteForm", () => {
       // 중간 아이템(B)을 비운다
       act(() => result.current.updateChecklistItem(1, "text", ""));
 
-      expect(result.current.filteredChecklist!.map((i) => i.order)).toEqual([0, 1]);
+      expect(result.current.filteredChecklist?.map((i) => i.order)).toEqual([0, 1]);
     });
   });
 });

--- a/apps/hobom-system/src/features/note/model/useNoteMemberShare.ts
+++ b/apps/hobom-system/src/features/note/model/useNoteMemberShare.ts
@@ -31,7 +31,10 @@ export const useNoteMemberShare = ({ open, note }: UseNoteMemberShareParams) => 
     ],
   });
 
-  const liveMembers = noteDetailData?.items?.members ?? note?.members ?? [];
+  const liveMembers = useMemo(
+    () => noteDetailData?.items?.members ?? note?.members ?? [],
+    [noteDetailData?.items?.members, note?.members],
+  );
 
   const usersMap = useMemo(
     () => new Map((usersData?.items ?? []).map((u: UserType) => [u.id, u])),

--- a/apps/hobom-system/src/features/note/ui/ColorPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ColorPickerPopover.tsx
@@ -2,6 +2,14 @@ import { Check } from "hobom-design-system/icons";
 import { NOTE_COLORS } from "@/entities/note";
 import { Hb } from "@/shared/ui";
 
+const swatchBorderColor = (selected: boolean, isWhite: boolean): string => {
+  if (selected) {
+    return "primary.main";
+  }
+
+  return isWhite ? "#dadce0" : "transparent";
+};
+
 interface ColorPickerPopoverProps {
   anchorEl: HTMLElement | null;
   onClose: () => void;
@@ -40,7 +48,7 @@ export const ColorPickerPopover = ({
               borderRadius: "50%",
               backgroundColor: hex,
               border: "2px solid",
-              borderColor: selected ? "primary.main" : isWhite ? "#dadce0" : "transparent",
+              borderColor: swatchBorderColor(selected, isWhite),
               p: 0,
               minWidth: 0,
               "&:hover": {

--- a/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
@@ -31,6 +31,56 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
     threshold: 100,
   });
 
+  const renderList = () => {
+    if (isPending) {
+      return (
+        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <Hb.Progress.Circular size={24} />
+        </Hb.Box>
+      );
+    }
+    if (notifications.length === 0) {
+      return (
+        <Hb.Box
+          sx={{
+            py: 6,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 1,
+          }}
+        >
+          <NotificationsNoneOutlined sx={{ fontSize: 40, color: "text.disabled" }} />
+          <Hb.Text variant="body2" sx={{ color: "text.disabled" }}>
+            {EMPTY_MESSAGES[filter]}
+          </Hb.Text>
+        </Hb.Box>
+      );
+    }
+
+    return (
+      <>
+        {notifications.map((notification) => (
+          <NotificationItem
+            key={notification.id}
+            notification={notification}
+            onClick={(n: NotificationItemType) => {
+              if (!n.isRead) {
+                markRead.mutate(n.id);
+              }
+              onClose();
+            }}
+          />
+        ))}
+        {isFetchingNextPage && (
+          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+            <Hb.Progress.Circular size={20} />
+          </Hb.Box>
+        )}
+      </>
+    );
+  };
+
   return (
     <Hb.Popover
       open={Boolean(anchorEl)}
@@ -88,46 +138,7 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
             "linear-gradient(to bottom, transparent, black 12px, black calc(100% - 12px), transparent)",
         }}
       >
-        {isPending ? (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
-            <Hb.Progress.Circular size={24} />
-          </Hb.Box>
-        ) : notifications.length === 0 ? (
-          <Hb.Box
-            sx={{
-              py: 6,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: 1,
-            }}
-          >
-            <NotificationsNoneOutlined sx={{ fontSize: 40, color: "text.disabled" }} />
-            <Hb.Text variant="body2" sx={{ color: "text.disabled" }}>
-              {EMPTY_MESSAGES[filter]}
-            </Hb.Text>
-          </Hb.Box>
-        ) : (
-          <>
-            {notifications.map((notification) => (
-              <NotificationItem
-                key={notification.id}
-                notification={notification}
-                onClick={(n: NotificationItemType) => {
-                  if (!n.isRead) {
-                    markRead.mutate(n.id);
-                  }
-                  onClose();
-                }}
-              />
-            ))}
-            {isFetchingNextPage && (
-              <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-                <Hb.Progress.Circular size={20} />
-              </Hb.Box>
-            )}
-          </>
-        )}
+        {renderList()}
       </Hb.Box>
       <Hb.Divider />
       <Hb.Box sx={{ px: 2, py: 1.5, textAlign: "center" }}>

--- a/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
@@ -18,6 +18,7 @@ const Inner = () => {
   const navigate = useNavigate();
   const { todayMenuId } = useTodayMenuId();
   const { handler, status } = useSelectTodayMenu();
+  const { mutate: selectTodayMenu } = handler;
   const { data } = useQuery({
     ...menuQueries.selectedTodayMenu({ id: String(todayMenuId) }),
     enabled: todayMenuId != null && status === "done" && handler.status === "success",
@@ -27,8 +28,8 @@ const Inner = () => {
     if (todayMenuId == null) {
       return;
     }
-    handler.mutate({ id: todayMenuId });
-  }, [todayMenuId]);
+    selectTodayMenu({ id: todayMenuId });
+  }, [todayMenuId, selectTodayMenu]);
 
   const showProgressCircle =
     todayMenuId == null || status === "loading" || handler.isPending || data == null;

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
@@ -90,6 +90,25 @@ const FillBlankInput = ({
   </Hb.Stack>
 );
 
+const choiceBorderColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
+  if (revealed) {
+    if (isAnswer) return "success.main";
+    if (selected) return "error.main";
+
+    return "divider";
+  }
+
+  return selected ? "primary.main" : "divider";
+};
+
+const choiceBgColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
+  if (!revealed) return "transparent";
+  if (isAnswer) return "success.50";
+  if (selected) return "error.50";
+
+  return "transparent";
+};
+
 const MultipleChoiceInput = ({
   choices,
   value,
@@ -142,22 +161,8 @@ const MultipleChoiceInput = ({
             py: 0.5,
             borderRadius: 1,
             border: 1,
-            borderColor: revealed
-              ? isAnswer
-                ? "success.main"
-                : selected
-                  ? "error.main"
-                  : "divider"
-              : selected
-                ? "primary.main"
-                : "divider",
-            bgcolor: revealed
-              ? isAnswer
-                ? "success.50"
-                : selected
-                  ? "error.50"
-                  : "transparent"
-              : "transparent",
+            borderColor: choiceBorderColor(revealed, isAnswer, selected),
+            bgcolor: choiceBgColor(revealed, isAnswer, selected),
           }}
         />
       );
@@ -169,6 +174,13 @@ const QUIZ_TYPE_LABEL: Record<string, string> = {
   OX: "OX 퀴즈",
   FILL_BLANK: "빈칸 채우기",
   MULTIPLE_CHOICE: "객관식",
+};
+
+const scoreMessage = (score: number, total: number): string => {
+  if (score === total) return "완벽합니다!";
+  if (score >= total * 0.7) return "잘했습니다!";
+
+  return "다시 도전해보세요.";
 };
 
 export const ExamQuestionCard = ({ questions }: Props) => {
@@ -199,11 +211,7 @@ export const ExamQuestionCard = ({ questions }: Props) => {
             {score} / {total}
           </Hb.Text>
           <Hb.Text variant="body2" color="text.secondary" gutterBottom>
-            {score === total
-              ? "완벽합니다!"
-              : score >= total * 0.7
-                ? "잘했습니다!"
-                : "다시 도전해보세요."}
+            {scoreMessage(score, total)}
           </Hb.Text>
           <Hb.Button variant="secondary" startIcon={<Replay />} onClick={reset} sx={{ mt: 2 }}>
             다시 풀기

--- a/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
@@ -90,6 +90,25 @@ const FillBlankInput = ({
   </Hb.Stack>
 );
 
+const choiceBorderColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
+  if (revealed) {
+    if (isAnswer) return "success.main";
+    if (selected) return "error.main";
+
+    return "divider";
+  }
+
+  return selected ? "primary.main" : "divider";
+};
+
+const choiceBgColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
+  if (!revealed) return "transparent";
+  if (isAnswer) return "success.50";
+  if (selected) return "error.50";
+
+  return "transparent";
+};
+
 const MultipleChoiceInput = ({
   choices,
   value,
@@ -142,22 +161,8 @@ const MultipleChoiceInput = ({
             py: 0.5,
             borderRadius: 1,
             border: 1,
-            borderColor: revealed
-              ? isAnswer
-                ? "success.main"
-                : selected
-                  ? "error.main"
-                  : "divider"
-              : selected
-                ? "primary.main"
-                : "divider",
-            bgcolor: revealed
-              ? isAnswer
-                ? "success.50"
-                : selected
-                  ? "error.50"
-                  : "transparent"
-              : "transparent",
+            borderColor: choiceBorderColor(revealed, isAnswer, selected),
+            bgcolor: choiceBgColor(revealed, isAnswer, selected),
           }}
         />
       );
@@ -169,6 +174,13 @@ const QUIZ_TYPE_LABEL: Record<string, string> = {
   OX: "OX 퀴즈",
   FILL_BLANK: "빈칸 채우기",
   MULTIPLE_CHOICE: "객관식",
+};
+
+const scoreMessage = (score: number, total: number): string => {
+  if (score === total) return "완벽합니다!";
+  if (score >= total * 0.7) return "잘했습니다!";
+
+  return "다시 도전해보세요.";
 };
 
 export const QuizCard = ({ quizzes }: Props) => {
@@ -199,11 +211,7 @@ export const QuizCard = ({ quizzes }: Props) => {
             {score} / {total}
           </Hb.Text>
           <Hb.Text variant="body2" color="text.secondary" gutterBottom>
-            {score === total
-              ? "완벽합니다!"
-              : score >= total * 0.7
-                ? "잘했습니다!"
-                : "다시 도전해보세요."}
+            {scoreMessage(score, total)}
           </Hb.Text>
           <Hb.Button variant="secondary" startIcon={<Replay />} onClick={reset} sx={{ mt: 2 }}>
             다시 풀기

--- a/apps/hobom-system/src/features/send-future-message/ui/GridBodyCell.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/GridBodyCell.tsx
@@ -15,24 +15,20 @@ interface Props {
   onDelete: (id: string) => void;
 }
 
+const cellPadding = (colKey: ColKey): string => {
+  if (colKey === "rowNum") return "0 0 0 16px";
+  if (colKey === "actions") return "0 8px";
+
+  return "0 16px";
+};
+
 export const GridBodyCell = ({ colKey, row, bodyIndex, onEdit, onDelete }: Props) => {
   const bg = bodyIndex % 2 === 0 ? COLORS.rowEven : COLORS.rowOdd;
   const isPending = isPendingMessageSendStatus(row.sendStatus);
 
-  return (
-    <div
-      style={{
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        padding: colKey === "rowNum" ? "0 0 0 16px" : colKey === "actions" ? "0 8px" : "0 16px",
-        backgroundColor: bg,
-        borderBottom: `1px solid ${COLORS.border}`,
-        boxSizing: "border-box",
-        justifyContent: colKey === "actions" ? "center" : "flex-start",
-      }}
-    >
-      {colKey === "rowNum" ? (
+  const renderContent = () => {
+    if (colKey === "rowNum") {
+      return (
         <span
           style={{
             fontSize: 12,
@@ -43,7 +39,11 @@ export const GridBodyCell = ({ colKey, row, bodyIndex, onEdit, onDelete }: Props
         >
           {String(bodyIndex + 1).padStart(2, "0")}
         </span>
-      ) : colKey === "title" ? (
+      );
+    }
+
+    if (colKey === "title") {
+      return (
         <div
           style={{
             display: "flex",
@@ -79,7 +79,11 @@ export const GridBodyCell = ({ colKey, row, bodyIndex, onEdit, onDelete }: Props
             {String(row.content ?? "")}
           </span>
         </div>
-      ) : colKey === "scheduledAt" ? (
+      );
+    }
+
+    if (colKey === "scheduledAt") {
+      return (
         <div
           style={{
             display: "flex",
@@ -107,31 +111,52 @@ export const GridBodyCell = ({ colKey, row, bodyIndex, onEdit, onDelete }: Props
             {formatTime(row.scheduledAt)}
           </span>
         </div>
-      ) : colKey === "actions" ? (
-        <FutureMessageRowActions row={row} onEdit={onEdit} onDelete={onDelete} />
-      ) : (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 5,
-            padding: "4px 12px",
-            borderRadius: 20,
-            fontSize: 11,
-            fontWeight: 600,
-            backgroundColor: isPending ? COLORS.pendingBg : COLORS.sentBg,
-            color: isPending ? COLORS.pendingText : COLORS.sentText,
-            whiteSpace: "nowrap",
-          }}
-        >
-          {isPending ? (
-            <ScheduleIcon style={{ fontSize: 13 }} />
-          ) : (
-            <CheckCircleIcon style={{ fontSize: 13 }} />
-          )}
-          {isPending ? "발송 대기" : "발송 완료"}
-        </span>
-      )}
+      );
+    }
+
+    if (colKey === "actions") {
+      return <FutureMessageRowActions row={row} onEdit={onEdit} onDelete={onDelete} />;
+    }
+
+    return (
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          padding: "4px 12px",
+          borderRadius: 20,
+          fontSize: 11,
+          fontWeight: 600,
+          backgroundColor: isPending ? COLORS.pendingBg : COLORS.sentBg,
+          color: isPending ? COLORS.pendingText : COLORS.sentText,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {isPending ? (
+          <ScheduleIcon style={{ fontSize: 13 }} />
+        ) : (
+          <CheckCircleIcon style={{ fontSize: 13 }} />
+        )}
+        {isPending ? "발송 대기" : "발송 완료"}
+      </span>
+    );
+  };
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        padding: cellPadding(colKey),
+        backgroundColor: bg,
+        borderBottom: `1px solid ${COLORS.border}`,
+        boxSizing: "border-box",
+        justifyContent: colKey === "actions" ? "center" : "flex-start",
+      }}
+    >
+      {renderContent()}
     </div>
   );
 };

--- a/apps/hobom-system/src/features/wiki-page-comments/lib/build-comment-tree.lib.ts
+++ b/apps/hobom-system/src/features/wiki-page-comments/lib/build-comment-tree.lib.ts
@@ -13,7 +13,9 @@ export const buildCommentTree = (comments: CommentType[]): CommentTreeNode[] => 
   }
 
   for (const comment of comments) {
-    const node = map.get(comment.id)!;
+    const node = map.get(comment.id);
+
+    if (!node) continue;
 
     if (comment.parentCommentId) {
       const parent = map.get(comment.parentCommentId);

--- a/apps/hobom-system/src/main.tsx
+++ b/apps/hobom-system/src/main.tsx
@@ -4,7 +4,11 @@ import App from "./App";
 
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+
+if (!rootElement) throw new Error("root element not found");
+
+createRoot(rootElement).render(
   <BrowserRouter>
     <App />
   </BrowserRouter>,

--- a/apps/hobom-system/src/pages/privacy-law-exam-detail/ui/PrivacyLawExamDetailPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-exam-detail/ui/PrivacyLawExamDetailPage.tsx
@@ -6,8 +6,8 @@ import { privacyLawQueries } from "@/entities/privacy-law";
 import { ExamQuestionCard } from "@/features/privacy-law-exam";
 
 const ExamDetail = () => {
-  const { examId } = useParams<{ examId: string }>();
-  const { data } = useSuspenseQuery(privacyLawQueries.exam(examId!));
+  const { examId = "" } = useParams<{ examId: string }>();
+  const { data } = useSuspenseQuery(privacyLawQueries.exam(examId));
   const exam = data.items;
 
   return (

--- a/apps/hobom-system/src/shared/api/auth.middleware.spec.ts
+++ b/apps/hobom-system/src/shared/api/auth.middleware.spec.ts
@@ -21,6 +21,12 @@ vi.mock("./csrf.middleware", () => ({
   }),
 }));
 
+const { onResponse } = authMiddleware;
+
+if (onResponse === undefined) {
+  throw new Error("authMiddleware.onResponse is not defined");
+}
+
 const createCtx = (status: number): MiddlewareContext => ({
   input: "https://api.test/some-path",
   init: {
@@ -39,7 +45,7 @@ describe("authMiddleware.onResponse", () => {
   it("401이 아닌 응답은 무시한다", async () => {
     const ctx = createCtx(200);
 
-    await authMiddleware.onResponse!(ctx);
+    await onResponse(ctx);
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -57,7 +63,7 @@ describe("authMiddleware.onResponse", () => {
 
     const ctx = createCtx(401);
 
-    await authMiddleware.onResponse!(ctx);
+    await onResponse(ctx);
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     // 첫 번째 호출: refresh
@@ -76,7 +82,7 @@ describe("authMiddleware.onResponse", () => {
 
     const ctx = createCtx(401);
 
-    await authMiddleware.onResponse!(ctx);
+    await onResponse(ctx);
 
     expect(eventSpy).toHaveBeenCalledOnce();
 
@@ -88,20 +94,20 @@ describe("authMiddleware.onResponse", () => {
     mockFetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
     const ctx1 = createCtx(401);
 
-    await authMiddleware.onResponse!(ctx1);
+    await onResponse(ctx1);
 
     mockFetch.mockReset();
 
     // 두 번째: dispatch 안 함
     const ctx2 = createCtx(401);
 
-    await authMiddleware.onResponse!(ctx2);
+    await onResponse(ctx2);
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("동시 401 요청이 하나의 refresh만 수행한다", async () => {
-    let refreshResolve: (value: Response) => void;
+    let refreshResolve: ((value: Response) => void) | undefined;
     const refreshPromise = new Promise<Response>((resolve) => {
       refreshResolve = resolve;
     });
@@ -117,10 +123,10 @@ describe("authMiddleware.onResponse", () => {
     const ctx1 = createCtx(401);
     const ctx2 = createCtx(401);
 
-    const p1 = authMiddleware.onResponse!(ctx1);
-    const p2 = authMiddleware.onResponse!(ctx2);
+    const p1 = onResponse(ctx1);
+    const p2 = onResponse(ctx2);
 
-    refreshResolve!(new Response(null, { status: 200 }));
+    refreshResolve?.(new Response(null, { status: 200 }));
 
     await Promise.all([p1, p2]);
 
@@ -136,7 +142,7 @@ describe("authMiddleware.onResponse", () => {
 
     const ctx = createCtx(401);
 
-    await authMiddleware.onResponse!(ctx);
+    await onResponse(ctx);
 
     const retryInit = mockFetch.mock.calls[1][1] as RequestInit;
     const headers = retryInit.headers as Record<string, string>;

--- a/apps/hobom-system/src/shared/model/useBottomSheetCTA.tsx
+++ b/apps/hobom-system/src/shared/model/useBottomSheetCTA.tsx
@@ -38,15 +38,16 @@ export const BottomSheetCTAProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const processNext = () => {
-    if (queue.current.length > 0) {
-      const next = queue.current.shift()!;
+    const next = queue.current.shift();
 
-      setSheet(next);
-      setOpen(true);
-      isShowing.current = true;
-    } else {
+    if (next === undefined) {
       isShowing.current = false;
+
+      return;
     }
+    setSheet(next);
+    setOpen(true);
+    isShowing.current = true;
   };
 
   const onOpen = useCallback((options: SheetOptions) => {
@@ -84,6 +85,9 @@ export const BottomSheetCTAProvider = ({ children }: { children: ReactNode }) =>
   );
 };
 
+// Context, provider, and hook are intentionally colocated; Fast Refresh is an
+// HMR heuristic that doesn't apply to this consumer hook export.
+// eslint-disable-next-line react-refresh/only-export-components
 export const useBottomSheetCTA = () => {
   const ctx = useContext(BottomSheetCTAContext);
 

--- a/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
+++ b/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
@@ -18,6 +18,69 @@ export const NotificationCenter = () => {
     handleMarkRead,
   } = useNotificationCenter();
 
+  const renderGroups = () => {
+    if (isPending) {
+      return (
+        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <Hb.Progress.Circular size={28} />
+        </Hb.Box>
+      );
+    }
+    if (dateGroups.length === 0) {
+      return (
+        <Hb.Box
+          sx={{
+            py: 8,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 1.5,
+          }}
+        >
+          <NotificationsNoneOutlined sx={{ fontSize: 48, color: "text.disabled" }} />
+          <Hb.Text variant="body2" sx={{ color: "text.disabled", fontSize: "0.875rem" }}>
+            {EMPTY_MESSAGES[filter]}
+          </Hb.Text>
+        </Hb.Box>
+      );
+    }
+
+    return (
+      <>
+        {dateGroups.map((group) => (
+          <Hb.Box key={group.label}>
+            <Hb.Box sx={{ px: 2, py: 1, bgcolor: "rgba(0,0,0,0.02)" }}>
+              <Hb.Text
+                variant="caption"
+                sx={{
+                  fontWeight: 600,
+                  fontSize: "0.6875rem",
+                  color: "text.secondary",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
+                {group.label}
+              </Hb.Text>
+            </Hb.Box>
+            {group.items.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onClick={handleMarkRead}
+              />
+            ))}
+          </Hb.Box>
+        ))}
+        {isFetchingNextPage && (
+          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+            <Hb.Progress.Circular size={24} />
+          </Hb.Box>
+        )}
+      </>
+    );
+  };
+
   return (
     <Hb.Box sx={{ p: 3, maxWidth: 800, mx: "auto" }}>
       <Hb.Box sx={{ mb: 2.5 }}>
@@ -61,59 +124,7 @@ export const NotificationCenter = () => {
             ...SUBTLE_SCROLLBAR_SX,
           }}
         >
-          {isPending ? (
-            <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
-              <Hb.Progress.Circular size={28} />
-            </Hb.Box>
-          ) : dateGroups.length === 0 ? (
-            <Hb.Box
-              sx={{
-                py: 8,
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: 1.5,
-              }}
-            >
-              <NotificationsNoneOutlined sx={{ fontSize: 48, color: "text.disabled" }} />
-              <Hb.Text variant="body2" sx={{ color: "text.disabled", fontSize: "0.875rem" }}>
-                {EMPTY_MESSAGES[filter]}
-              </Hb.Text>
-            </Hb.Box>
-          ) : (
-            <>
-              {dateGroups.map((group) => (
-                <Hb.Box key={group.label}>
-                  <Hb.Box sx={{ px: 2, py: 1, bgcolor: "rgba(0,0,0,0.02)" }}>
-                    <Hb.Text
-                      variant="caption"
-                      sx={{
-                        fontWeight: 600,
-                        fontSize: "0.6875rem",
-                        color: "text.secondary",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.05em",
-                      }}
-                    >
-                      {group.label}
-                    </Hb.Text>
-                  </Hb.Box>
-                  {group.items.map((notification) => (
-                    <NotificationItem
-                      key={notification.id}
-                      notification={notification}
-                      onClick={handleMarkRead}
-                    />
-                  ))}
-                </Hb.Box>
-              ))}
-              {isFetchingNextPage && (
-                <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-                  <Hb.Progress.Circular size={24} />
-                </Hb.Box>
-              )}
-            </>
-          )}
+          {renderGroups()}
         </Hb.Box>
       </Hb.Paper>
     </Hb.Box>

--- a/apps/hobom-system/src/widgets/wiki-space-layout/model/useWikiSpaceLayout.ts
+++ b/apps/hobom-system/src/widgets/wiki-space-layout/model/useWikiSpaceLayout.ts
@@ -11,7 +11,7 @@ interface CreateDialogState {
 }
 
 export const useWikiSpaceLayout = () => {
-  const { spaceKey, pageId } = useParams<{
+  const { spaceKey = "", pageId } = useParams<{
     spaceKey: string;
     pageId: string;
   }>();
@@ -22,7 +22,7 @@ export const useWikiSpaceLayout = () => {
   });
   const createPage = useCreatePage();
 
-  const { data } = useSuspenseQuery(wikiSpaceQueries.detail(spaceKey!));
+  const { data } = useSuspenseQuery(wikiSpaceQueries.detail(spaceKey));
   const space = data.items;
 
   const handleNavigateToWiki = useCallback(() => {
@@ -43,7 +43,7 @@ export const useWikiSpaceLayout = () => {
   const handleCreatePage = (title: string) => {
     createPage.mutate(
       {
-        spaceKey: spaceKey!,
+        spaceKey,
         title,
         content: "",
         parentPageId: createDialog.parentPageId,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ import stylistic from "@stylistic/eslint-plugin";
  * export default tseslint.config(...baseConfig, { … });
  */
 export const baseIgnores = {
-  ignores: ["**/dist", "**/coverage", "**/node_modules"],
+  ignores: ["**/dist", "**/coverage", "**/node_modules", "**/storybook-static"],
 };
 
 export const baseConfig = {

--- a/packages/hobom-data/eslint.config.js
+++ b/packages/hobom-data/eslint.config.js
@@ -20,6 +20,8 @@ export default tseslint.config(baseIgnores, {
     ...baseConfig.rules,
     ...reactHooks.configs.recommended.rules,
     "react-hooks/refs": "off",
-    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    // Library source (context + provider + hook colocated); Fast Refresh is an
+    // app-HMR heuristic that doesn't apply to published package source.
+    "react-refresh/only-export-components": "off",
   },
 });

--- a/packages/hobom-data/src/core/mutation.ts
+++ b/packages/hobom-data/src/core/mutation.ts
@@ -54,7 +54,7 @@ export class Mutation<TData = unknown, TError = Error, TVariables = void, TConte
         error: null,
       };
 
-      await this.options.onSuccess?.(data, variables, context!);
+      await this.options.onSuccess?.(data, variables, context);
       await this.options.onSettled?.(data, null, variables, context);
 
       return data;

--- a/packages/hobom-data/src/core/query-cache.ts
+++ b/packages/hobom-data/src/core/query-cache.ts
@@ -41,8 +41,10 @@ export class QueryCache {
   findAll(filters?: QueryFilters): Query[] {
     if (!filters?.queryKey) return [...this.queries.values()];
 
+    const { queryKey } = filters;
+
     return [...this.queries.values()].filter((query) =>
-      partialMatchKey(filters.queryKey!, query.queryKey),
+      partialMatchKey(queryKey, query.queryKey),
     );
   }
 

--- a/packages/hobom-data/src/core/query.spec.ts
+++ b/packages/hobom-data/src/core/query.spec.ts
@@ -95,11 +95,11 @@ describe("Query", () => {
   });
 
   it("cancel()이 AbortController를 abort한다", async () => {
-    let receivedSignal: AbortSignal | null = null;
+    const captured: { signal: AbortSignal | null } = { signal: null };
 
     const query = createQuery({
       queryFn: ({ signal }) => {
-        receivedSignal = signal;
+        captured.signal = signal;
 
         return new Promise((_, reject) => {
           signal.addEventListener("abort", () => reject(new Error("aborted")));
@@ -111,7 +111,7 @@ describe("Query", () => {
 
     query.cancel();
 
-    expect(receivedSignal!.aborted).toBe(true);
+    expect(captured.signal?.aborted).toBe(true);
     await expect(promise).rejects.toThrow("aborted");
   });
 

--- a/packages/hobom-data/src/core/query.ts
+++ b/packages/hobom-data/src/core/query.ts
@@ -107,11 +107,14 @@ export class Query<TData = unknown, TError = Error> extends Subscribable {
   private async executeFetch(): Promise<TData> {
     const maxRetries = this.options.retry === false ? 0 : (this.options.retry ?? DEFAULT_MAX_RETRY);
 
+    this.abortController ??= new AbortController();
+    const { signal } = this.abortController;
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const rawData = await this.options.queryFn({
           queryKey: this.queryKey,
-          signal: this.abortController!.signal,
+          signal,
         });
 
         const data = replaceEqualDeep(this.state.data, rawData) as TData;

--- a/packages/hobom-data/src/core/types.ts
+++ b/packages/hobom-data/src/core/types.ts
@@ -45,7 +45,11 @@ export interface MutationOptions<
   mutationKey?: QueryKey;
   mutationFn: (variables: TVariables) => Promise<TData>;
   onMutate?: (variables: TVariables) => Promise<TContext> | TContext;
-  onSuccess?: (data: TData, variables: TVariables, context: TContext) => Promise<unknown> | unknown;
+  onSuccess?: (
+    data: TData,
+    variables: TVariables,
+    context: TContext | undefined,
+  ) => Promise<unknown> | unknown;
   onError?: (
     error: TError,
     variables: TVariables,

--- a/packages/hobom-data/src/react/infinite-query-observer.ts
+++ b/packages/hobom-data/src/react/infinite-query-observer.ts
@@ -171,8 +171,8 @@ export class InfiniteQueryObserver<TData = unknown, TPageParam = unknown> extend
     const data = state.data ?? undefined;
     const lastPage = data ? data.pages[data.pages.length - 1] : undefined;
     const hasNextPage =
-      lastPage !== undefined
-        ? this.options.getNextPageParam(lastPage, data!.pages) !== undefined
+      lastPage !== undefined && data !== undefined
+        ? this.options.getNextPageParam(lastPage, data.pages) !== undefined
         : false;
 
     return {

--- a/packages/hobom-data/src/react/use-queries.ts
+++ b/packages/hobom-data/src/react/use-queries.ts
@@ -69,7 +69,7 @@ export function useQueries<
     cachedResultsRef.current = buildResults();
   }
 
-  const getSnapshot = () => cachedResultsRef.current!;
+  const getSnapshot = () => cachedResultsRef.current ?? buildResults();
 
   useSyncExternalStore(subscribeAll, getSnapshot, getSnapshot);
 

--- a/packages/hobom-data/src/react/use-suspense-queries.ts
+++ b/packages/hobom-data/src/react/use-suspense-queries.ts
@@ -82,7 +82,7 @@ export function useSuspenseQueries<
     cachedResultsRef.current = buildResults();
   }
 
-  const getSnapshot = () => cachedResultsRef.current!;
+  const getSnapshot = () => cachedResultsRef.current ?? buildResults();
 
   useSyncExternalStore(subscribeAll, getSnapshot, getSnapshot);
 

--- a/packages/hobom-design-system/eslint.config.js
+++ b/packages/hobom-design-system/eslint.config.js
@@ -20,7 +20,10 @@ export default tseslint.config(baseIgnores, {
     ...baseConfig.rules,
     ...reactHooks.configs.recommended.rules,
     "react-hooks/refs": "off",
-    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    // The compound-component API (`export const Card = { Root, Content, ... }`)
+    // exports namespace objects, which this Fast-Refresh heuristic can't
+    // recognize. The pattern is intentional, so the rule is off for the library.
+    "react-refresh/only-export-components": "off",
   },
 }, {
   // The public barrel must stay engine-free. Components may wrap the engine

--- a/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.stories.tsx
@@ -23,6 +23,7 @@ const meta = {
 } satisfies Meta<typeof Chip>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Filled: Story = { args: { color: "primary" } };
@@ -50,6 +51,7 @@ export const StatusChips: Story = {
       { label: "GET", bg: "#2ca87f18", fg: "#2ca87f" },
       { label: "3/5 완료", bg: "#e8f5e9", fg: "#2ca87f" },
     ];
+
     return (
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         {chips.map((c) => (

--- a/packages/hobom-design-system/src/components/Chip/Chip.tsx
+++ b/packages/hobom-design-system/src/components/Chip/Chip.tsx
@@ -2,7 +2,9 @@ import type { CSSProperties, HTMLAttributes, MouseEvent, ReactElement, ReactNode
 import * as stylex from "@stylexjs/stylex";
 
 type ChipVariant = "filled" | "outlined" | "soft";
+
 type ChipColor = "default" | "primary" | "secondary" | "success" | "warning" | "error";
+
 type ChipSize = "small" | "medium";
 
 interface ChipProps extends Omit<HTMLAttributes<HTMLDivElement>, "color"> {
@@ -84,8 +86,10 @@ const ON_FILLED = {
 function surfaceStyle(color: ChipColor, outlined: boolean): CSSProperties {
   if (outlined) {
     const line = color === "default" ? "var(--hb-color-border)" : COLORS[color];
+
     return { backgroundColor: "transparent", borderColor: line, color: line };
   }
+
   return { backgroundColor: COLORS[color], color: ON_FILLED[color] };
 }
 

--- a/packages/hobom-design-system/src/components/Paper/Paper.stories.tsx
+++ b/packages/hobom-design-system/src/components/Paper/Paper.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
 } satisfies Meta<typeof Paper>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Elevation: Story = {};

--- a/packages/hobom-design-system/src/components/Paper/Paper.tsx
+++ b/packages/hobom-design-system/src/components/Paper/Paper.tsx
@@ -28,6 +28,7 @@ const styles = stylex.create({
 function elevationStyle(elevation: number) {
   if (elevation <= 0) return styles.elev0;
   if (elevation === 1) return styles.elev1;
+
   return styles.elev2;
 }
 

--- a/packages/hobom-design-system/src/components/index.ts
+++ b/packages/hobom-design-system/src/components/index.ts
@@ -9,7 +9,6 @@ import { TextField } from "./TextField";
 import { Chip } from "./Chip";
 import { Dialog } from "./Dialog";
 import { Card } from "./Card";
-
 // Batch 2 — passthrough
 import { Tooltip } from "./Tooltip";
 import { Avatar } from "./Avatar";
@@ -26,7 +25,6 @@ import { Collapse } from "./Collapse";
 import { InputBase } from "./InputBase";
 import { Drawer } from "./Drawer";
 import { ToggleButton } from "./ToggleButton";
-
 // Batch 2 — compound
 import { Progress } from "./Progress";
 import { Menu } from "./Menu";
@@ -36,7 +34,6 @@ import { Form } from "./Form";
 import { Table } from "./Table";
 import { Radio } from "./Radio";
 import { Accordion } from "./Accordion";
-
 // Batch 2 — infra
 import { CssBaseline, GlobalStyles, ThemeProvider } from "./Infra";
 

--- a/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
@@ -108,7 +108,7 @@ const NavList = ({
         const hasChildren = item.children && item.children.length > 0;
         const isGroupOpen = openGroups.has(item.value);
         const isActive = item.value === activeValue;
-        const isChildActive = hasChildren && item.children!.some((c) => c.value === activeValue);
+        const isChildActive = item.children?.some((c) => c.value === activeValue) ?? false;
 
         const button = (
           <ListItemButton
@@ -161,7 +161,7 @@ const NavList = ({
           return (
             <Box key={item.value}>
               {wrappedButton}
-              {item.children!.map((child) => {
+              {item.children?.map((child) => {
                 const childActive = child.value === activeValue;
 
                 return (
@@ -189,7 +189,7 @@ const NavList = ({
             {wrappedButton}
             <Collapse in={isGroupOpen} unmountOnExit>
               <List disablePadding>
-                {item.children!.map((child) => {
+                {item.children?.map((child) => {
                   const childActive = child.value === activeValue;
 
                   return (

--- a/packages/hobom-schema/eslint.config.js
+++ b/packages/hobom-schema/eslint.config.js
@@ -5,6 +5,5 @@ export default tseslint.config(baseIgnores, {
   ...baseConfig,
   rules: {
     ...baseConfig.rules,
-    "@typescript-eslint/no-explicit-any": "warn",
   },
 });

--- a/packages/hobom-utils/eslint.config.js
+++ b/packages/hobom-utils/eslint.config.js
@@ -5,8 +5,6 @@ export default tseslint.config(baseIgnores, {
   ...baseConfig,
   rules: {
     ...baseConfig.rules,
-    // noname 라이브러리 소스 — 제네릭 유틸리티 특성상 any 허용
-    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/ban-ts-comment": [
       "error",
       {

--- a/packages/hobom-utils/src/core/types/inferGuardType.ts
+++ b/packages/hobom-utils/src/core/types/inferGuardType.ts
@@ -1,3 +1,6 @@
-export type InferGuardType<T, Fallback = never> = T extends (x: any, ...rest: any) => x is infer U
+// Matches any type-predicate function to infer its guarded type. The predicate
+// parameter must be `any` (a narrower type breaks the `x is U` constraint).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type InferGuardType<T, Fallback = never> = T extends (x: any, ...rest: any[]) => x is infer U
   ? U
   : Fallback;

--- a/packages/hobom-utils/src/core/types/lazy.type.ts
+++ b/packages/hobom-utils/src/core/types/lazy.type.ts
@@ -7,6 +7,8 @@ interface LazyMeta {
 }
 
 export interface LazyDefinition {
+  // Lazy factory of any arity; see curry.ts for why `any` args are required here.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly lazy: LazyMeta & ((...args: any) => LazyFn);
   readonly lazyArgs: readonly unknown[];
 }

--- a/packages/hobom-utils/src/packages/curry/curry.ts
+++ b/packages/hobom-utils/src/packages/curry/curry.ts
@@ -11,8 +11,12 @@ import type { Evaluator } from "../../core/types/evaluator.type";
  * @category Function
  */
 export function curry(
+  // Accepts a function of any arity and calls it with collected args; `unknown[]`
+  // args would be uncallable and `never[]` would reject real functions.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fn: (...args: any) => unknown,
   args: readonly unknown[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   lazy?: (...args: any) => Evaluator,
 ) {
   const diff = fn.length - args.length;

--- a/packages/hobom-utils/src/packages/groupBy/groupBy.ts
+++ b/packages/hobom-utils/src/packages/groupBy/groupBy.ts
@@ -32,10 +32,7 @@ function groupByImpl<T>(
   for (const [index, item] of data.entries()) {
     const key = fn(item, index, data);
 
-    if (result[key] === undefined) {
-      result[key] = [];
-    }
-    result[key]!.push(item);
+    (result[key] ??= []).push(item);
   }
 
   return result;

--- a/packages/hobom-utils/src/packages/pipe/pipe.ts
+++ b/packages/hobom-utils/src/packages/pipe/pipe.ts
@@ -170,8 +170,11 @@ export function pipe<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(
 ): P;
 export function pipe(
   input: unknown,
+  // Operations accept the running value whose type is only known to the typed
+  // overloads above; `unknown` here would break param contravariance.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...operations: readonly (LazyOp | ((value: any) => unknown))[]
-): any {
+): unknown {
   let output = input;
 
   const lazyOperations = operations.map((op) =>
@@ -184,9 +187,11 @@ export function pipe(
     const lazyOperation = lazyOperations[operationIndex];
 
     if (lazyOperation === undefined || !isIterable(output)) {
-      const operation = operations[operationIndex]!;
+      const operation = operations[operationIndex];
 
-      output = operation(output);
+      if (operation !== undefined) {
+        output = operation(output);
+      }
       operationIndex += 1;
 
       continue;
@@ -218,7 +223,7 @@ export function pipe(
       }
     }
 
-    const { isSingle } = lazySequence.at(-1)!;
+    const isSingle = lazySequence.at(-1)?.isSingle ?? false;
 
     output = isSingle ? accumulator[0] : accumulator;
     operationIndex += lazySequence.length;
@@ -239,7 +244,7 @@ function processItem(
   }
 
   let currentItem = item;
-  let lazyResult: LazyResult<any> = { done: false, hasNext: false };
+  let lazyResult: LazyResult<unknown> = { done: false, hasNext: false };
   let isDone = false;
 
   for (const [operationsIndex, lazyFn] of lazySequence.entries()) {

--- a/packages/hobom-utils/src/packages/sortBy/sortBy.ts
+++ b/packages/hobom-utils/src/packages/sortBy/sortBy.ts
@@ -23,6 +23,9 @@ function sortByImpl<T>(data: readonly T[], fn: (item: T) => number | string): T[
     const ka = fn(a);
     const kb = fn(b);
 
-    return ka < kb ? -1 : ka > kb ? 1 : 0;
+    if (ka < kb) return -1;
+    if (ka > kb) return 1;
+
+    return 0;
   });
 }

--- a/packages/hobom-utils/src/packages/when/when.ts
+++ b/packages/hobom-utils/src/packages/when/when.ts
@@ -21,7 +21,7 @@ import type { InferGuardType } from "../../core/types/inferGuardType";
  */
 export function when<
   T,
-  ExtraArgs extends any[],
+  ExtraArgs extends unknown[],
   Predicate extends (data: T, ...extraArgs: ExtraArgs) => boolean,
   OnTrue extends (data: InferGuardType<Predicate, T>, ...extraArgs: ExtraArgs) => unknown,
 >(
@@ -30,7 +30,7 @@ export function when<
 ): (data: T, ...extraArgs: ExtraArgs) => Exclude<T, InferGuardType<Predicate>> | ReturnType<OnTrue>;
 export function when<
   T,
-  ExtraArgs extends any[],
+  ExtraArgs extends unknown[],
   Predicate extends (data: T, ...extraArgs: ExtraArgs) => boolean,
   OnTrue extends (data: InferGuardType<Predicate, T>, ...extraArgs: ExtraArgs) => unknown,
   OnFalse extends (data: Exclude<T, InferGuardType<Predicate>>, ...extraArgs: ExtraArgs) => unknown,
@@ -43,7 +43,7 @@ export function when<
 ): (data: T, ...extraArgs: ExtraArgs) => ReturnType<OnFalse> | ReturnType<OnTrue>;
 export function when<
   T,
-  ExtraArgs extends any[],
+  ExtraArgs extends unknown[],
   Predicate extends (data: T, ...extraArgs: ExtraArgs) => boolean,
   OnTrue extends (data: InferGuardType<Predicate, T>, ...extraArgs: ExtraArgs) => unknown,
 >(
@@ -54,7 +54,7 @@ export function when<
 ): Exclude<T, InferGuardType<Predicate>> | ReturnType<OnTrue>;
 export function when<
   T,
-  ExtraArgs extends any[],
+  ExtraArgs extends unknown[],
   Predicate extends (data: T, ...extraArgs: ExtraArgs) => boolean,
   OnTrue extends (data: InferGuardType<Predicate, T>, ...extraArgs: ExtraArgs) => unknown,
   OnFalse extends (data: Exclude<T, InferGuardType<Predicate>>, ...extraArgs: ExtraArgs) => unknown,
@@ -78,7 +78,7 @@ export function when(...args: readonly unknown[]): unknown {
   return whenImpl(...args);
 }
 
-function whenImpl<T, ExtraArgs extends any[], WhenTrue, WhenFalse>(
+function whenImpl<T, ExtraArgs extends unknown[], WhenTrue, WhenFalse>(
   data: T,
   predicate: (data: T, ...extraArgs: ExtraArgs) => boolean,
   onTrueOrBranches:


### PR DESCRIPTION
Brings the entire monorepo to **zero ESLint warnings** and makes `any` a hard error everywhere. 161 warnings → 0.

## Config decisions
- **`any` blocked**: removed the `no-explicit-any: warn` overrides in `hobom-utils` / `hobom-schema` so they inherit the root `error`.
- **`react-refresh/only-export-components` off for the two libraries** (`hobom-design-system`, `hobom-data`): the compound-component API (`export const Card = { Root, ... }`) and colocated context files export namespace objects the Fast-Refresh heuristic can't recognize. It is an app-HMR concern, not applicable to published library source. **Rule stays on for the app.**
- **Ignore `storybook-static`**: never lint generated build output (was contributing 13 phantom warnings).

## Source fixes by rule
| Rule | Count | How |
|---|---|---|
| no-non-null-assertion | 52 | narrowing guards / optional chaining / `??` / captured const — no `as` dodges |
| no-nested-ternary | 28 | extracted to named helpers or lookup maps; value mappings unchanged |
| no-explicit-any (utils) | 13 | safe retypes to `unknown`; only the genuinely-variadic combinator fn params keep `any` with a justified disable |
| react-hooks (deps / incompatible-library / react-refresh) | 7 | `watch()`→`getValues()` in handlers, reactive read→`useWatch()`, memoized `liveMembers`, stabilized effect deps |

Also relaxed `MutationOptions.onSuccess` context to `TContext | undefined` (consistent with onError/onSettled; honest since context comes from optional `onMutate`).

The two app context+hook files (`useBottomSheetCTA`, `useTodayMenuIdContext`) keep the react-refresh rule but carry a justified per-line disable on the hook export — the Provider+hook colocation is intentional.

## Verification
- All 5 packages: **0 lint problems**
- `hobom-system` `tsc -b`: **0 errors**
- Tests: app **582**, hobom-data **82**, hobom-utils **90** — all green