### PR TITLE
fix: keep React contexts Fast Refresh-safe (stale-context error)

### DIFF
--- a/apps/hobom-system/src/entities/menu-recommendation/index.ts
+++ b/apps/hobom-system/src/entities/menu-recommendation/index.ts
@@ -8,7 +8,8 @@ import {
   validateTodayMenuInput,
   validateMenuRecommendationInput,
 } from "./model/validate-menu-recommendation.model";
-import { useTodayMenuId, TodayMenuIdContextProvider } from "./model/useTodayMenuIdContext";
+import { useTodayMenuId } from "./model/useTodayMenuIdContext";
+import { TodayMenuIdContextProvider } from "./model/TodayMenuIdContextProvider";
 import type { AddMenuRecommendationInput } from "./model/menu-recommendation.model";
 import type { MenuRecommendationType } from "./api/menu-recommendation.type";
 

--- a/apps/hobom-system/src/entities/menu-recommendation/model/TodayMenuIdContextProvider.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/model/TodayMenuIdContextProvider.tsx
@@ -1,0 +1,12 @@
+import { useState, type ReactNode } from "react";
+import { TodayMenuIdContext } from "./useTodayMenuIdContext";
+
+export const TodayMenuIdContextProvider = ({ children }: { children: ReactNode }) => {
+  const [todayMenuId, setTodayMenuId] = useState<string | null>(null);
+
+  return (
+    <TodayMenuIdContext.Provider value={{ todayMenuId, setTodayMenuId }}>
+      {children}
+    </TodayMenuIdContext.Provider>
+  );
+};

--- a/apps/hobom-system/src/entities/menu-recommendation/model/useTodayMenuIdContext.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/model/useTodayMenuIdContext.tsx
@@ -1,25 +1,14 @@
-import { createContext, type ReactNode, useContext, useState } from "react";
+import { createContext, useContext } from "react";
 
-interface TodayMenuIdContextType {
+export interface TodayMenuIdContextType {
   todayMenuId: string | null;
   setTodayMenuId: (id: string) => void;
 }
 
-const TodayMenuIdContext = createContext<TodayMenuIdContextType | null>(null);
+// Kept in this component-free module so its identity survives Fast Refresh (see
+// the note in shared/model/useBottomSheetCTA for the failure this avoids).
+export const TodayMenuIdContext = createContext<TodayMenuIdContextType | null>(null);
 
-export const TodayMenuIdContextProvider = ({ children }: { children: ReactNode }) => {
-  const [todayMenuId, setTodayMenuId] = useState<string | null>(null);
-
-  return (
-    <TodayMenuIdContext.Provider value={{ todayMenuId, setTodayMenuId }}>
-      {children}
-    </TodayMenuIdContext.Provider>
-  );
-};
-
-// Context, provider, and hook are intentionally colocated; Fast Refresh is an
-// HMR heuristic that doesn't apply to this consumer hook export.
-// eslint-disable-next-line react-refresh/only-export-components
 export const useTodayMenuId = () => {
   const ctx = useContext(TodayMenuIdContext);
 

--- a/apps/hobom-system/src/shared/model/BottomSheetCTAProvider.tsx
+++ b/apps/hobom-system/src/shared/model/BottomSheetCTAProvider.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { BottomSheetCTA } from "@/shared/ui";
+import { BottomSheetCTAContext, type SheetOptions } from "./useBottomSheetCTA";
+
+export const BottomSheetCTAProvider = ({ children }: { children: ReactNode }) => {
+  const [sheet, setSheet] = useState<SheetOptions | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const queue = useRef<SheetOptions[]>([]);
+  const isShowing = useRef(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const processNext = () => {
+    const next = queue.current.shift();
+
+    if (next === undefined) {
+      isShowing.current = false;
+
+      return;
+    }
+    setSheet(next);
+    setOpen(true);
+    isShowing.current = true;
+  };
+
+  const onOpen = useCallback((options: SheetOptions) => {
+    if (isShowing.current) {
+      queue.current.push(options);
+    } else {
+      setSheet(options);
+      setOpen(true);
+      isShowing.current = true;
+    }
+  }, []);
+
+  const onClose = useCallback(() => {
+    const TIMEOUT_MS = 300;
+
+    setOpen(false);
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      setSheet(null);
+      processNext();
+    }, TIMEOUT_MS);
+  }, []);
+
+  return (
+    <BottomSheetCTAContext.Provider value={{ onOpen, onClose }}>
+      {children}
+      <BottomSheetCTA open={open} onClose={onClose} height={sheet?.height}>
+        {sheet?.title != null ? <BottomSheetCTA.Title>{sheet.title}</BottomSheetCTA.Title> : null}
+        {sheet?.content != null ? <BottomSheetCTA.Body>{sheet.content}</BottomSheetCTA.Body> : null}
+        {sheet?.footer != null ? (
+          <BottomSheetCTA.Footer>{sheet.footer}</BottomSheetCTA.Footer>
+        ) : null}
+      </BottomSheetCTA>
+    </BottomSheetCTAContext.Provider>
+  );
+};

--- a/apps/hobom-system/src/shared/model/index.ts
+++ b/apps/hobom-system/src/shared/model/index.ts
@@ -1,4 +1,5 @@
-export { useBottomSheetCTA, BottomSheetCTAProvider } from "./useBottomSheetCTA";
+export { useBottomSheetCTA } from "./useBottomSheetCTA";
+export { BottomSheetCTAProvider } from "./BottomSheetCTAProvider";
 export { useFunnel } from "./useFunnel";
 export { useInfiniteScroll } from "./useInfiniteScroll";
 export { useOverlay } from "./useOverlay";

--- a/apps/hobom-system/src/shared/model/useBottomSheetCTA.tsx
+++ b/apps/hobom-system/src/shared/model/useBottomSheetCTA.tsx
@@ -1,93 +1,24 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-  type ReactNode,
-} from "react";
-import { BottomSheetCTA } from "@/shared/ui";
+import { createContext, useContext, type ReactNode } from "react";
 
-interface SheetOptions {
+export interface SheetOptions {
   title?: ReactNode;
   content?: ReactNode;
   footer?: ReactNode;
   height?: string;
 }
 
-interface BottomSheetContextType {
+export interface BottomSheetContextType {
   onOpen: (options: SheetOptions) => void;
   onClose: () => void;
 }
 
-const BottomSheetCTAContext = createContext<BottomSheetContextType | null>(null);
+// The context lives in this component-free module so its identity stays stable
+// across Fast Refresh. Colocating it with the provider component (a mixed
+// component/non-component export) disables Fast Refresh for the file, which lets
+// an HMR update recreate the context and detach mounted consumers ("must be used
+// within a provider" despite being wrapped).
+export const BottomSheetCTAContext = createContext<BottomSheetContextType | null>(null);
 
-export const BottomSheetCTAProvider = ({ children }: { children: ReactNode }) => {
-  const [sheet, setSheet] = useState<SheetOptions | null>(null);
-  const [open, setOpen] = useState(false);
-
-  const queue = useRef<SheetOptions[]>([]);
-  const isShowing = useRef(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
-  }, []);
-
-  const processNext = () => {
-    const next = queue.current.shift();
-
-    if (next === undefined) {
-      isShowing.current = false;
-
-      return;
-    }
-    setSheet(next);
-    setOpen(true);
-    isShowing.current = true;
-  };
-
-  const onOpen = useCallback((options: SheetOptions) => {
-    if (isShowing.current) {
-      queue.current.push(options);
-    } else {
-      setSheet(options);
-      setOpen(true);
-      isShowing.current = true;
-    }
-  }, []);
-
-  const onClose = useCallback(() => {
-    const TIMEOUT_MS = 300;
-
-    setOpen(false);
-    timeoutRef.current = setTimeout(() => {
-      timeoutRef.current = null;
-      setSheet(null);
-      processNext();
-    }, TIMEOUT_MS);
-  }, []);
-
-  return (
-    <BottomSheetCTAContext.Provider value={{ onOpen, onClose }}>
-      {children}
-      <BottomSheetCTA open={open} onClose={onClose} height={sheet?.height}>
-        {sheet?.title != null ? <BottomSheetCTA.Title>{sheet.title}</BottomSheetCTA.Title> : null}
-        {sheet?.content != null ? <BottomSheetCTA.Body>{sheet.content}</BottomSheetCTA.Body> : null}
-        {sheet?.footer != null ? (
-          <BottomSheetCTA.Footer>{sheet.footer}</BottomSheetCTA.Footer>
-        ) : null}
-      </BottomSheetCTA>
-    </BottomSheetCTAContext.Provider>
-  );
-};
-
-// Context, provider, and hook are intentionally colocated; Fast Refresh is an
-// HMR heuristic that doesn't apply to this consumer hook export.
-// eslint-disable-next-line react-refresh/only-export-components
 export const useBottomSheetCTA = () => {
   const ctx = useContext(BottomSheetCTAContext);
 


### PR DESCRIPTION
## Symptom
"오늘의 메뉴" (menu recommendation) threw **"BottomSheetProvider 안에서만 사용해야 합니다"** even though the component is correctly wrapped by `BottomSheetCTAProvider` in `AppProvider`.

## Cause
`useBottomSheetCTA.tsx` and `useTodayMenuIdContext.tsx` each colocated `createContext` + the provider **component** + the consumer **hook** in one file. A file exporting both a component and non-components can't use Fast Refresh, so an HMR update re-executes the module and creates a **new** context object while already-mounted providers/consumers still reference the old one → `useContext` returns `null` → the guard throws. This is exactly what `react-refresh/only-export-components` warns about (the warning was previously suppressed with a disable).

## Fix
Split each into:
- a component-free module (`useBottomSheetCTA.tsx`, `useTodayMenuIdContext.tsx`) holding the context object + hook + types — its identity now survives Fast Refresh;
- a provider-only file (`BottomSheetCTAProvider.tsx`, `TodayMenuIdContextProvider.tsx`) that Fast Refresh can handle.

Barrels re-export both, so no consumer imports change. The `react-refresh/only-export-components` disables are removed — resolved structurally, not suppressed.

## Verify
- app `tsc -b` **0 errors**, `eslint` **0 problems** (no disable needed)
- menu-recommendation + pick-menu tests green (19)