### PR TITLE
feat: in-house Box, drop MUI Box

### DIFF
--- a/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
+++ b/apps/hobom-system/src/apps/ui/UserDetailSection.tsx
@@ -19,12 +19,14 @@ interface UserDetailSectionProps {
 
 export const UserDetailSection = ({ user }: UserDetailSectionProps) => (
   <Hb.Box
-    sx={{
-      px: 2.5,
-      py: 2,
+    style={{
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingTop: 16,
+      paddingBottom: 16,
       display: "flex",
       flexDirection: "column",
-      gap: 1.5,
+      gap: 12,
     }}
   >
     <InfoRow
@@ -82,11 +84,26 @@ const FriendsRow = ({ friends }: { friends: string[] }) => {
   };
 
   return (
-    <Hb.Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
-      <Hb.Box sx={{ color: "text.secondary", pt: 0.25 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 12,
+      }}
+    >
+      <Hb.Box
+        style={{
+          color: "var(--hb-color-text-secondary)",
+          paddingTop: 2,
+        }}
+      >
         <PeopleOutline sx={{ fontSize: 18 }} />
       </Hb.Box>
-      <Hb.Box sx={{ minWidth: 0 }}>
+      <Hb.Box
+        style={{
+          minWidth: 0,
+        }}
+      >
         <Hb.Text
           variant="caption"
           style={{
@@ -97,7 +114,14 @@ const FriendsRow = ({ friends }: { friends: string[] }) => {
         >
           친구
         </Hb.Text>
-        <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.25 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 4,
+            marginTop: 2,
+          }}
+        >
           {renderFriends()}
         </Hb.Box>
       </Hb.Box>
@@ -114,9 +138,25 @@ const InfoRow = ({
   label: string;
   value: string;
 }) => (
-  <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-    <Hb.Box sx={{ color: "text.secondary" }}>{icon}</Hb.Box>
-    <Hb.Box sx={{ minWidth: 0 }}>
+  <Hb.Box
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 12,
+    }}
+  >
+    <Hb.Box
+      style={{
+        color: "var(--hb-color-text-secondary)",
+      }}
+    >
+      {icon}
+    </Hb.Box>
+    <Hb.Box
+      style={{
+        minWidth: 0,
+      }}
+    >
       <Hb.Text
         variant="caption"
         style={{

--- a/apps/hobom-system/src/apps/ui/UserInfoSection.tsx
+++ b/apps/hobom-system/src/apps/ui/UserInfoSection.tsx
@@ -8,12 +8,14 @@ interface UserInfoSectionProps {
 
 export const UserInfoSection = ({ initial, nickname, email }: UserInfoSectionProps) => (
   <Hb.Box
-    sx={{
+    style={{
       display: "flex",
       alignItems: "center",
-      gap: 2,
-      px: 2.5,
-      py: 2,
+      gap: 16,
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingTop: 16,
+      paddingBottom: 16,
     }}
   >
     <Hb.Avatar
@@ -27,7 +29,11 @@ export const UserInfoSection = ({ initial, nickname, email }: UserInfoSectionPro
     >
       {initial}
     </Hb.Avatar>
-    <Hb.Box sx={{ minWidth: 0 }}>
+    <Hb.Box
+      style={{
+        minWidth: 0,
+      }}
+    >
       <Hb.Text
         variant="body1"
         style={{

--- a/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
+++ b/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
@@ -124,7 +124,14 @@ const LogoutSection = ({
   isLoggingOut: boolean;
   onLogout: () => void;
 }) => (
-  <Hb.Box sx={{ px: 2.5, py: 1.5 }}>
+  <Hb.Box
+    style={{
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingTop: 12,
+      paddingBottom: 12,
+    }}
+  >
     <Hb.Button
       fullWidth
       variant="secondary"

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -73,7 +73,12 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                     </Hb.Text>
                   ),
                   content: (
-                    <Hb.Box sx={{ px: 2 }}>
+                    <Hb.Box
+                      style={{
+                        paddingLeft: 16,
+                        paddingRight: 16,
+                      }}
+                    >
                       <Hb.Text gutterBottom variant="subtitle1" style={{ fontWeight: "bold" }}>
                         {formatDate(normalizeTodoDateToUtcMidnight(item.date))}
                       </Hb.Text>
@@ -94,7 +99,12 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                     </Hb.Box>
                   ),
                   footer: (
-                    <Hb.Box display="flex" gap={2}>
+                    <Hb.Box
+                      style={{
+                        display: "flex",
+                        gap: 16,
+                      }}
+                    >
                       <Hb.Button
                         fullWidth
                         variant="danger"
@@ -140,7 +150,13 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
           </Hb.List.ItemIcon>
           <Hb.List.ItemText
             primary={
-              <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+              <Hb.Box
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
                 <span>{item.title}</span>
                 {item.cycle !== "EVERYDAY" && (
                   <Hb.Chip

--- a/apps/hobom-system/src/entities/dashboard/ui/KpiCard.tsx
+++ b/apps/hobom-system/src/entities/dashboard/ui/KpiCard.tsx
@@ -14,13 +14,34 @@ interface KpiCardProps {
 export const KpiCard = ({ label, value, suffix, trend, icon }: KpiCardProps) => {
   return (
     <DashboardPaper style={{ height: "100%" }}>
-      <Hb.Box sx={{ display: "flex", justifyContent: "space-between", mb: 1 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
         <Hb.Text variant="body2" color="text.secondary">
           {label}
         </Hb.Text>
-        {icon && <Hb.Box sx={{ color: "text.secondary", display: "flex" }}>{icon}</Hb.Box>}
+        {icon && (
+          <Hb.Box
+            style={{
+              color: "var(--hb-color-text-secondary)",
+              display: "flex",
+            }}
+          >
+            {icon}
+          </Hb.Box>
+        )}
       </Hb.Box>
-      <Hb.Box sx={{ display: "flex", alignItems: "baseline", gap: 0.5 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 4,
+        }}
+      >
         <Hb.Text variant="h4" fontWeight={700}>
           {value}
         </Hb.Text>
@@ -32,11 +53,11 @@ export const KpiCard = ({ label, value, suffix, trend, icon }: KpiCardProps) => 
       </Hb.Box>
       {trend != null && (
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
-            gap: 0.5,
-            mt: 1,
+            gap: 4,
+            marginTop: 8,
             color: trend >= 0 ? "success.main" : "error.main",
           }}
         >

--- a/apps/hobom-system/src/entities/dashboard/ui/PeriodSelector.tsx
+++ b/apps/hobom-system/src/entities/dashboard/ui/PeriodSelector.tsx
@@ -22,12 +22,12 @@ export const PeriodSelector = (props: PeriodSelectorProps) => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "inline-flex",
-        gap: 0.75,
-        p: 0.5,
-        bgcolor: "grey.100",
-        borderRadius: 2,
+        gap: 6,
+        padding: 4,
+        backgroundColor: "grey.100",
+        borderRadius: 16,
       }}
     >
       {Object.entries(labels).map(([key, label]) => {

--- a/apps/hobom-system/src/entities/issue/ui/IssueCard.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/IssueCard.tsx
@@ -1,7 +1,17 @@
 import { memo } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
 import { ISSUE_KIND_REGISTRY, ISSUE_PRIORITY_REGISTRY } from "./IssueRegistry";
 import type { IssueType } from "../api/issue.type";
+
+const styles = stylex.create({
+  cardHover: {
+    ":hover": {
+      boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+      transform: "translateY(-1px)",
+    },
+  },
+});
 
 interface IssueCardProps {
   issue: IssueType;
@@ -18,19 +28,14 @@ export const IssueCard = memo(
 
     return (
       <Hb.Box
-        sx={{
-          p: 1.5,
-          bgcolor: "background.paper",
-          borderRadius: 2,
+        {...stylex.props(isDragOverlay ? undefined : styles.cardHover)}
+        style={{
+          padding: 12,
+          backgroundColor: "var(--hb-color-surface)",
+          borderRadius: 16,
           borderLeft: `3px solid ${kind.color}`,
           cursor: isDragOverlay ? "grabbing" : "grab",
           boxShadow: isDragOverlay ? "0 12px 28px rgba(0,0,0,0.16)" : "0 1px 3px rgba(0,0,0,0.06)",
-          "&:hover": isDragOverlay
-            ? undefined
-            : {
-                boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
-                transform: "translateY(-1px)",
-              },
           transition: "box-shadow 0.15s, transform 0.15s",
           userSelect: "none",
         }}
@@ -50,22 +55,28 @@ export const IssueCard = memo(
           {issue.title}
         </Hb.Text>
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
           }}
         >
-          <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
             <Hb.Box
-              sx={{
+              style={{
                 display: "inline-flex",
                 alignItems: "center",
                 justifyContent: "center",
                 width: 22,
                 height: 22,
-                borderRadius: 0.75,
-                bgcolor: kind.bg,
+                borderRadius: 6,
+                backgroundColor: kind.bg,
                 color: kind.color,
               }}
             >
@@ -117,7 +128,13 @@ export const IssueCard = memo(
             )}
           </Hb.Box>
 
-          <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
             <priority.Icon sx={{ fontSize: 16, color: priority.color }} />
             {issue.assignee && (
               <Hb.Avatar

--- a/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
@@ -36,15 +36,17 @@ export const ParentIssueAutocomplete = ({
       return (
         <li key={params.key}>
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
-              gap: 0.75,
-              px: 1.5,
-              py: 0.75,
+              gap: 6,
+              paddingLeft: 12,
+              paddingRight: 12,
+              paddingTop: 6,
+              paddingBottom: 6,
               position: "sticky",
               top: -8,
-              bgcolor: config?.bg ?? "#f3f4f6",
+              backgroundColor: config?.bg ?? "#f3f4f6",
               zIndex: 1,
             }}
           >

--- a/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
@@ -55,7 +55,14 @@ export const MenuRecommendationListItem = memo(function MenuRecommendationListIt
             mb: 0.75,
           }}
           secondary={
-            <Hb.Box component="span" sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+            <Hb.Box
+              component="span"
+              style={{
+                display: "flex",
+                gap: 4,
+                flexWrap: "wrap",
+              }}
+            >
               <Hb.Chip
                 label={MENU_KIND_LABEL[item.menuKind] ?? item.menuKind}
                 size="small"

--- a/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
+++ b/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
@@ -91,7 +91,7 @@ export const NoteCard = ({
         {/* 드래그 핸들 — top-left */}
         {dragHandle && (
           <Hb.Box
-            sx={{
+            style={{
               position: "absolute",
               top: 2,
               left: 2,
@@ -170,17 +170,23 @@ export const NoteCard = ({
         )}
 
         {hasChecklist && (
-          <Hb.Box sx={{ mx: -0.5 }}>
+          <Hb.Box
+            style={{
+              marginLeft: -4,
+              marginRight: -4,
+            }}
+          >
             {[...note.checklistItems]
               .sort((a, b) => a.order - b.order)
               .slice(0, 8)
               .map((item, idx) => (
                 <Hb.Box
                   key={idx}
-                  sx={{
+                  style={{
                     display: "flex",
                     alignItems: "center",
-                    py: 0.125,
+                    paddingTop: 1,
+                    paddingBottom: 1,
                   }}
                 >
                   <Hb.Checkbox
@@ -223,7 +229,14 @@ export const NoteCard = ({
         )}
 
         {(note.reminder || note.labels?.length > 0 || note.members?.length > 0) && (
-          <Hb.Box sx={{ mt: 1.5, display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+          <Hb.Box
+            style={{
+              marginTop: 12,
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 4,
+            }}
+          >
             {note.reminder && (
               <Hb.Chip
                 icon={<NotificationsActiveOutlined sx={{ fontSize: 14 }} />}

--- a/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
@@ -37,22 +37,34 @@ export const NotificationItem = memo(function NotificationItem({ notification, o
       }}
     >
       <Hb.Box
-        sx={{
+        style={{
           width: 36,
           height: 36,
           borderRadius: "10px",
-          bgcolor: meta.bgColor,
+          backgroundColor: meta.bgColor,
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
           flexShrink: 0,
-          mt: 0.25,
+          marginTop: 2,
         }}
       >
         <Icon sx={{ fontSize: 18, color: meta.color }} />
       </Hb.Box>
-      <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.25 }}>
+      <Hb.Box
+        style={{
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            marginBottom: 2,
+          }}
+        >
           <Hb.Text
             variant="body2"
             style={{
@@ -71,17 +83,17 @@ export const NotificationItem = memo(function NotificationItem({ notification, o
             <>
               <Hb.Box
                 aria-hidden="true"
-                sx={{
+                style={{
                   width: 7,
                   height: 7,
                   borderRadius: "50%",
-                  bgcolor: "primary.main",
+                  backgroundColor: "var(--hb-color-accent)",
                   flexShrink: 0,
                 }}
               />
               <Hb.Box
                 component="span"
-                sx={{
+                style={{
                   position: "absolute",
                   width: 1,
                   height: 1,

--- a/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
+++ b/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
@@ -93,13 +93,13 @@ export const ProjectLabelPicker = ({
               />
             </Hb.List.ItemIcon>
             <Hb.Box
-              sx={{
+              style={{
                 width: 12,
                 height: 12,
                 borderRadius: "50%",
-                bgcolor: label.color,
+                backgroundColor: label.color,
                 flexShrink: 0,
-                mr: 1,
+                marginRight: 8,
               }}
             />
             <Hb.List.ItemText
@@ -131,7 +131,14 @@ export const ProjectLabelPicker = ({
       </Hb.List.Root>
       <Hb.Divider />
       {creating ? (
-        <Hb.Box sx={{ p: 1.5, display: "flex", flexDirection: "column", gap: 1 }}>
+        <Hb.Box
+          style={{
+            padding: 12,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
           <Hb.TextField
             size="small"
             placeholder="라벨 이름"
@@ -144,7 +151,13 @@ export const ProjectLabelPicker = ({
             autoFocus
             fullWidth
           />
-          <Hb.Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              gap: 4,
+              flexWrap: "wrap",
+            }}
+          >
             {LABEL_COLORS.map((color) => (
               <Hb.Box
                 key={color}
@@ -159,20 +172,26 @@ export const ProjectLabelPicker = ({
                     setNewColor(color);
                   }
                 }}
-                sx={{
+                style={{
                   width: 20,
                   height: 20,
                   borderRadius: "50%",
-                  bgcolor: color,
+                  backgroundColor: color,
                   cursor: "pointer",
                   border: color === newColor ? "2px solid" : "2px solid transparent",
-                  borderColor: color === newColor ? "text.primary" : "transparent",
+                  borderColor: color === newColor ? "var(--hb-color-text-primary)" : "transparent",
                   transition: "border-color 0.1s ease",
                 }}
               />
             ))}
           </Hb.Box>
-          <Hb.Box sx={{ display: "flex", gap: 0.5, justifyContent: "flex-end" }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              gap: 4,
+              justifyContent: "flex-end",
+            }}
+          >
             <Hb.Button.Icon
               size="small"
               aria-label="라벨 생성 취소"

--- a/apps/hobom-system/src/entities/project/ui/ProjectCard.tsx
+++ b/apps/hobom-system/src/entities/project/ui/ProjectCard.tsx
@@ -33,11 +33,11 @@ export const ProjectCard = ({ project, onClick }: ProjectCardProps) => {
     >
       <Hb.Card.Content sx={{ p: 2.5, "&:last-child": { pb: 2.5 } }}>
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
-            gap: 1.5,
-            mb: 1.5,
+            gap: 12,
+            marginBottom: 12,
           }}
         >
           <Hb.Avatar
@@ -53,7 +53,12 @@ export const ProjectCard = ({ project, onClick }: ProjectCardProps) => {
           >
             {project.key.slice(0, 2)}
           </Hb.Avatar>
-          <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+          <Hb.Box
+            style={{
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             <Hb.Text variant="subtitle2" fontWeight={600} noWrap>
               {project.name}
             </Hb.Text>
@@ -87,7 +92,7 @@ export const ProjectCard = ({ project, onClick }: ProjectCardProps) => {
         )}
 
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",

--- a/apps/hobom-system/src/entities/wiki-space/ui/SpaceCard.tsx
+++ b/apps/hobom-system/src/entities/wiki-space/ui/SpaceCard.tsx
@@ -38,13 +38,20 @@ export const SpaceCard = ({ space, onClick, onEdit, onDelete }: SpaceCardProps) 
       }}
     >
       <Hb.Card.Content sx={{ p: 2.5 }}>
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginBottom: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 36,
               height: 36,
-              borderRadius: 1,
-              bgcolor: "primary.main",
+              borderRadius: 8,
+              backgroundColor: "var(--hb-color-accent)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
@@ -52,7 +59,12 @@ export const SpaceCard = ({ space, onClick, onEdit, onDelete }: SpaceCardProps) 
           >
             <ArticleOutlined sx={{ color: "#fff", fontSize: 20 }} />
           </Hb.Box>
-          <Hb.Box sx={{ minWidth: 0, flex: 1 }}>
+          <Hb.Box
+            style={{
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
             <Hb.Text variant="subtitle2" fontWeight={700} noWrap>
               {space.name}
             </Hb.Text>

--- a/apps/hobom-system/src/features/backlog-board/ui/BacklogBoard.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/BacklogBoard.tsx
@@ -42,7 +42,13 @@ export const BacklogBoard = ({
 
   return (
     <BacklogContext.Provider value={contextValue}>
-      <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
+      >
         {sprintGroups.map(({ sprint, issues }) => (
           <SprintSection key={sprint.id} sprint={sprint} issues={issues} />
         ))}
@@ -55,13 +61,15 @@ export const BacklogBoard = ({
           }}
         >
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
-              gap: 1,
-              px: 2,
-              py: 1.2,
-              bgcolor: "action.hover",
+              gap: 8,
+              paddingLeft: 16,
+              paddingRight: 16,
+              paddingTop: 9.6,
+              paddingBottom: 9.6,
+              backgroundColor: "var(--hb-color-border)",
             }}
           >
             <InboxOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
@@ -89,12 +97,17 @@ export const BacklogBoard = ({
           ) : (
             <Hb.Box
               {...containerProps}
-              sx={{
+              style={{
                 ...containerProps.style,
                 maxHeight: "calc(100vh - 300px)",
               }}
             >
-              <Hb.Box sx={{ height: totalHeight, position: "relative" }}>
+              <Hb.Box
+                style={{
+                  height: totalHeight,
+                  position: "relative",
+                }}
+              >
                 {virtualItems.map(({ item, offsetTop }) => {
                   const { issue, depth, childCount } = item;
                   const progress =
@@ -105,7 +118,7 @@ export const BacklogBoard = ({
                   return (
                     <Hb.Box
                       key={issue.id}
-                      sx={{
+                      style={{
                         position: "absolute",
                         top: offsetTop,
                         width: "100%",

--- a/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
@@ -43,7 +43,12 @@ export const CreateSprintDialog = ({ open, onClose, projectId }: CreateSprintDia
           size="small"
           sx={{ mt: 1 }}
         />
-        <Hb.Box sx={{ display: "flex", gap: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 16,
+          }}
+        >
           <Hb.TextField
             label="시작일"
             type="date"

--- a/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
@@ -13,6 +13,25 @@ import { ISSUE_KIND_REGISTRY, ISSUE_PRIORITY_REGISTRY } from "@/entities/issue/u
 import { Hb } from "@/shared/ui";
 import { useBacklogContext } from "../model/useBacklogContext";
 
+// StyleX is atomic and cannot express the hover-reveal descendant selectors, so
+// the row styling is rendered as a scoped <style> tag instead.
+const ROW_CLASS = "backlog-issue-row";
+const ROW_CSS = `
+.${ROW_CLASS} {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-right: 16px;
+  padding-top: 6.4px;
+  padding-bottom: 6.4px;
+  border-bottom: 1px solid var(--hb-color-border);
+  transition: background 0.1s;
+}
+.${ROW_CLASS}:hover { background-color: var(--hb-color-border); }
+.${ROW_CLASS}:hover .move-btn { opacity: 1; }
+.${ROW_CLASS}:focus-within .move-btn { opacity: 1; }
+`;
+
 interface IssueRowProps {
   issue: IssueType;
   depth?: number;
@@ -85,19 +104,15 @@ export const IssueRow = ({
 
   return (
     <>
+      {/* React 19 hoists and de-dupes by `href`, so the rule is emitted once
+          even though every row renders this. */}
+      <style href={ROW_CLASS} precedence="default">
+        {ROW_CSS}
+      </style>
       <Hb.Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1.5,
-          pl: 2 + depth * 3,
-          pr: 2,
-          py: 0.8,
-          borderBottom: "1px solid",
-          borderColor: "divider",
-          "&:hover": { bgcolor: "action.hover" },
-          "&:hover .move-btn, &:focus-within .move-btn": { opacity: 1 },
-          transition: "background 0.1s",
+        className={ROW_CLASS}
+        style={{
+          paddingLeft: (2 + depth * 3) * 8,
           cursor: onIssueClick ? "pointer" : undefined,
         }}
         onClick={() => onIssueClick?.(issue.id)}

--- a/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
@@ -5,6 +5,7 @@ import {
   PlayArrowOutlined,
   CheckCircleOutline,
 } from "hobom-design-system/icons";
+import * as stylex from "@stylexjs/stylex";
 import { getDescendantProgress, type IssueType } from "@/entities/issue";
 import { SPRINT_STATUS_LABEL, type SprintType } from "@/entities/sprint";
 import { Hb } from "@/shared/ui";
@@ -13,6 +14,15 @@ import { useCollapsibleTree } from "../model/useCollapsibleTree";
 import { useSprintActions } from "../model/useSprintActions";
 import { STATUS_COLOR } from "./backlog-constants";
 import { IssueRow } from "./IssueRow";
+
+const styles = stylex.create({
+  headerActiveHover: {
+    ":hover": { backgroundColor: "rgba(var(--mui-palette-primary-mainChannel) / 0.1)" },
+  },
+  headerHover: {
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
 
 export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: IssueType[] }) => {
   const { projectId, doneStatusIds } = useBacklogContext();
@@ -30,23 +40,22 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
       }}
     >
       <Hb.Box
-        sx={{
+        {...stylex.props(
+          sprint.status === "ACTIVE" ? styles.headerActiveHover : styles.headerHover,
+        )}
+        style={{
           display: "flex",
           alignItems: "center",
-          gap: 1,
-          px: 2,
-          py: 1.2,
-          bgcolor:
+          gap: 8,
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 9.6,
+          paddingBottom: 9.6,
+          backgroundColor:
             sprint.status === "ACTIVE"
               ? "rgba(var(--mui-palette-primary-mainChannel) / 0.06)"
-              : "action.hover",
+              : "var(--hb-color-border)",
           cursor: "pointer",
-          "&:hover": {
-            bgcolor:
-              sprint.status === "ACTIVE"
-                ? "rgba(var(--mui-palette-primary-mainChannel) / 0.1)"
-                : "action.selected",
-          },
           transition: "background 0.15s",
         }}
         onClick={() => setExpanded(!expanded)}
@@ -84,7 +93,11 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
         >
           {issues.length}건
         </Hb.Text>
-        <Hb.Box sx={{ flex: 1 }} />
+        <Hb.Box
+          style={{
+            flex: 1,
+          }}
+        />
         {sprint.status === "PLANNING" && (
           <Hb.Button
             size="small"
@@ -132,7 +145,15 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
       </Hb.Box>
       <Hb.Collapse in={expanded}>
         {issues.length === 0 ? (
-          <Hb.Box sx={{ px: 2, py: 3, textAlign: "center" }}>
+          <Hb.Box
+            style={{
+              paddingLeft: 16,
+              paddingRight: 16,
+              paddingTop: 24,
+              paddingBottom: 24,
+              textAlign: "center",
+            }}
+          >
             <Hb.Text
               variant="body2"
               color="text.disabled"

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -61,7 +61,12 @@ export const CreateIssueDialog = ({
           rows={3}
           size="small"
         />
-        <Hb.Box sx={{ display: "flex", gap: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 16,
+          }}
+        >
           <Hb.Form.Control size="small" sx={{ flex: 1 }}>
             <Hb.Form.Label>유형</Hb.Form.Label>
             <Hb.Form.Select
@@ -91,7 +96,12 @@ export const CreateIssueDialog = ({
             </Hb.Form.Select>
           </Hb.Form.Control>
         </Hb.Box>
-        <Hb.Box sx={{ display: "flex", gap: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 16,
+          }}
+        >
           {activeSprints.length > 0 && (
             <Hb.Form.Control size="small" sx={{ flex: 1 }}>
               <Hb.Form.Label>스프린트 (선택)</Hb.Form.Label>
@@ -132,9 +142,9 @@ export const CreateIssueDialog = ({
             라벨
           </Hb.Text>
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
-              gap: 0.5,
+              gap: 4,
               flexWrap: "wrap",
               alignItems: "center",
             }}

--- a/apps/hobom-system/src/features/dashboard-activity/ui/ActivityHeatmap.tsx
+++ b/apps/hobom-system/src/features/dashboard-activity/ui/ActivityHeatmap.tsx
@@ -47,7 +47,7 @@ export const ActivityHeatmap = ({ data }: ActivityHeatmapProps) => {
         활동 히트맵
       </Hb.Text>
       <Hb.Box
-        sx={{
+        style={{
           display: "grid",
           gridTemplateColumns: `repeat(${WEEKS}, 14px)`,
           gridTemplateRows: `repeat(${DAYS_PER_WEEK}, 14px)`,
@@ -58,11 +58,11 @@ export const ActivityHeatmap = ({ data }: ActivityHeatmapProps) => {
         {cells.map((cell) => (
           <Hb.Tooltip key={cell.date} title={`${cell.date}: ${cell.count}건`} arrow placement="top">
             <Hb.Box
-              sx={{
+              style={{
                 width: 14,
                 height: 14,
                 borderRadius: "2px",
-                bgcolor: LEVEL_COLORS[cell.level],
+                backgroundColor: LEVEL_COLORS[cell.level],
               }}
             />
           </Hb.Tooltip>

--- a/apps/hobom-system/src/features/dashboard-activity/ui/StreakBadge.tsx
+++ b/apps/hobom-system/src/features/dashboard-activity/ui/StreakBadge.tsx
@@ -9,18 +9,18 @@ interface StreakBadgeProps {
 export const StreakBadge = ({ currentStreak, longestStreak }: StreakBadgeProps) => {
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
-        gap: 2,
+        gap: 16,
       }}
     >
       <Hb.Box
-        sx={{
+        style={{
           flex: 1,
-          p: 2,
-          borderRadius: 2,
+          padding: 16,
+          borderRadius: 16,
           border: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           textAlign: "center",
         }}
       >
@@ -33,12 +33,12 @@ export const StreakBadge = ({ currentStreak, longestStreak }: StreakBadgeProps) 
         </Hb.Text>
       </Hb.Box>
       <Hb.Box
-        sx={{
+        style={{
           flex: 1,
-          p: 2,
-          borderRadius: 2,
+          padding: 16,
+          borderRadius: 16,
           border: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           textAlign: "center",
         }}
       >

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorTable.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorTable.tsx
@@ -73,8 +73,20 @@ export const EndpointErrorTable = ({ data }: EndpointErrorTableProps) => {
   );
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <Hb.Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          marginBottom: 8,
+        }}
+      >
         <Hb.Text variant="body2" fontWeight={600}>
           Top Error 엔드포인트
         </Hb.Text>
@@ -116,12 +128,13 @@ export const EndpointErrorTable = ({ data }: EndpointErrorTableProps) => {
         )}
         {rowModel.rowCount === 0 && (
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
-              py: 4,
-              gap: 1,
+              paddingTop: 32,
+              paddingBottom: 32,
+              gap: 8,
             }}
           >
             <ErrorOutline sx={{ fontSize: 40, color: "#dadce0" }} />

--- a/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
@@ -37,7 +37,13 @@ export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) =>
       >
         로그 레벨 분포
       </Hb.Text>
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 4 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 32,
+        }}
+      >
         <ResponsiveContainer width={180} height={180}>
           <PieChart>
             <Pie
@@ -88,7 +94,14 @@ export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) =>
             </text>
           </PieChart>
         </ResponsiveContainer>
-        <Hb.Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+          }}
+        >
           {sorted.map((entry) => {
             const pct = total > 0 ? (entry.count / total) * 100 : 0;
             const color = LEVEL_COLORS[entry.level] ?? "#94baff";
@@ -96,20 +109,26 @@ export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) =>
             return (
               <Hb.Box key={entry.level}>
                 <Hb.Box
-                  sx={{
+                  style={{
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "space-between",
-                    mb: 0.25,
+                    marginBottom: 2,
                   }}
                 >
-                  <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Hb.Box
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
                     <Hb.Box
-                      sx={{
+                      style={{
                         width: 8,
                         height: 8,
                         borderRadius: "50%",
-                        bgcolor: color,
+                        backgroundColor: color,
                         flexShrink: 0,
                       }}
                     />

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
@@ -37,14 +37,20 @@ export const LogSearchSection = () => {
   return (
     <Hb.Box>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          mb: 2,
+          marginBottom: 16,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
           <SearchOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
           <Hb.Text variant="body2" fontWeight={600}>
             로그 검색
@@ -56,21 +62,20 @@ export const LogSearchSection = () => {
           )}
         </Hb.Box>
       </Hb.Box>
-
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           width: "100%",
           justifyContent: "space-between",
           alignItems: "center",
-          mb: 2,
+          marginBottom: 16,
         }}
       >
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
-            gap: 1.5,
+            gap: 12,
             flexWrap: "wrap",
           }}
         >
@@ -126,7 +131,7 @@ export const LogSearchSection = () => {
         </Hb.Box>
         {totalPages > 1 && (
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
               height: "100%",
@@ -142,9 +147,15 @@ export const LogSearchSection = () => {
           </Hb.Box>
         )}
       </Hb.Box>
-
       {isLoading ? (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 32,
+            paddingBottom: 32,
+          }}
+        >
           <Hb.Progress.Circular size={28} />
         </Hb.Box>
       ) : (

--- a/apps/hobom-system/src/features/dashboard-log/ui/ServiceTrafficChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/ServiceTrafficChart.tsx
@@ -22,7 +22,13 @@ export const ServiceTrafficChart = ({ data }: ServiceTrafficChartProps) => {
       >
         서비스별 트래픽
       </Hb.Text>
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 4 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 32,
+        }}
+      >
         <ResponsiveContainer width={180} height={180}>
           <PieChart>
             <Pie
@@ -76,7 +82,14 @@ export const ServiceTrafficChart = ({ data }: ServiceTrafficChartProps) => {
             </text>
           </PieChart>
         </ResponsiveContainer>
-        <Hb.Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Hb.Box
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+          }}
+        >
           {data.map((entry, i) => {
             const pct = total > 0 ? (entry.count / total) * 100 : 0;
             const color = CHART_COLORS[i % CHART_COLORS.length];
@@ -84,18 +97,18 @@ export const ServiceTrafficChart = ({ data }: ServiceTrafficChartProps) => {
             return (
               <Hb.Box
                 key={entry.serviceType}
-                sx={{
+                style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: 1.5,
+                  gap: 12,
                 }}
               >
                 <Hb.Box
-                  sx={{
+                  style={{
                     width: 32,
                     height: 32,
-                    borderRadius: 1.5,
-                    bgcolor: `${color}18`,
+                    borderRadius: 12,
+                    backgroundColor: `${color}18`,
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
@@ -103,15 +116,20 @@ export const ServiceTrafficChart = ({ data }: ServiceTrafficChartProps) => {
                   }}
                 >
                   <Hb.Box
-                    sx={{
+                    style={{
                       width: 10,
                       height: 10,
                       borderRadius: "50%",
-                      bgcolor: color,
+                      backgroundColor: color,
                     }}
                   />
                 </Hb.Box>
-                <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+                <Hb.Box
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                >
                   <Hb.Text
                     variant="body2"
                     style={{

--- a/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
@@ -74,7 +74,13 @@ interface StatusCodeChartProps {
 
 export const StatusCodeChart = ({ data }: StatusCodeChartProps) => {
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
       <Hb.Text
         variant="body2"
         fontWeight={600}

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
@@ -28,7 +28,14 @@ export const DlqDetailDialog = ({
   const renderContent = () => {
     if (isLoading) {
       return (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 32,
+            paddingBottom: 32,
+          }}
+        >
           <Hb.Progress.Circular size={28} />
         </Hb.Box>
       );
@@ -38,7 +45,13 @@ export const DlqDetailDialog = ({
 
     return (
       <>
-        <Hb.Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 8,
+            marginBottom: 16,
+          }}
+        >
           <Hb.Text
             variant="body2"
             style={{
@@ -72,16 +85,16 @@ export const DlqDetailDialog = ({
         </Hb.Text>
         <Hb.Box
           component="pre"
-          sx={{
-            p: 2,
-            borderRadius: 1,
-            bgcolor: "action.hover",
+          style={{
+            padding: 16,
+            borderRadius: 8,
+            backgroundColor: "var(--hb-color-border)",
             fontSize: 12,
             fontFamily: "'JetBrains Mono', monospace",
             overflow: "auto",
             maxHeight: 400,
             whiteSpace: "pre",
-            m: 0,
+            margin: 0,
           }}
         >
           {JSON.stringify(detail.payload, null, 2)}

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
@@ -19,7 +19,14 @@ export const DlqManagementContent = () => {
   const renderTable = () => {
     if (isLoading) {
       return (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 32,
+            paddingBottom: 32,
+          }}
+        >
           <Hb.Progress.Circular size={28} />
         </Hb.Box>
       );
@@ -101,23 +108,33 @@ export const DlqManagementContent = () => {
   };
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       {/* Header */}
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 3,
+          marginBottom: 24,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 40,
               height: 40,
-              borderRadius: 2,
-              bgcolor: "error.main",
+              borderRadius: 16,
+              backgroundColor: "var(--hb-color-danger)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
@@ -10,7 +10,13 @@ interface ErrorEventDetailDialogProps {
 }
 
 const InfoRow = ({ label, value }: { label: string; value: string | null }) => (
-  <Hb.Box sx={{ display: "flex", gap: 1, mb: 1 }}>
+  <Hb.Box
+    style={{
+      display: "flex",
+      gap: 8,
+      marginBottom: 8,
+    }}
+  >
     <Hb.Text
       variant="body2"
       style={{
@@ -46,7 +52,13 @@ export const ErrorEventDetailDialog = ({ event, open, onClose }: ErrorEventDetai
           justifyContent: "space-between",
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
           <Hb.Text
             variant="h6"
             style={{
@@ -79,7 +91,11 @@ export const ErrorEventDetailDialog = ({ event, open, onClose }: ErrorEventDetai
         <InfoRow label="발생 시간" value={event.createdAt?.replace("T", " ").slice(0, 19) ?? "-"} />
 
         {event.stackTrace && (
-          <Hb.Box sx={{ mt: 2 }}>
+          <Hb.Box
+            style={{
+              marginTop: 16,
+            }}
+          >
             <Hb.Text
               variant="body2"
               style={{
@@ -92,16 +108,16 @@ export const ErrorEventDetailDialog = ({ event, open, onClose }: ErrorEventDetai
             </Hb.Text>
             <Hb.Box
               component="pre"
-              sx={{
-                p: 2,
-                borderRadius: 1,
-                bgcolor: "action.hover",
+              style={{
+                padding: 16,
+                borderRadius: 8,
+                backgroundColor: "var(--hb-color-border)",
                 fontSize: 12,
                 fontFamily: "'JetBrains Mono', monospace",
                 overflow: "auto",
                 maxHeight: 400,
                 whiteSpace: "pre",
-                m: 0,
+                margin: 0,
               }}
             >
               {event.stackTrace}

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
@@ -22,14 +22,20 @@ export const ErrorEventFilter = ({
 }: ErrorEventFilterProps) => (
   <Hb.Box>
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        mb: 2,
+        marginBottom: 16,
       }}
     >
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
         <SearchOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
         <Hb.Text variant="body2" fontWeight={600}>
           에러 검색
@@ -43,12 +49,12 @@ export const ErrorEventFilter = ({
     </Hb.Box>
 
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
-        gap: 1.5,
+        gap: 12,
         flexWrap: "wrap",
-        mb: 2,
+        marginBottom: 16,
       }}
     >
       <Hb.Form.Control size="small" sx={{ minWidth: 160 }}>

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventTable.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventTable.tsx
@@ -1,9 +1,24 @@
+import * as stylex from "@stylexjs/stylex";
 import { useVirtualList } from "@/shared/model";
 import type { ErrorEventDto } from "@/entities/error-event";
 import { Hb } from "@/shared/ui";
 import { ERROR_TYPE_CHIP } from "./error-type-chip";
 
 const ROW_HEIGHT = 40;
+
+const styles = stylex.create({
+  row: {
+    position: "absolute",
+    width: "100%",
+    height: ROW_HEIGHT,
+    display: "flex",
+    alignItems: "center",
+    cursor: "pointer",
+    borderBottom: "1px solid",
+    borderColor: "var(--hb-color-border)",
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
 
 const COLUMNS = [
   { label: "시간", width: 160 },
@@ -13,13 +28,14 @@ const COLUMNS = [
   { label: "사용자", width: 100 },
 ] as const;
 
-const HEADER_SX = {
+const HEADER_STYLE = {
   fontWeight: 600,
   fontSize: 11,
   textTransform: "uppercase",
   letterSpacing: "0.04em",
-  color: "text.secondary",
-  px: 1.5,
+  color: "var(--hb-color-text-secondary)",
+  paddingLeft: 12,
+  paddingRight: 12,
 } as const;
 
 interface ErrorEventTableProps {
@@ -53,19 +69,19 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
     <Hb.Box>
       {/* Header */}
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           height: 36,
           borderBottom: 1,
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
         }}
       >
         {COLUMNS.map((col) => (
           <Hb.Box
             key={col.label}
-            sx={{
-              ...HEADER_SX,
+            style={{
+              ...HEADER_STYLE,
               width: "width" in col ? col.width : undefined,
               flex: "flex" in col ? col.flex : undefined,
             }}
@@ -77,13 +93,18 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
       {/* Virtual Rows */}
       <Hb.Box
         {...containerProps}
-        sx={{
+        style={{
           ...containerProps.style,
           maxHeight: "calc(100vh - 340px)",
           minHeight: 200,
         }}
       >
-        <Hb.Box sx={{ height: totalHeight, position: "relative" }}>
+        <Hb.Box
+          style={{
+            height: totalHeight,
+            position: "relative",
+          }}
+        >
           {virtualItems.map(({ item: row, offsetTop }) => {
             const chip = ERROR_TYPE_CHIP[row.errorType];
 
@@ -91,20 +112,16 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
               <Hb.Box
                 key={row.id}
                 onClick={() => onRowClick(row)}
-                sx={{
-                  position: "absolute",
-                  top: offsetTop,
-                  width: "100%",
-                  height: ROW_HEIGHT,
-                  display: "flex",
-                  alignItems: "center",
-                  cursor: "pointer",
-                  borderBottom: 1,
-                  borderColor: "divider",
-                  "&:hover": { bgcolor: "action.hover" },
-                }}
+                {...stylex.props(styles.row)}
+                style={{ top: offsetTop }}
               >
-                <Hb.Box sx={{ width: 160, px: 1.5 }}>
+                <Hb.Box
+                  style={{
+                    width: 160,
+                    paddingLeft: 12,
+                    paddingRight: 12,
+                  }}
+                >
                   <Hb.Text
                     variant="caption"
                     style={{
@@ -116,7 +133,13 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
                     {row.createdAt?.replace("T", " ").slice(0, 19) ?? "-"}
                   </Hb.Text>
                 </Hb.Box>
-                <Hb.Box sx={{ width: 90, px: 1.5 }}>
+                <Hb.Box
+                  style={{
+                    width: 90,
+                    paddingLeft: 12,
+                    paddingRight: 12,
+                  }}
+                >
                   <Hb.Chip
                     label={chip.label}
                     size="small"
@@ -129,7 +152,14 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
                     }}
                   />
                 </Hb.Box>
-                <Hb.Box sx={{ width: 200, px: 1.5, overflow: "hidden" }}>
+                <Hb.Box
+                  style={{
+                    width: 200,
+                    paddingLeft: 12,
+                    paddingRight: 12,
+                    overflow: "hidden",
+                  }}
+                >
                   <Hb.Tooltip title={row.screen} enterDelay={200}>
                     <Hb.Text
                       variant="body2"
@@ -143,7 +173,14 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
                     </Hb.Text>
                   </Hb.Tooltip>
                 </Hb.Box>
-                <Hb.Box sx={{ flex: 1, px: 1.5, overflow: "hidden" }}>
+                <Hb.Box
+                  style={{
+                    flex: 1,
+                    paddingLeft: 12,
+                    paddingRight: 12,
+                    overflow: "hidden",
+                  }}
+                >
                   <Hb.Tooltip title={row.message} enterDelay={200}>
                     <Hb.Text
                       variant="body2"
@@ -156,7 +193,13 @@ export const ErrorEventTable = ({ data, onRowClick }: ErrorEventTableProps) => {
                     </Hb.Text>
                   </Hb.Tooltip>
                 </Hb.Box>
-                <Hb.Box sx={{ width: 100, px: 1.5 }}>
+                <Hb.Box
+                  style={{
+                    width: 100,
+                    paddingLeft: 12,
+                    paddingRight: 12,
+                  }}
+                >
                   <Hb.Text
                     variant="body2"
                     style={{

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorMonitoringContent.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorMonitoringContent.tsx
@@ -29,17 +29,28 @@ export const ErrorMonitoringContent = () => {
         onFilterChange={handleFilterChange}
         onReset={handleReset}
       />
-
       {isLoading ? (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 32,
+            paddingBottom: 32,
+          }}
+        >
           <Hb.Progress.Circular size={28} />
         </Hb.Box>
       ) : (
         <ErrorEventTable data={items} onRowClick={setSelectedEvent} />
       )}
-
       {totalPages > 1 && (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            marginTop: 16,
+          }}
+        >
           <Hb.Pagination
             count={totalPages}
             page={page + 1}
@@ -49,7 +60,6 @@ export const ErrorMonitoringContent = () => {
           />
         </Hb.Box>
       )}
-
       <ErrorEventDetailDialog
         event={selectedEvent}
         open={selectedEvent !== null}

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueChildrenSection.tsx
@@ -1,3 +1,4 @@
+import * as stylex from "@stylexjs/stylex";
 import { SubdirectoryArrowRightOutlined } from "hobom-design-system/icons";
 import { ISSUE_KIND_LABEL } from "@/entities/issue";
 import { ISSUE_KIND_REGISTRY } from "@/entities/issue/ui";
@@ -5,6 +6,23 @@ import { getStatusName, getStatusColor } from "@/entities/project";
 import { useProjectContext } from "@/shared/model";
 import { Hb } from "@/shared/ui";
 import { useIssueDetailContext } from "../model/useIssueDetailContext";
+
+const styles = stylex.create({
+  childRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    paddingLeft: 12,
+    paddingRight: 12,
+    paddingTop: 6.4,
+    paddingBottom: 6.4,
+    borderRadius: 12,
+    transition: "background 0.1s",
+  },
+  childRowHover: {
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
 
 export const IssueChildrenSection = () => {
   const { childIssues, progress, onNavigateToIssue } = useIssueDetailContext();
@@ -20,7 +38,14 @@ export const IssueChildrenSection = () => {
           marginBottom: 16,
         }}
       />
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
         <Hb.Text
           variant="subtitle2"
           fontWeight={600}
@@ -44,7 +69,13 @@ export const IssueChildrenSection = () => {
           />
         )}
       </Hb.Box>
-      <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
         {childIssues.map((child) => {
           const statusColor = getStatusColor(statuses, child.status);
 
@@ -65,17 +96,8 @@ export const IssueChildrenSection = () => {
                     }
                   : undefined
               }
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1,
-                px: 1.5,
-                py: 0.8,
-                borderRadius: 1.5,
-                cursor: onNavigateToIssue ? "pointer" : "default",
-                "&:hover": onNavigateToIssue ? { bgcolor: "action.hover" } : undefined,
-                transition: "background 0.1s",
-              }}
+              {...stylex.props(styles.childRow, onNavigateToIssue && styles.childRowHover)}
+              style={{ cursor: onNavigateToIssue ? "pointer" : "default" }}
             >
               <SubdirectoryArrowRightOutlined
                 aria-hidden="true"

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueCommentInput.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueCommentInput.tsx
@@ -18,7 +18,13 @@ export const IssueCommentInput = ({ onSubmit, loading }: IssueCommentInputProps)
   };
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
       <Hb.TextField
         fullWidth
         multiline
@@ -36,7 +42,12 @@ export const IssueCommentInput = ({ onSubmit, loading }: IssueCommentInputProps)
           }
         }}
       />
-      <Hb.Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+        }}
+      >
         <Hb.Button
           variant="primary"
           size="small"

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueCommentItem.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueCommentItem.tsx
@@ -3,6 +3,19 @@ import { EditOutlined, DeleteOutlined } from "hobom-design-system/icons";
 import type { IssueCommentType } from "@/entities/issue-comment";
 import { Hb } from "@/shared/ui";
 
+// StyleX is atomic and cannot express the hover-reveal descendant selector, so
+// the row styling is rendered as a scoped <style> tag instead.
+const ROOT_CLASS = "issue-comment-item-root";
+const ROOT_CSS = `
+.${ROOT_CLASS} {
+  display: flex;
+  gap: 12px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+.${ROOT_CLASS}:hover .comment-actions { opacity: 1; }
+`;
+
 interface IssueCommentItemProps {
   comment: IssueCommentType;
   authorName: string;
@@ -32,126 +45,150 @@ export const IssueCommentItem = ({
   };
 
   return (
-    <Hb.Box
-      sx={{
-        display: "flex",
-        gap: 1.5,
-        py: 1.5,
-        "&:hover .comment-actions": { opacity: 1 },
-      }}
-    >
-      <Hb.Avatar
-        sx={{
-          width: 28,
-          height: 28,
-          fontSize: "0.75rem",
-          fontWeight: 600,
-          bgcolor: "primary.main",
-          flexShrink: 0,
-          mt: 0.25,
-        }}
-      >
-        {initial}
-      </Hb.Avatar>
-      <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
-          <Hb.Text
-            variant="body2"
-            fontWeight={600}
+    <>
+      {/* React 19 hoists and de-dupes by `href`, so the rule is emitted once
+          even though every comment renders this. */}
+      <style href={ROOT_CLASS} precedence="default">
+        {ROOT_CSS}
+      </style>
+      <Hb.Box className={ROOT_CLASS}>
+        <Hb.Avatar
+          sx={{
+            width: 28,
+            height: 28,
+            fontSize: "0.75rem",
+            fontWeight: 600,
+            bgcolor: "primary.main",
+            flexShrink: 0,
+            mt: 0.25,
+          }}
+        >
+          {initial}
+        </Hb.Avatar>
+        <Hb.Box
+          style={{
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          <Hb.Box
             style={{
-              fontSize: 13,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              marginBottom: 4,
             }}
           >
-            {authorName}
-          </Hb.Text>
-          <Hb.Text variant="caption" color="text.disabled">
-            {new Date(comment.createdAt).toLocaleDateString("ko-KR")}
-          </Hb.Text>
-          {comment.editedAt && (
-            <Hb.Text variant="caption" color="text.disabled">
-              (수정됨)
-            </Hb.Text>
-          )}
-
-          {isOwn && (
-            <Hb.Box
-              className="comment-actions"
-              sx={{
-                display: "flex",
-                gap: 0.25,
-                ml: "auto",
-                opacity: 0,
-                transition: "opacity 0.15s ease",
+            <Hb.Text
+              variant="body2"
+              fontWeight={600}
+              style={{
+                fontSize: 13,
               }}
             >
-              <Hb.Tooltip title="수정">
-                <Hb.Button.Icon
+              {authorName}
+            </Hb.Text>
+            <Hb.Text variant="caption" color="text.disabled">
+              {new Date(comment.createdAt).toLocaleDateString("ko-KR")}
+            </Hb.Text>
+            {comment.editedAt && (
+              <Hb.Text variant="caption" color="text.disabled">
+                (수정됨)
+              </Hb.Text>
+            )}
+
+            {isOwn && (
+              <Hb.Box
+                className="comment-actions"
+                style={{
+                  display: "flex",
+                  gap: 2,
+                  marginLeft: "auto",
+                  opacity: 0,
+                  transition: "opacity 0.15s ease",
+                }}
+              >
+                <Hb.Tooltip title="수정">
+                  <Hb.Button.Icon
+                    size="small"
+                    aria-label="수정"
+                    onClick={() => {
+                      setEditing(!editing);
+                      setEditBody(comment.body);
+                    }}
+                    sx={{ p: 0.25 }}
+                  >
+                    <EditOutlined sx={{ fontSize: 15 }} />
+                  </Hb.Button.Icon>
+                </Hb.Tooltip>
+                <Hb.Tooltip title="삭제">
+                  <Hb.Button.Icon
+                    size="small"
+                    aria-label="삭제"
+                    onClick={() => onDelete(comment.id)}
+                    sx={{ p: 0.25 }}
+                  >
+                    <DeleteOutlined sx={{ fontSize: 15 }} />
+                  </Hb.Button.Icon>
+                </Hb.Tooltip>
+              </Hb.Box>
+            )}
+          </Hb.Box>
+
+          {editing ? (
+            <Hb.Box
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
+              <Hb.TextField
+                fullWidth
+                multiline
+                minRows={2}
+                maxRows={6}
+                size="small"
+                aria-label="댓글 수정"
+                value={editBody}
+                onChange={(e) => setEditBody(e.target.value)}
+                autoFocus
+              />
+              <Hb.Box
+                style={{
+                  display: "flex",
+                  gap: 8,
+                  justifyContent: "flex-end",
+                }}
+              >
+                <Hb.Button size="small" onClick={() => setEditing(false)}>
+                  취소
+                </Hb.Button>
+                <Hb.Button
                   size="small"
-                  aria-label="수정"
-                  onClick={() => {
-                    setEditing(!editing);
-                    setEditBody(comment.body);
-                  }}
-                  sx={{ p: 0.25 }}
+                  variant="primary"
+                  onClick={handleUpdate}
+                  disabled={!editBody.trim()}
                 >
-                  <EditOutlined sx={{ fontSize: 15 }} />
-                </Hb.Button.Icon>
-              </Hb.Tooltip>
-              <Hb.Tooltip title="삭제">
-                <Hb.Button.Icon
-                  size="small"
-                  aria-label="삭제"
-                  onClick={() => onDelete(comment.id)}
-                  sx={{ p: 0.25 }}
-                >
-                  <DeleteOutlined sx={{ fontSize: 15 }} />
-                </Hb.Button.Icon>
-              </Hb.Tooltip>
+                  수정
+                </Hb.Button>
+              </Hb.Box>
             </Hb.Box>
+          ) : (
+            <Hb.Text
+              variant="body2"
+              style={{
+                whiteSpace: "pre-wrap",
+                color: "var(--hb-color-text-primary)",
+                lineHeight: 1.6,
+                fontSize: 13,
+              }}
+            >
+              {comment.body}
+            </Hb.Text>
           )}
         </Hb.Box>
-
-        {editing ? (
-          <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-            <Hb.TextField
-              fullWidth
-              multiline
-              minRows={2}
-              maxRows={6}
-              size="small"
-              aria-label="댓글 수정"
-              value={editBody}
-              onChange={(e) => setEditBody(e.target.value)}
-              autoFocus
-            />
-            <Hb.Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
-              <Hb.Button size="small" onClick={() => setEditing(false)}>
-                취소
-              </Hb.Button>
-              <Hb.Button
-                size="small"
-                variant="primary"
-                onClick={handleUpdate}
-                disabled={!editBody.trim()}
-              >
-                수정
-              </Hb.Button>
-            </Hb.Box>
-          </Hb.Box>
-        ) : (
-          <Hb.Text
-            variant="body2"
-            style={{
-              whiteSpace: "pre-wrap",
-              color: "var(--hb-color-text-primary)",
-              lineHeight: 1.6,
-              fontSize: 13,
-            }}
-          >
-            {comment.body}
-          </Hb.Text>
-        )}
       </Hb.Box>
-    </Hb.Box>
+    </>
   );
 };

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueCommentsSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueCommentsSection.tsx
@@ -67,7 +67,11 @@ export const IssueCommentsSection = () => {
       </Hb.Text>
       <IssueCommentInput onSubmit={handleCreate} loading={createComment.isPending} />
       {comments.length > 0 && (
-        <Hb.Box sx={{ mt: 1 }}>
+        <Hb.Box
+          style={{
+            marginTop: 8,
+          }}
+        >
           {comments.map((comment) => (
             <IssueCommentItem
               key={comment.id}

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -147,12 +147,12 @@ export const IssueDetailDialog = ({
             sx={{ fontSize: 13, py: 0.8 }}
           >
             <Hb.Box
-              sx={{
+              style={{
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                bgcolor: getStatusColor(statuses, t.to),
-                mr: 1.5,
+                backgroundColor: getStatusColor(statuses, t.to),
+                marginRight: 12,
                 flexShrink: 0,
               }}
             />
@@ -178,12 +178,12 @@ export const IssueDetailDialog = ({
             sx={{ fontSize: 13, py: 0.8 }}
           >
             <Hb.Box
-              sx={{
+              style={{
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                bgcolor: ISSUE_PRIORITY_REGISTRY[key].color,
-                mr: 1.5,
+                backgroundColor: ISSUE_PRIORITY_REGISTRY[key].color,
+                marginRight: 12,
                 flexShrink: 0,
               }}
             />

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
@@ -22,7 +22,14 @@ const styles = stylex.create({
 });
 
 const MetaRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <Hb.Box sx={{ display: "flex", alignItems: "center", py: 0.5 }}>
+  <Hb.Box
+    style={{
+      display: "flex",
+      alignItems: "center",
+      paddingTop: 4,
+      paddingBottom: 4,
+    }}
+  >
     <Hb.Text
       variant="body2"
       style={{
@@ -34,7 +41,13 @@ const MetaRow = ({ label, children }: { label: string; children: React.ReactNode
     >
       {label}
     </Hb.Text>
-    <Hb.Box sx={{ flex: 1 }}>{children}</Hb.Box>
+    <Hb.Box
+      style={{
+        flex: 1,
+      }}
+    >
+      {children}
+    </Hb.Box>
   </Hb.Box>
 );
 
@@ -141,7 +154,14 @@ export const IssueMetaSection = () => {
   const statusColor = getStatusColor(statuses, issue.status);
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 2 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        marginBottom: 16,
+      }}
+    >
       <MetaRow label="상태">
         <Hb.Chip
           label={getStatusName(statuses, issue.status)}
@@ -215,9 +235,9 @@ export const IssueMetaSection = () => {
       </MetaRow>
       <MetaRow label="라벨">
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
-            gap: 0.5,
+            gap: 4,
             flexWrap: "wrap",
             alignItems: "center",
           }}

--- a/apps/hobom-system/src/features/issue-list-table/ui/IssueGrid.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/IssueGrid.tsx
@@ -161,18 +161,25 @@ export const IssueGrid = ({
       </div>
       {pagination.totalPages > 1 && (
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
-            mt: 1.5,
-            px: 1,
+            marginTop: 12,
+            paddingLeft: 8,
+            paddingRight: 8,
           }}
         >
           <Hb.Text variant="body2" color="text.secondary">
             총 {pagination.totalRows}건
           </Hb.Text>
-          <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
             <Hb.Button
               size="small"
               variant="secondary"

--- a/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
@@ -79,7 +79,15 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
 
   return (
     <Hb.Box>
-      <Hb.Box sx={{ display: "flex", gap: 1.5, mb: 2, flexWrap: "wrap", alignItems: "center" }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 12,
+          marginBottom: 16,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
         <Hb.Form.Control size="small" sx={{ minWidth: 120 }}>
           <Hb.Form.Label shrink>상태</Hb.Form.Label>
           <Hb.Form.Select
@@ -128,7 +136,11 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
-        <Hb.Box sx={{ flex: 1 }} />
+        <Hb.Box
+          style={{
+            flex: 1,
+          }}
+        />
         <Hb.Button
           size="small"
           variant="secondary"
@@ -138,7 +150,6 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
           CSV 내보내기
         </Hb.Button>
       </Hb.Box>
-
       {data.items.length === 0 ? (
         <EmptyState message="조건에 맞는 이슈가 없어요" />
       ) : (
@@ -156,7 +167,6 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
           onRowClick={onIssueClick}
         />
       )}
-
       <Hb.Menu.Root
         anchorEl={menuAnchor?.el}
         open={Boolean(menuAnchor)}
@@ -174,12 +184,12 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             sx={{ fontSize: 13, py: 0.8 }}
           >
             <Hb.Box
-              sx={{
+              style={{
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                bgcolor: getStatusColor(statuses, t.to),
-                mr: 1.5,
+                backgroundColor: getStatusColor(statuses, t.to),
+                marginRight: 12,
                 flexShrink: 0,
               }}
             />

--- a/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
@@ -45,7 +45,11 @@ export const CreateIssueInlineForm = ({ onSubmit }: CreateIssueInlineFormProps) 
   }
 
   return (
-    <Hb.Box sx={{ mt: 1 }}>
+    <Hb.Box
+      style={{
+        marginTop: 8,
+      }}
+    >
       <Hb.TextField
         value={title}
         onChange={(e) => setTitle(e.target.value)}

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -89,7 +89,14 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
         }
       >
         {/* Toolbar */}
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginBottom: 16,
+          }}
+        >
           {filters.epics.length > 0 && (
             <Hb.Form.Control size="small" sx={{ minWidth: 200 }}>
               <Hb.Form.Label shrink>에픽 필터</Hb.Form.Label>
@@ -128,11 +135,11 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
 
         {/* Columns */}
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
-            gap: 2,
+            gap: 16,
             overflowX: "auto",
-            pb: 1,
+            paddingBottom: 8,
             minHeight: 480,
           }}
         >

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
@@ -24,34 +24,35 @@ export const KanbanColumn = ({ column, issues }: KanbanColumnProps) => {
   return (
     <Hb.Box
       ref={setNodeRef}
-      sx={{
+      style={{
         flex: "0 0 296px",
         minHeight: 400,
         display: "flex",
         flexDirection: "column",
-        bgcolor: isOver ? `${config.color}14` : "action.hover",
-        borderRadius: 2,
+        backgroundColor: isOver ? `${config.color}14` : "action.hover",
+        borderRadius: 16,
         border: "1px solid",
         borderColor: isOver ? config.color : "divider",
-        p: 1.5,
+        padding: 12,
         transition: "all 0.2s",
       }}
     >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          gap: 1,
-          mb: 2,
-          px: 0.5,
+          gap: 8,
+          marginBottom: 16,
+          paddingLeft: 4,
+          paddingRight: 4,
         }}
       >
         <Hb.Box
-          sx={{
+          style={{
             width: 10,
             height: 10,
             borderRadius: "50%",
-            bgcolor: config.color,
+            backgroundColor: config.color,
             boxShadow: `0 0 0 3px ${config.color}28`,
           }}
         />
@@ -78,10 +79,10 @@ export const KanbanColumn = ({ column, issues }: KanbanColumnProps) => {
       </Hb.Box>
       <Sortable.List items={issues.map((i) => i.id)} strategy="vertical">
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             flexDirection: "column",
-            gap: 1,
+            gap: 8,
             flex: 1,
             minHeight: 60,
           }}
@@ -143,7 +144,9 @@ const renderIssueItem = (
     <Sortable.Item key={issue.id} id={issue.id}>
       <Hb.Box
         onClick={() => onIssueClick?.(issue.id)}
-        sx={{ cursor: onIssueClick ? "pointer" : undefined }}
+        style={{
+          cursor: onIssueClick ? "pointer" : undefined,
+        }}
       >
         <IssueCard
           issue={issue}

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanSwimlane.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanSwimlane.tsx
@@ -9,14 +9,19 @@ interface KanbanSwimlaneProps {
 }
 
 export const KanbanSwimlane = ({ epicKey, epicTitle, progress, children }: KanbanSwimlaneProps) => (
-  <Hb.Box sx={{ mb: 1.5 }}>
+  <Hb.Box
+    style={{
+      marginBottom: 12,
+    }}
+  >
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
-        gap: 0.75,
-        mb: 0.75,
-        px: 0.5,
+        gap: 6,
+        marginBottom: 6,
+        paddingLeft: 4,
+        paddingRight: 4,
       }}
     >
       <Hb.Text
@@ -54,6 +59,14 @@ export const KanbanSwimlane = ({ epicKey, epicTitle, progress, children }: Kanba
         />
       )}
     </Hb.Box>
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>{children}</Hb.Box>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      {children}
+    </Hb.Box>
   </Hb.Box>
 );

--- a/apps/hobom-system/src/features/menu-recommendation-header/ui/MenuRecommendationHeader.tsx
+++ b/apps/hobom-system/src/features/menu-recommendation-header/ui/MenuRecommendationHeader.tsx
@@ -1,7 +1,15 @@
 import { Hb } from "@/shared/ui";
 export const MenuRecommendationHeader = () => {
   return (
-    <Hb.Box sx={{ px: 3, py: 2.5, flexShrink: 0 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingTop: 20,
+        paddingBottom: 20,
+        flexShrink: 0,
+      }}
+    >
       <Hb.Box>
         <Hb.Text
           variant="h6"

--- a/apps/hobom-system/src/features/note/ui/ColorPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ColorPickerPopover.tsx
@@ -29,7 +29,13 @@ export const ColorPickerPopover = ({
     onClose={onClose}
     anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
   >
-    <Hb.Box sx={{ display: "flex", gap: 0.5, p: 1.5 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        gap: 4,
+        padding: 12,
+      }}
+    >
       {Object.entries(NOTE_COLORS).map(([key, hex]) => {
         const selected = value === hex;
         const isWhite = hex === "#ffffff";

--- a/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
@@ -35,7 +35,12 @@ export const LabelPickerPopover = ({
       onClose={onClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
     >
-      <Hb.Box sx={{ minWidth: 220, maxHeight: 320 }}>
+      <Hb.Box
+        style={{
+          minWidth: 220,
+          maxHeight: 320,
+        }}
+      >
         <Hb.Text
           variant="caption"
           fontWeight={600}
@@ -80,14 +85,15 @@ export const LabelPickerPopover = ({
         )}
 
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
-            gap: 0.5,
-            px: 1.5,
-            pt: 1,
-            pb: 1.5,
+            gap: 4,
+            paddingLeft: 12,
+            paddingRight: 12,
+            paddingTop: 8,
+            paddingBottom: 12,
             borderTop: labels.length > 0 ? "1px solid" : "none",
-            borderColor: "divider",
+            borderColor: "var(--hb-color-border)",
           }}
         >
           <Hb.InputBase

--- a/apps/hobom-system/src/features/note/ui/MemberPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/MemberPickerPopover.tsx
@@ -29,7 +29,12 @@ export const MemberPickerPopover = ({
       onClose={onClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
     >
-      <Hb.Box sx={{ minWidth: 260, maxHeight: 400 }}>
+      <Hb.Box
+        style={{
+          minWidth: 260,
+          maxHeight: 400,
+        }}
+      >
         <Hb.Text
           variant="caption"
           fontWeight={600}
@@ -103,12 +108,13 @@ export const MemberPickerPopover = ({
 
         {isOwner && (
           <Hb.Box
-            sx={{
-              px: 1.5,
-              pt: 1,
-              pb: 1.5,
+            style={{
+              paddingLeft: 12,
+              paddingRight: 12,
+              paddingTop: 8,
+              paddingBottom: 12,
               borderTop: "1px solid",
-              borderColor: "divider",
+              borderColor: "var(--hb-color-border)",
             }}
           >
             <Hb.Autocomplete
@@ -120,7 +126,11 @@ export const MemberPickerPopover = ({
                   component="li"
                   {...props}
                   key={u.id}
-                  sx={{ display: "flex", gap: 1.5, alignItems: "center" }}
+                  style={{
+                    display: "flex",
+                    gap: 12,
+                    alignItems: "center",
+                  }}
                 >
                   <Hb.Avatar
                     sx={{

--- a/apps/hobom-system/src/features/note/ui/NoteCreateBar.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteCreateBar.tsx
@@ -41,7 +41,14 @@ export const NoteCreateBar = ({ onClick }: NoteCreateBarProps) => {
       >
         메모 작성...
       </Hb.Text>
-      <Hb.Box sx={{ display: "flex", gap: 0.25, ml: 2 }} onClick={(e) => e.stopPropagation()}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 2,
+          marginLeft: 16,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <Hb.Tooltip title="체크리스트" arrow>
           <Hb.Button.Icon
             size="small"

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -98,7 +98,14 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
         {form.type === "CHECKLIST" && (
           <Hb.Box>
             {form.checklistItems.map((item, idx) => (
-              <Hb.Box key={idx} sx={{ display: "flex", alignItems: "center", mb: 0.5 }}>
+              <Hb.Box
+                key={idx}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  marginBottom: 4,
+                }}
+              >
                 <Hb.Checkbox
                   size="small"
                   checked={item.checked}
@@ -138,7 +145,14 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
         )}
 
         {selectedLabelIds.size > 0 && (
-          <Hb.Box sx={{ mt: 2, display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+          <Hb.Box
+            style={{
+              marginTop: 16,
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 4,
+            }}
+          >
             {form.labels.map((labelId) => (
               <Hb.Chip
                 key={labelId}
@@ -163,7 +177,12 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
         )}
       </Hb.Dialog.Content>
       <Hb.Dialog.Actions sx={{ px: 2, pb: 1.5, justifyContent: "space-between" }}>
-        <Hb.Box sx={{ display: "flex", gap: 0.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 4,
+          }}
+        >
           {!isEdit && (
             <Hb.Tooltip title={form.type === "TEXT" ? "체크리스트로 전환" : "텍스트로 전환"}>
               <Hb.Button.Icon

--- a/apps/hobom-system/src/features/note/ui/NoteGrid.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteGrid.tsx
@@ -105,13 +105,13 @@ export const NoteGrid = ({
   if (Bom.isEmpty(pinnedNotes) && Bom.isEmpty(otherNotes)) {
     return (
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
           minHeight: 280,
-          gap: 1.5,
+          gap: 12,
         }}
       >
         <LightbulbOutlined sx={{ fontSize: 96, color: "action.disabled", strokeWidth: 0.5 }} />
@@ -137,11 +137,11 @@ export const NoteGrid = ({
       overlay={
         activeNote && (
           <Hb.Box
-            sx={{
+            style={{
               width: CARD_WIDTH,
               transform: "rotate(2deg) scale(1.04)",
               boxShadow: "0 16px 40px rgba(0,0,0,0.25)",
-              borderRadius: 2,
+              borderRadius: 16,
               cursor: "grabbing",
               opacity: 0.95,
             }}
@@ -160,12 +160,16 @@ export const NoteGrid = ({
     >
       <Hb.Box>
         {!Bom.isEmpty(pinnedNotes) && (
-          <Hb.Box sx={{ mb: 3 }}>
+          <Hb.Box
+            style={{
+              marginBottom: 24,
+            }}
+          >
             <Hb.Text variant="caption" style={SECTION_HEADER_STYLE}>
               고정됨
             </Hb.Text>
             <Sortable.List items={pinnedNotes.map((n) => n.id)}>
-              <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: `${GAP}px` }}>
+              <Hb.Box style={{ display: "flex", flexWrap: "wrap", gap: `${GAP}px` }}>
                 {pinnedNotes.map((note) => (
                   <NoteItem key={note.id} note={note} {...sharedProps} />
                 ))}
@@ -182,7 +186,7 @@ export const NoteGrid = ({
               </Hb.Text>
             )}
             <Sortable.List items={otherNotes.map((n) => n.id)}>
-              <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: `${GAP}px` }}>
+              <Hb.Box style={{ display: "flex", flexWrap: "wrap", gap: `${GAP}px` }}>
                 {otherNotes.map((note) => (
                   <NoteItem key={note.id} note={note} {...sharedProps} />
                 ))}

--- a/apps/hobom-system/src/features/note/ui/NoteStatusTabs.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteStatusTabs.tsx
@@ -30,7 +30,14 @@ const TAB_ITEMS: {
 ];
 
 export const NoteStatusTabs = ({ value, onChange }: NoteStatusTabsProps) => (
-  <Hb.Box role="tablist" sx={{ display: "flex", gap: 1, mb: 3 }}>
+  <Hb.Box
+    role="tablist"
+    style={{
+      display: "flex",
+      gap: 8,
+      marginBottom: 24,
+    }}
+  >
     {TAB_ITEMS.map((item) => {
       const selected = value === item.value;
 

--- a/apps/hobom-system/src/features/note/ui/NoteTrashActions.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteTrashActions.tsx
@@ -7,19 +7,27 @@ export const NoteTrashActions = () => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        mb: 3,
-        px: 2,
-        py: 1.5,
-        borderRadius: 2,
-        bgcolor: "#fef7e0",
+        marginBottom: 24,
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingTop: 12,
+        paddingBottom: 12,
+        borderRadius: 16,
+        backgroundColor: "#fef7e0",
         border: "1px solid #fde293",
       }}
     >
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
         <InfoOutlined sx={{ fontSize: 18, color: "#b06000" }} />
         <Hb.Text
           variant="body2"

--- a/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
@@ -32,7 +32,12 @@ export const ReminderPickerPopover = ({ anchorEl, onClose, onSet }: ReminderPick
       onClose={onClose}
       anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
     >
-      <Hb.Box sx={{ p: 1.5, minWidth: 240 }}>
+      <Hb.Box
+        style={{
+          padding: 12,
+          minWidth: 240,
+        }}
+      >
         <Hb.Text variant="caption" fontWeight={600}>
           리마인더 설정
         </Hb.Text>
@@ -57,7 +62,13 @@ export const ReminderPickerPopover = ({ anchorEl, onClose, onSet }: ReminderPick
             </Hb.Menu.Item>
           ))}
         </Hb.Form.Select>
-        <Hb.Box sx={{ display: "flex", justifyContent: "flex-end", mt: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            marginTop: 8,
+          }}
+        >
           <Hb.Button
             size="small"
             onClick={handleSet}

--- a/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { NotificationsNoneOutlined } from "hobom-design-system/icons";
 import type { NotificationItemType } from "@/entities/notification";
 import { NotificationItem } from "@/entities/notification/ui";
-import { RoutesConfig, SUBTLE_SCROLLBAR_SX } from "@/shared/config";
+import { RoutesConfig } from "@/shared/config";
 import { useInfiniteScroll } from "@/shared/model";
 import { Hb } from "@/shared/ui";
 import { useNotificationList } from "../model/useNotificationList";
@@ -34,7 +34,14 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
   const renderList = () => {
     if (isPending) {
       return (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 48,
+            paddingBottom: 48,
+          }}
+        >
           <Hb.Progress.Circular size={24} />
         </Hb.Box>
       );
@@ -42,12 +49,13 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
     if (notifications.length === 0) {
       return (
         <Hb.Box
-          sx={{
-            py: 6,
+          style={{
+            paddingTop: 48,
+            paddingBottom: 48,
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
-            gap: 1,
+            gap: 8,
           }}
         >
           <NotificationsNoneOutlined sx={{ fontSize: 40, color: "text.disabled" }} />
@@ -78,7 +86,14 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
           />
         ))}
         {isFetchingNextPage && (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 16,
+              paddingBottom: 16,
+            }}
+          >
             <Hb.Progress.Circular size={20} />
           </Hb.Box>
         )}
@@ -106,7 +121,14 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
         },
       }}
     >
-      <Hb.Box sx={{ px: 2, pt: 2, pb: 0 }}>
+      <Hb.Box
+        style={{
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 16,
+          paddingBottom: 0,
+        }}
+      >
         <Hb.Text
           variant="h6"
           style={{
@@ -139,10 +161,9 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
       <Hb.Divider />
       <Hb.Box
         onScroll={handleScroll}
-        sx={{
+        style={{
           maxHeight: 380,
           overflowY: "auto",
-          ...SUBTLE_SCROLLBAR_SX,
           maskImage:
             "linear-gradient(to bottom, transparent, black 12px, black calc(100% - 12px), transparent)",
           WebkitMaskImage:
@@ -152,7 +173,15 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
         {renderList()}
       </Hb.Box>
       <Hb.Divider />
-      <Hb.Box sx={{ px: 2, py: 1.5, textAlign: "center" }}>
+      <Hb.Box
+        style={{
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 12,
+          paddingBottom: 12,
+          textAlign: "center",
+        }}
+      >
         <Hb.Button
           size="small"
           variant="ghost"

--- a/apps/hobom-system/src/features/pick-menu/ui/PickMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/PickMenuContent.tsx
@@ -19,7 +19,7 @@ export const PickMenuContent = ({ onNextCallback }: Props) => {
     <Suspense
       fallback={
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             flexDirection: "column",
             height: "100%",
@@ -46,7 +46,7 @@ const Inner = ({ onNextCallback }: Props) => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         flexDirection: "column",
         height: "100%",
@@ -72,13 +72,15 @@ const Inner = ({ onNextCallback }: Props) => {
         </Hb.List.Root>
       </PickMenuContent.Layout>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
-          gap: 1.5,
-          px: 3,
-          py: 2,
+          gap: 12,
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
           borderTop: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           flexShrink: 0,
         }}
       >

--- a/apps/hobom-system/src/features/pick-menu/ui/PickMenuFunnel.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/PickMenuFunnel.tsx
@@ -12,15 +12,30 @@ export const PickMenuFunnel = () => {
   return (
     <Funnel>
       <Funnel.Step name="select-menu">
-        <Hb.Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            height: "100%",
+          }}
+        >
           <PickMenuHeader />
-          <Hb.Box sx={{ flexGrow: 1, minHeight: 0 }}>
+          <Hb.Box
+            style={{
+              flexGrow: 1,
+              minHeight: 0,
+            }}
+          >
             <PickMenuContent onNextCallback={() => setState({ step: "pick" })} />
           </Hb.Box>
         </Hb.Box>
       </Funnel.Step>
       <Funnel.Step name="pick">
-        <Hb.Box sx={{ height: "100%" }}>
+        <Hb.Box
+          style={{
+            height: "100%",
+          }}
+        >
           <SelectedMenuContent />
         </Hb.Box>
       </Funnel.Step>

--- a/apps/hobom-system/src/features/pick-menu/ui/PickMenuHeader.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/PickMenuHeader.tsx
@@ -1,7 +1,15 @@
 import { Hb } from "@/shared/ui";
 export const PickMenuHeader = () => {
   return (
-    <Hb.Box sx={{ px: 3, py: 2.5, flexShrink: 0 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingTop: 20,
+        paddingBottom: 20,
+        flexShrink: 0,
+      }}
+    >
       <Hb.Text
         variant="h6"
         style={{

--- a/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
@@ -36,7 +36,7 @@ const Inner = () => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         flexDirection: "column",
         height: "100%",
@@ -44,11 +44,13 @@ const Inner = () => {
     >
       <SelectedMenuContent.Layout>
         <Hb.Box
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          width="100%"
-          height="100%"
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: "100%",
+            height: "100%",
+          }}
         >
           {showProgressCircle ? (
             <Hb.Stack direction="column" alignItems="center" spacing={1.5}>
@@ -84,11 +86,13 @@ const Inner = () => {
         </Hb.Box>
       </SelectedMenuContent.Layout>
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2,
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
           borderTop: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           flexShrink: 0,
         }}
       >

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
@@ -64,12 +64,12 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
       {change.changeType === "MODIFIED" && (
         <Hb.Stack spacing={1}>
           <Hb.Box
-            sx={{
-              p: 1.5,
-              borderRadius: 1,
-              bgcolor: "error.50",
+            style={{
+              padding: 12,
+              borderRadius: 8,
+              backgroundColor: "error.50",
               borderLeft: 3,
-              borderColor: "error.main",
+              borderColor: "var(--hb-color-danger)",
             }}
           >
             <Hb.Text variant="caption" color="error.main" fontWeight={600}>
@@ -86,12 +86,12 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
             </Hb.Text>
           </Hb.Box>
           <Hb.Box
-            sx={{
-              p: 1.5,
-              borderRadius: 1,
-              bgcolor: "success.50",
+            style={{
+              padding: 12,
+              borderRadius: 8,
+              backgroundColor: "success.50",
               borderLeft: 3,
-              borderColor: "success.main",
+              borderColor: "var(--hb-color-success)",
             }}
           >
             <Hb.Text variant="caption" color="success.main" fontWeight={600}>
@@ -111,12 +111,12 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
       )}
       {change.changeType === "ADDED" && change.after && (
         <Hb.Box
-          sx={{
-            p: 1.5,
-            borderRadius: 1,
-            bgcolor: "success.50",
+          style={{
+            padding: 12,
+            borderRadius: 8,
+            backgroundColor: "success.50",
             borderLeft: 3,
-            borderColor: "success.main",
+            borderColor: "var(--hb-color-success)",
           }}
         >
           <Hb.Text
@@ -131,12 +131,12 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
       )}
       {change.changeType === "DELETED" && change.before && (
         <Hb.Box
-          sx={{
-            p: 1.5,
-            borderRadius: 1,
-            bgcolor: "error.50",
+          style={{
+            padding: 12,
+            borderRadius: 8,
+            backgroundColor: "error.50",
             borderLeft: 3,
-            borderColor: "error.main",
+            borderColor: "var(--hb-color-danger)",
             textDecoration: "line-through",
           }}
         >

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
@@ -261,7 +261,11 @@ export const ExamQuestionCard = ({ questions }: Props) => {
           {currentQuestion.question}
         </Hb.Text>
 
-        <Hb.Box sx={{ mt: 2 }}>
+        <Hb.Box
+          style={{
+            marginTop: 16,
+          }}
+        >
           {currentQuestion.type === "OX" && (
             <OxInput
               value={userAnswer}
@@ -298,7 +302,13 @@ export const ExamQuestionCard = ({ questions }: Props) => {
           </Hb.Alert>
         )}
 
-        <Hb.Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
+        <Hb.Box
+          style={{
+            marginTop: 16,
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
           <Hb.Button variant="secondary" disabled={currentIndex === 0} onClick={prev}>
             이전
           </Hb.Button>

--- a/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
@@ -255,7 +255,11 @@ export const QuizCard = ({ quizzes }: Props) => {
           {currentQuiz.question}
         </Hb.Text>
 
-        <Hb.Box sx={{ mt: 2 }}>
+        <Hb.Box
+          style={{
+            marginTop: 16,
+          }}
+        >
           {currentQuiz.type === "OX" && (
             <OxInput
               value={userAnswer}
@@ -292,7 +296,13 @@ export const QuizCard = ({ quizzes }: Props) => {
           </Hb.Alert>
         )}
 
-        <Hb.Box sx={{ mt: 2, display: "flex", justifyContent: "space-between" }}>
+        <Hb.Box
+          style={{
+            marginTop: 16,
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
           <Hb.Button variant="secondary" disabled={currentIndex === 0} onClick={prev}>
             이전
           </Hb.Button>

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
@@ -34,7 +34,11 @@ export const LawVersionList = () => {
             <Hb.Text variant="caption" color="text.disabled" gutterBottom>
               법률 데이터를 수집하면 최신 개인정보보호법을 불러옵니다.
             </Hb.Text>
-            <Hb.Box mt={2}>
+            <Hb.Box
+              style={{
+                marginTop: 16,
+              }}
+            >
               <Hb.Button
                 variant="primary"
                 startIcon={<CloudDownloadOutlined />}
@@ -47,7 +51,6 @@ export const LawVersionList = () => {
           </Hb.Card.Content>
         </Hb.Card.Root>
       )}
-
       {versions.map((version) => (
         <Hb.Card.Root key={version.id} variant="outlined">
           <Hb.Card.Clickable onClick={() => navigate(`/privacy-law/versions/${version.id}`)}>

--- a/apps/hobom-system/src/features/project-dashboard/ui/IssueDashboardSection.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/IssueDashboardSection.tsx
@@ -53,15 +53,14 @@ export const IssueDashboardSection = ({ data }: IssueDashboardSectionProps) => {
           icon={<WarningAmberOutlined fontSize="small" />}
         />
       </Hb.Grid>
-
       <Hb.Grid size={12}>
         <DashboardPaper>
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
-              mb: 1,
+              marginBottom: 8,
             }}
           >
             <Hb.Text variant="body2" fontWeight={600}>
@@ -83,7 +82,6 @@ export const IssueDashboardSection = ({ data }: IssueDashboardSectionProps) => {
           />
         </DashboardPaper>
       </Hb.Grid>
-
       <Hb.Grid size={{ xs: 12, md: 4 }}>
         <DashboardPaper>
           <StatusDistributionChart data={data.byStatus} />

--- a/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
@@ -34,11 +34,11 @@ export const ProjectDashboardContent = () => {
         }}
       />
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          mb: 2.5,
+          marginBottom: 20,
         }}
       >
         <Hb.Text variant="h6" fontWeight={700}>

--- a/apps/hobom-system/src/features/project-dashboard/ui/SprintDashboardSection.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/SprintDashboardSection.tsx
@@ -57,11 +57,11 @@ const SprintDashboardInner = ({ projectId, sprintId }: SprintDashboardSectionPro
       <Hb.Grid size={12}>
         <DashboardPaper>
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
-              gap: 1,
-              mb: 1,
+              gap: 8,
+              marginBottom: 8,
             }}
           >
             <Hb.Text variant="subtitle1" fontWeight={700}>

--- a/apps/hobom-system/src/features/project-list/ui/ProjectGrid.tsx
+++ b/apps/hobom-system/src/features/project-list/ui/ProjectGrid.tsx
@@ -14,13 +14,13 @@ export const ProjectGrid = ({ projects }: ProjectGridProps) => {
   if (projects.length === 0) {
     return (
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           minHeight: 280,
-          gap: 1.5,
+          gap: 12,
         }}
       >
         <FolderOutlined sx={{ fontSize: 96, color: "#dadce0", strokeWidth: 0.5 }} />
@@ -40,10 +40,10 @@ export const ProjectGrid = ({ projects }: ProjectGridProps) => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "grid",
         gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
-        gap: 2,
+        gap: 16,
       }}
     >
       {projects.map((project) => (

--- a/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
@@ -33,7 +33,11 @@ export const AddMemberDialog = ({
               component="li"
               {...props}
               key={u.id}
-              sx={{ display: "flex", gap: 1.5, alignItems: "center" }}
+              style={{
+                display: "flex",
+                gap: 12,
+                alignItems: "center",
+              }}
             >
               <Hb.Avatar
                 sx={{

--- a/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
@@ -35,20 +35,20 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
 
   return (
     <Hb.Box
-      sx={{
-        p: 2,
-        borderRadius: 2,
+      style={{
+        padding: 16,
+        borderRadius: 16,
         border: "1px solid",
-        borderColor: "divider",
+        borderColor: "var(--hb-color-border)",
       }}
     >
       {/* 보드 헤더 */}
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          mb: 1.5,
+          marginBottom: 12,
         }}
       >
         {isEditing ? (
@@ -69,7 +69,13 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
             sx={{ flex: 1, mr: 1 }}
           />
         ) : (
-          <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
             <Hb.Text variant="body2" fontWeight={600}>
               {board.name}
             </Hb.Text>
@@ -86,7 +92,13 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
             />
           </Hb.Box>
         )}
-        <Hb.Box sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 4,
+            flexShrink: 0,
+          }}
+        >
           <Hb.Tooltip title="이름 수정">
             <Hb.Button.Icon
               size="small"
@@ -131,16 +143,18 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
               return (
                 <Sortable.Item key={col.statusId} id={col.statusId} useHandle>
                   <Hb.Box
-                    sx={{
+                    style={{
                       display: "flex",
                       alignItems: "center",
-                      gap: 1,
-                      px: 1,
-                      py: 0.5,
-                      borderRadius: 1.5,
-                      bgcolor: "action.hover",
+                      gap: 8,
+                      paddingLeft: 8,
+                      paddingRight: 8,
+                      paddingTop: 4,
+                      paddingBottom: 4,
+                      borderRadius: 12,
+                      backgroundColor: "var(--hb-color-border)",
                       border: "1px solid",
-                      borderColor: "divider",
+                      borderColor: "var(--hb-color-border)",
                     }}
                   >
                     <Sortable.Handle>
@@ -153,11 +167,11 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
                       />
                     </Sortable.Handle>
                     <Hb.Box
-                      sx={{
+                      style={{
                         width: 8,
                         height: 8,
                         borderRadius: "50%",
-                        bgcolor: config.color,
+                        backgroundColor: config.color,
                         flexShrink: 0,
                       }}
                     />
@@ -210,7 +224,13 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
         </Sortable.List>
       </Sortable.Root>
       {/* 컬럼 추가 */}
-      <Hb.Box sx={{ display: "flex", gap: 0.5, mt: 1 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 4,
+          marginTop: 8,
+        }}
+      >
         <Hb.TextField
           size="small"
           placeholder="status ID"

--- a/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
@@ -57,18 +57,26 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
       }}
     >
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2,
-          bgcolor: "action.hover",
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
+          backgroundColor: "var(--hb-color-border)",
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
           <DashboardOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
           <Hb.Text variant="subtitle2" fontWeight={700}>
             보드
@@ -87,9 +95,13 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
           />
         </Hb.Box>
       </Hb.Box>
-      <Hb.Box sx={{ p: 3 }}>
+      <Hb.Box
+        style={{
+          padding: 24,
+        }}
+      >
         {/* 보드 생성 */}
-        <Hb.Box sx={{ display: "flex", gap: 1, mb: boards.length > 0 ? 2 : 0 }}>
+        <Hb.Box style={{ display: "flex", gap: 8, marginBottom: boards.length > 0 ? 16 : 0 }}>
           <Hb.TextField
             size="small"
             placeholder="새 보드 이름"

--- a/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
@@ -58,15 +58,17 @@ export const DangerZoneSection = ({ projectId }: DangerZoneSectionProps) => {
       }}
     >
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2,
-          bgcolor: "rgba(var(--mui-palette-error-mainChannel) / 0.06)",
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
+          backgroundColor: "rgba(var(--mui-palette-error-mainChannel) / 0.06)",
           borderBottom: "1px solid",
-          borderColor: "error.light",
+          borderColor: "var(--hb-color-danger)",
           display: "flex",
           alignItems: "center",
-          gap: 1,
+          gap: 8,
         }}
       >
         <DeleteOutline sx={{ fontSize: 18, color: "error.main" }} />
@@ -75,9 +77,11 @@ export const DangerZoneSection = ({ projectId }: DangerZoneSectionProps) => {
         </Hb.Text>
       </Hb.Box>
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2.5,
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 20,
+          paddingBottom: 20,
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",

--- a/apps/hobom-system/src/features/project-settings/ui/GeneralSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/GeneralSettingsSection.tsx
@@ -38,15 +38,17 @@ export const GeneralSettingsSection = ({ projectId }: GeneralSettingsSectionProp
       }}
     >
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2,
-          bgcolor: "action.hover",
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
+          backgroundColor: "var(--hb-color-border)",
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           display: "flex",
           alignItems: "center",
-          gap: 1,
+          gap: 8,
         }}
       >
         <SettingsOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
@@ -54,7 +56,14 @@ export const GeneralSettingsSection = ({ projectId }: GeneralSettingsSectionProp
           일반
         </Hb.Text>
       </Hb.Box>
-      <Hb.Box sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Hb.Box
+        style={{
+          padding: 24,
+          display: "flex",
+          flexDirection: "column",
+          gap: 20,
+        }}
+      >
         <Hb.TextField
           label="프로젝트 키"
           value={project.key}
@@ -80,7 +89,12 @@ export const GeneralSettingsSection = ({ projectId }: GeneralSettingsSectionProp
           rows={3}
           placeholder="프로젝트에 대한 간단한 설명을 입력하세요"
         />
-        <Hb.Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+          }}
+        >
           <Hb.Button
             variant="primary"
             onClick={handleSave}

--- a/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/MemberSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import * as stylex from "@stylexjs/stylex";
 import {
   CalendarTodayOutlined,
   PeopleOutline,
@@ -14,6 +15,20 @@ import { Hb } from "@/shared/ui";
 import { ROLE_LABEL, ROLE_COLOR, getAvatarColor, formatDate } from "./project-settings-constants";
 import { AddMemberDialog } from "./AddMemberDialog";
 import { RemoveMemberDialog } from "./RemoveMemberDialog";
+
+const styles = stylex.create({
+  memberRow: {
+    paddingLeft: 24,
+    paddingRight: 24,
+    paddingTop: 12,
+    paddingBottom: 12,
+    display: "flex",
+    alignItems: "center",
+    gap: 16,
+    transition: "background-color 0.15s",
+    ":hover": { backgroundColor: "#f8f9fa" },
+  },
+});
 
 interface MemberSettingsSectionProps {
   projectId: string;
@@ -73,18 +88,26 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
       }}
     >
       <Hb.Box
-        sx={{
-          px: 3,
-          py: 2,
-          bgcolor: "action.hover",
+        style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
+          backgroundColor: "var(--hb-color-border)",
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
           <PeopleOutline sx={{ fontSize: 18, color: "text.secondary" }} />
           <Hb.Text variant="subtitle2" fontWeight={700}>
             멤버
@@ -118,9 +141,19 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
           멤버 추가
         </Hb.Button>
       </Hb.Box>
-      <Hb.Box sx={{ p: 0 }}>
+      <Hb.Box
+        style={{
+          padding: 0,
+        }}
+      >
         {project.members.length === 0 ? (
-          <Hb.Box sx={{ py: 6, textAlign: "center" }}>
+          <Hb.Box
+            style={{
+              paddingTop: 48,
+              paddingBottom: 48,
+              textAlign: "center",
+            }}
+          >
             <PeopleOutline sx={{ fontSize: 48, color: "action.disabled", mb: 1 }} />
             <Hb.Text variant="body2" color="text.disabled">
               멤버가 없어요
@@ -136,18 +169,7 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
               const roleColor = ROLE_COLOR[member.role] ?? "#6b7280";
 
               return (
-                <Hb.Box
-                  key={member.userId}
-                  sx={{
-                    px: 3,
-                    py: 1.5,
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 2,
-                    "&:hover": { bgcolor: "#f8f9fa" },
-                    transition: "background-color 0.15s",
-                  }}
-                >
+                <Hb.Box key={member.userId} {...stylex.props(styles.memberRow)}>
                   <Hb.Avatar
                     sx={{
                       width: 36,
@@ -160,12 +182,17 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
                   >
                     {displayName.charAt(0).toUpperCase()}
                   </Hb.Avatar>
-                  <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Hb.Box
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
                     <Hb.Box
-                      sx={{
+                      style={{
                         display: "flex",
                         alignItems: "center",
-                        gap: 1,
+                        gap: 8,
                       }}
                     >
                       <Hb.Text variant="body2" fontWeight={600} noWrap>
@@ -180,10 +207,10 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
                       />
                     </Hb.Box>
                     <Hb.Box
-                      sx={{
+                      style={{
                         display: "flex",
                         alignItems: "center",
-                        gap: 2,
+                        gap: 16,
                       }}
                     >
                       {user?.email && (
@@ -193,10 +220,10 @@ export const MemberSettingsSection = ({ projectId }: MemberSettingsSectionProps)
                       )}
                       <Hb.Tooltip title="참여일" arrow>
                         <Hb.Box
-                          sx={{
+                          style={{
                             display: "flex",
                             alignItems: "center",
-                            gap: 0.3,
+                            gap: 2.4,
                           }}
                         >
                           <CalendarTodayOutlined sx={{ fontSize: 11, color: "text.disabled" }} />

--- a/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
@@ -8,7 +8,14 @@ import { BoardSettingsSection } from "./BoardSettingsSection";
 import { DangerZoneSection } from "./DangerZoneSection";
 
 const SuspenseFallback = () => (
-  <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+  <Hb.Box
+    style={{
+      display: "flex",
+      justifyContent: "center",
+      paddingTop: 32,
+      paddingBottom: 32,
+    }}
+  >
     <Hb.Progress.Circular size={24} />
   </Hb.Box>
 );
@@ -22,9 +29,16 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
   const project = data.items;
 
   return (
-    <Hb.Box sx={{ maxWidth: 1080, mx: "auto" }}>
+    <Hb.Box style={{ maxWidth: 1080, marginLeft: "auto", marginRight: "auto" }}>
       {/* 헤더 */}
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 3 }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          marginBottom: 24,
+        }}
+      >
         <Hb.Avatar
           sx={{
             width: 48,
@@ -37,7 +51,13 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
           {project.key.charAt(0)}
         </Hb.Avatar>
         <Hb.Box>
-          <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
             <Hb.Text variant="h6" fontWeight={700}>
               {project.name}
             </Hb.Text>
@@ -59,14 +79,20 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
         </Hb.Box>
       </Hb.Box>
       {/* 2-column 레이아웃 */}
-      <Hb.Box sx={{ display: "flex", gap: 3, alignItems: "flex-start" }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 24,
+          alignItems: "flex-start",
+        }}
+      >
         {/* 좌측: 일반 + 위험 구역 */}
         <Hb.Box
-          sx={{
+          style={{
             flex: 1,
             display: "flex",
             flexDirection: "column",
-            gap: 3,
+            gap: 24,
             minWidth: 0,
           }}
         >
@@ -76,11 +102,11 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
 
         {/* 우측: 보드 + 멤버 */}
         <Hb.Box
-          sx={{
+          style={{
             flex: 1,
             display: "flex",
             flexDirection: "column",
-            gap: 3,
+            gap: 24,
             minWidth: 0,
           }}
         >

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationContent.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationContent.tsx
@@ -8,18 +8,23 @@ export const MenuRecommendationContent = () => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
         height: "100%",
-        gap: 2,
-        py: 8,
+        gap: 16,
+        paddingTop: 64,
+        paddingBottom: 64,
       }}
     >
       <Casino sx={{ fontSize: 64, color: "#dadce0" }} />
-      <Hb.Box sx={{ textAlign: "center" }}>
+      <Hb.Box
+        style={{
+          textAlign: "center",
+        }}
+      >
         <Hb.Text
           variant="h6"
           style={{

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationList.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationList.tsx
@@ -23,13 +23,14 @@ const Inner = () => {
   if (itemList.length === 0) {
     return (
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          py: 10,
-          gap: 1.5,
+          paddingTop: 80,
+          paddingBottom: 80,
+          gap: 12,
         }}
       >
         <MenuBook sx={{ fontSize: 64, color: "#dadce0" }} />

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
@@ -62,7 +62,15 @@ export const MenuRecommendationSpeedDial = () => {
         </Hb.Text>
       ),
       content: (
-        <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 2, px: 2 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            paddingLeft: 16,
+            paddingRight: 16,
+          }}
+        >
           <Hb.TextField
             fullWidth
             size="small"
@@ -109,7 +117,13 @@ export const MenuRecommendationSpeedDial = () => {
         </Hb.Box>
       ),
       footer: (
-        <Hb.Box display="flex" gap={1.5} width="100%">
+        <Hb.Box
+          style={{
+            display: "flex",
+            gap: 12,
+            width: "100%",
+          }}
+        >
           <Hb.Button
             fullWidth
             variant="secondary"

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
@@ -33,13 +33,13 @@ export const MenuRecommendationTab = () => {
       }}
     >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           borderBottom: "1px solid",
-          borderColor: "divider",
-          pr: 2,
+          borderColor: "var(--hb-color-border)",
+          paddingRight: 16,
         }}
       >
         <Hb.Tabs.Root
@@ -61,7 +61,12 @@ export const MenuRecommendationTab = () => {
         </Hb.Tabs.Root>
         {tab === "list" && <MenuRecommendationSpeedDial />}
       </Hb.Box>
-      <Hb.Box sx={{ flex: 1, overflow: "auto" }}>
+      <Hb.Box
+        style={{
+          flex: 1,
+          overflow: "auto",
+        }}
+      >
         <TabPanel visible={tab === "recommendation"}>
           <MenuRecommendationContent />
         </TabPanel>

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContent.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContent.tsx
@@ -14,7 +14,11 @@ export const FutureMessageContent = () => {
       key={status}
       fallback={
         <FutureMessageContent.Layout>
-          <Hb.Box sx={{ p: 2 }}>
+          <Hb.Box
+            style={{
+              padding: 16,
+            }}
+          >
             {Array.from({ length: 8 }).map((_, i) => (
               <HoBomSkeleton.List key={i} />
             ))}
@@ -44,5 +48,13 @@ const Inner = () => {
 };
 
 FutureMessageContent.Layout = ({ children }: { children: ReactNode }) => (
-  <Hb.Box sx={{ width: "100%", height: "100%", overflow: "hidden" }}>{children}</Hb.Box>
+  <Hb.Box
+    style={{
+      width: "100%",
+      height: "100%",
+      overflow: "hidden",
+    }}
+  >
+    {children}
+  </Hb.Box>
 );

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContentFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContentFunnel.tsx
@@ -11,7 +11,13 @@ export const FutureMessageContentFunnel = ({ onPrevStep, onNextStep }: Props) =>
   const { setValue, watch } = useFormContext<FutureMessageSendSchemaType>();
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
       <Hb.Box>
         <Hb.Text
           fontWeight={700}
@@ -37,7 +43,12 @@ export const FutureMessageContentFunnel = ({ onPrevStep, onNextStep }: Props) =>
         />
         <Hb.Form.Helper>전하고 싶은 말을 자유롭게 작성해 주세요.</Hb.Form.Helper>
       </Hb.Form.Control>
-      <Hb.Box display="flex" gap={1.5}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 12,
+        }}
+      >
         <Hb.Button fullWidth variant="secondary" onClick={onPrevStep}>
           이전
         </Hb.Button>

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageGrid.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageGrid.tsx
@@ -23,13 +23,14 @@ export const FutureMessageGrid = ({ messages }: { messages: FutureMessageType[] 
   if (messages.length === 0) {
     return (
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
-          py: 10,
-          gap: 1.5,
+          paddingTop: 80,
+          paddingBottom: 80,
+          gap: 12,
         }}
       >
         <MailOutline sx={{ fontSize: 64, color: "#dadce0" }} />

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageHeader.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageHeader.tsx
@@ -8,7 +8,7 @@ export const FutureMessageHeader = () => {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
@@ -26,7 +26,13 @@ const Inner = ({ onNextStep }: Props) => {
   const { data: users } = useSuspenseQuery(authQueries.users());
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
       <Hb.Box>
         <Hb.Text
           fontWeight={700}
@@ -58,7 +64,12 @@ const Inner = ({ onNextStep }: Props) => {
         </Hb.Form.Select>
         <Hb.Form.Helper>목록에서 선택해 주세요.</Hb.Form.Helper>
       </Hb.Form.Control>
-      <Hb.Box display="flex" gap={1.5}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 12,
+        }}
+      >
         <Hb.Button
           fullWidth
           variant="secondary"

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
@@ -29,7 +29,13 @@ export const FutureMessageScheduleFunnel = ({ onPrevStep }: Props) => {
   const navigate = useNavigate();
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
       <Hb.Box>
         <Hb.Text
           fontWeight={700}
@@ -55,7 +61,12 @@ export const FutureMessageScheduleFunnel = ({ onPrevStep }: Props) => {
         />
         <Hb.Form.Helper>발송 예정일을 선택해 주세요.</Hb.Form.Helper>
       </Hb.Form.Control>
-      <Hb.Box display="flex" gap={1.5}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 12,
+        }}
+      >
         <Hb.Button fullWidth variant="secondary" onClick={onPrevStep}>
           이전
         </Hb.Button>

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageTitleFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageTitleFunnel.tsx
@@ -11,7 +11,13 @@ export const FutureMessageTitleFunnel = ({ onPrevStep, onNextStep }: Props) => {
   const { setValue, watch } = useFormContext<FutureMessageSendSchemaType>();
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 24,
+      }}
+    >
       <Hb.Box>
         <Hb.Text
           fontWeight={700}
@@ -35,7 +41,12 @@ export const FutureMessageTitleFunnel = ({ onPrevStep, onNextStep }: Props) => {
         />
         <Hb.Form.Helper>메시지 제목을 입력해 주세요.</Hb.Form.Helper>
       </Hb.Form.Control>
-      <Hb.Box display="flex" gap={1.5}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          gap: 12,
+        }}
+      >
         <Hb.Button fullWidth variant="secondary" onClick={onPrevStep}>
           이전
         </Hb.Button>

--- a/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
@@ -63,11 +63,13 @@ export const AuthLoginForm = () => {
           component="form"
           noValidate
           autoComplete="off"
-          width="100%"
-          display="flex"
-          flexDirection="column"
-          gap={2}
           onSubmit={formMethods.handleSubmit(handleValidFormSubmit, handleInvalidFormSubmit)}
+          style={{
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+          }}
         >
           <Hb.Text variant="h6" fontWeight={700} style={{ marginBottom: 4 }}>
             로그인

--- a/apps/hobom-system/src/features/submit-auth-login/ui/LoginTransitionOverlay.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/LoginTransitionOverlay.tsx
@@ -1,23 +1,30 @@
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
+
+const fadeIn = stylex.keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+});
+
+const styles = stylex.create({
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 1300,
+    backgroundColor: "var(--hb-color-accent)",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 24,
+    animationName: fadeIn,
+    animationDuration: "0.4s",
+    animationTimingFunction: "ease",
+  },
+});
+
 export const LoginTransitionOverlay = () => (
-  <Hb.Box
-    sx={{
-      position: "fixed",
-      inset: 0,
-      zIndex: "modal",
-      bgcolor: "primary.main",
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "center",
-      alignItems: "center",
-      gap: 3,
-      animation: "fadeIn 0.4s ease",
-      "@keyframes fadeIn": {
-        from: { opacity: 0 },
-        to: { opacity: 1 },
-      },
-    }}
-  >
+  <Hb.Box {...stylex.props(styles.overlay)}>
     <Hb.Text
       variant="h4"
       style={{

--- a/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
@@ -58,11 +58,13 @@ export const AuthSignUpForm = () => {
         component="form"
         noValidate
         autoComplete="off"
-        width="100%"
-        display="flex"
-        flexDirection="column"
-        gap={2}
         onSubmit={formMethods.handleSubmit(handleValidFormSubmit, handleInvalidFormSubmit)}
+        style={{
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
       >
         <Hb.Text variant="h6" fontWeight={700} style={{ marginBottom: 4 }}>
           회원가입

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoList.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoList.tsx
@@ -8,7 +8,13 @@ export const DailyTodoList = () => {
   const { groupedTodosWithCategory } = useDailyTodoList();
 
   return (
-    <Hb.Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
+    <Hb.Box
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       <DailyTodoListContentSection
         groupedTodos={groupedTodosWithCategory}
         renderItem={(todo) => <DailyTodoListItem key={todo.id} item={todo} />}

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
@@ -42,13 +42,14 @@ export const DailyTodoListContentSection = ({ groupedTodos, renderItem }: Props)
     <>
       {groupedTodos.length === 0 ? (
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
             justifyContent: "center",
-            py: 8,
-            gap: 1.5,
+            paddingTop: 64,
+            paddingBottom: 64,
+            gap: 12,
           }}
         >
           <CheckCircleOutline sx={{ fontSize: 64, color: "#dadce0" }} />
@@ -63,7 +64,13 @@ export const DailyTodoListContentSection = ({ groupedTodos, renderItem }: Props)
           </Hb.Text>
         </Hb.Box>
       ) : (
-        <Hb.Box sx={{ width: "100%", py: 1 }}>
+        <Hb.Box
+          style={{
+            width: "100%",
+            paddingTop: 8,
+            paddingBottom: 8,
+          }}
+        >
           {groupedTodos.map((item) => (
             <Hb.List.Root
               key={item.categoryId}
@@ -91,7 +98,7 @@ export const DailyTodoListContentSection = ({ groupedTodos, renderItem }: Props)
                   {item.categoryTitle}
                   <CategoryProgress items={item.todoItems} />
                   <CategoryMenu categoryId={item.categoryId} categoryTitle={item.categoryTitle} />
-                  <Hb.Box sx={{ ml: "auto" }}>
+                  <Hb.Box style={{ marginLeft: "auto" }}>
                     <DailyTodoAddButton item={item} />
                   </Hb.Box>
                 </Hb.List.Subheader>
@@ -102,7 +109,14 @@ export const DailyTodoListContentSection = ({ groupedTodos, renderItem }: Props)
           ))}
         </Hb.Box>
       )}
-      <Hb.Box sx={{ px: 2.5, py: 1.5 }}>
+      <Hb.Box
+        style={{
+          paddingLeft: 20,
+          paddingRight: 20,
+          paddingTop: 12,
+          paddingBottom: 12,
+        }}
+      >
         <Hb.Button
           size="small"
           startIcon={<Add />}

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
@@ -1,5 +1,22 @@
 import { useEffect, useState } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  swatch: {
+    width: 28,
+    height: 28,
+    borderRadius: "50%",
+    cursor: "pointer",
+    transition: "border-color 0.15s",
+    ":hover": { opacity: 0.8 },
+    ":focus-visible": {
+      outline: "2px solid",
+      outlineColor: "var(--hb-color-accent)",
+      outlineOffset: 2,
+    },
+  },
+});
 
 const LABEL_COLORS: { hex: string; name: string }[] = [
   { hex: "#4680ff", name: "파랑" },
@@ -79,7 +96,12 @@ export const CreateLabelDialog = ({
         <Hb.Box
           role="radiogroup"
           aria-labelledby="color-picker-label"
-          sx={{ display: "flex", gap: 1, flexWrap: "wrap", mt: 0.5 }}
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            marginTop: 4,
+          }}
         >
           {LABEL_COLORS.map((c) => (
             <Hb.Box
@@ -95,21 +117,11 @@ export const CreateLabelDialog = ({
                   setColor(c.hex);
                 }
               }}
-              sx={{
-                width: 28,
-                height: 28,
-                borderRadius: "50%",
-                bgcolor: c.hex,
-                cursor: "pointer",
+              {...stylex.props(styles.swatch)}
+              style={{
+                backgroundColor: c.hex,
                 border: color === c.hex ? "2px solid" : "2px solid transparent",
-                borderColor: color === c.hex ? "text.primary" : "transparent",
-                transition: "border-color 0.15s",
-                "&:hover": { opacity: 0.8 },
-                "&:focus-visible": {
-                  outline: "2px solid",
-                  outlineColor: "primary.main",
-                  outlineOffset: 2,
-                },
+                borderColor: color === c.hex ? "var(--hb-color-text-primary)" : "transparent",
               }}
             />
           ))}

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/LabelList.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/LabelList.tsx
@@ -25,12 +25,14 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
   return (
     <Hb.Box>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          px: 2,
-          py: 1.5,
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 12,
+          paddingBottom: 12,
         }}
       >
         <Hb.Text variant="caption" fontWeight={600} color="text.secondary">
@@ -44,7 +46,6 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
           <AddOutlined fontSize="small" />
         </Hb.Button.Icon>
       </Hb.Box>
-
       {!labels.length ? (
         <EmptyState message="라벨이 없어요." />
       ) : (
@@ -54,7 +55,12 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
               key={label.id}
               sx={{ px: 2 }}
               secondaryAction={
-                <Hb.Box sx={{ display: "flex", gap: 0.5 }}>
+                <Hb.Box
+                  style={{
+                    display: "flex",
+                    gap: 4,
+                  }}
+                >
                   <Hb.Button.Icon
                     size="small"
                     aria-label={`${label.name} 수정`}
@@ -76,12 +82,12 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
               }
             >
               <Hb.Box
-                sx={{
+                style={{
                   width: 12,
                   height: 12,
                   borderRadius: "50%",
-                  bgcolor: label.color,
-                  mr: 1.5,
+                  backgroundColor: label.color,
+                  marginRight: 12,
                   flexShrink: 0,
                 }}
               />
@@ -95,14 +101,12 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
           ))}
         </Hb.List.Root>
       )}
-
       <CreateLabelDialog
         open={createDialogOpen}
         onClose={() => setCreateDialogOpen(false)}
         onSubmit={handleCreate}
         loading={isCreating}
       />
-
       <CreateLabelDialog
         open={editingLabel !== null}
         onClose={() => setEditingLabel(null)}

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -25,7 +25,14 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
   const availableLabels = allLabels.filter((l) => !pageLabelIds.has(l.id));
 
   return (
-    <Hb.Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap", alignItems: "center" }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        gap: 4,
+        flexWrap: "wrap",
+        alignItems: "center",
+      }}
+    >
       {pageLabels.map((label) => (
         <Hb.Chip
           key={label.id}
@@ -73,12 +80,12 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
           {availableLabels.map((label) => (
             <Hb.Menu.Item key={label.id} value={label.id}>
               <Hb.Box
-                sx={{
+                style={{
                   width: 10,
                   height: 10,
                   borderRadius: "50%",
-                  bgcolor: label.color,
-                  mr: 1,
+                  backgroundColor: label.color,
+                  marginRight: 8,
                 }}
               />
               {label.name}

--- a/apps/hobom-system/src/features/wiki-page-comments/ui/CommentInput.tsx
+++ b/apps/hobom-system/src/features/wiki-page-comments/ui/CommentInput.tsx
@@ -25,7 +25,13 @@ export const CommentInput = ({
   };
 
   return (
-    <Hb.Box sx={{ display: "flex", gap: 1, alignItems: "flex-start" }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "flex-start",
+      }}
+    >
       <Hb.TextField
         fullWidth
         multiline

--- a/apps/hobom-system/src/features/wiki-page-comments/ui/CommentList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-comments/ui/CommentList.tsx
@@ -1,10 +1,47 @@
 import { Fragment } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { ReplyOutlined, EditOutlined, DeleteOutlined } from "hobom-design-system/icons";
 import type { UserType } from "@/entities/user";
 import { Hb } from "@/shared/ui";
 import { useCommentNode } from "../model/useCommentNode";
 import { CommentInput } from "./CommentInput";
 import type { CommentTreeNode } from "../lib/build-comment-tree.lib";
+
+const styles = stylex.create({
+  node: {
+    display: "flex",
+    gap: 12,
+    paddingTop: 12,
+    paddingBottom: 12,
+    ":hover .comment-actions": { opacity: 1 },
+  },
+  nodeRoot: {
+    borderBottom: "1px solid",
+    borderColor: "var(--hb-color-border)",
+    ":last-of-type": { borderBottom: "none" },
+  },
+  nodeNested: (indent: number) => ({
+    position: "relative",
+    paddingLeft: indent,
+    "::before": {
+      content: '""',
+      position: "absolute",
+      left: indent - 20,
+      top: 0,
+      bottom: 0,
+      width: 2,
+      backgroundColor: "var(--hb-color-border)",
+      borderRadius: 8,
+    },
+  }),
+  actions: {
+    display: "flex",
+    gap: 2,
+    marginLeft: "auto",
+    opacity: 0,
+    transition: "opacity 0.15s ease",
+  },
+});
 
 interface CommentListProps {
   comments: CommentTreeNode[];
@@ -15,7 +52,12 @@ interface CommentListProps {
 
 export const CommentList = ({ comments, spaceKey, pageId, userInfo }: CommentListProps) => {
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column" }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       {comments.map((comment) => (
         <CommentNode
           key={comment.id}
@@ -65,31 +107,11 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
   return (
     <Fragment>
       <Hb.Box
-        sx={{
-          display: "flex",
-          gap: 1.5,
-          py: 1.5,
-          pl: depth > 0 ? depth * 5 : 0,
-          ...(depth === 0 && {
-            borderBottom: "1px solid",
-            borderColor: "divider",
-            "&:last-of-type": { borderBottom: "none" },
-          }),
-          ...(depth > 0 && {
-            position: "relative",
-            "&::before": {
-              content: '""',
-              position: "absolute",
-              left: depth * 5 - 2.5 * 8,
-              top: 0,
-              bottom: 0,
-              width: 2,
-              bgcolor: "divider",
-              borderRadius: 1,
-            },
-          }),
-          "&:hover .comment-actions": { opacity: 1 },
-        }}
+        {...stylex.props(
+          styles.node,
+          depth === 0 && styles.nodeRoot,
+          depth > 0 && styles.nodeNested(depth * 40),
+        )}
       >
         <Hb.Avatar
           sx={{
@@ -105,13 +127,18 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
           {initial}
         </Hb.Avatar>
 
-        <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+        <Hb.Box
+          style={{
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               display: "flex",
               alignItems: "center",
-              gap: 1,
-              mb: 0.5,
+              gap: 8,
+              marginBottom: 4,
             }}
           >
             <Hb.Text
@@ -127,16 +154,7 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
               {new Date(comment.createdAt).toLocaleDateString("ko-KR")}
             </Hb.Text>
 
-            <Hb.Box
-              className="comment-actions"
-              sx={{
-                display: "flex",
-                gap: 0.25,
-                ml: "auto",
-                opacity: 0,
-                transition: "opacity 0.15s ease",
-              }}
-            >
+            <Hb.Box className={`comment-actions ${stylex.props(styles.actions).className}`}>
               {depth < 2 && (
                 <Hb.Tooltip title="답글">
                   <Hb.Button.Icon
@@ -173,7 +191,13 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
           </Hb.Box>
 
           {editing ? (
-            <Hb.Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            <Hb.Box
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 8,
+              }}
+            >
               <Hb.TextField
                 fullWidth
                 multiline
@@ -183,7 +207,13 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
                 value={editContent}
                 onChange={(e) => setEditContent(e.target.value)}
               />
-              <Hb.Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+              <Hb.Box
+                style={{
+                  display: "flex",
+                  gap: 8,
+                  justifyContent: "flex-end",
+                }}
+              >
                 <Hb.Button size="small" onClick={cancelEditing} sx={{ textTransform: "none" }}>
                   취소
                 </Hb.Button>
@@ -212,7 +242,11 @@ const CommentNode = ({ comment, spaceKey, pageId, depth, userInfo }: CommentNode
           )}
 
           {replying && (
-            <Hb.Box sx={{ mt: 1.5 }}>
+            <Hb.Box
+              style={{
+                marginTop: 12,
+              }}
+            >
               <CommentInput
                 onSubmit={handleReply}
                 loading={isReplyPending}

--- a/apps/hobom-system/src/features/wiki-page-comments/ui/CommentsSection.tsx
+++ b/apps/hobom-system/src/features/wiki-page-comments/ui/CommentsSection.tsx
@@ -38,7 +38,14 @@ export const CommentsSection = ({ spaceKey, pageId, userInfo }: CommentsSectionP
   };
 
   return (
-    <Hb.Box sx={{ px: 3, py: 2 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <Hb.Text
         variant="subtitle1"
         fontWeight={600}
@@ -50,7 +57,11 @@ export const CommentsSection = ({ spaceKey, pageId, userInfo }: CommentsSectionP
       </Hb.Text>
       <CommentInput onSubmit={handleCreateComment} loading={createComment.isPending} />
       {loadedCount > 0 && (
-        <Hb.Box sx={{ mt: 2 }}>
+        <Hb.Box
+          style={{
+            marginTop: 16,
+          }}
+        >
           <CommentList
             comments={comments}
             spaceKey={spaceKey}
@@ -58,7 +69,13 @@ export const CommentsSection = ({ spaceKey, pageId, userInfo }: CommentsSectionP
             userInfo={userInfo}
           />
           {hasNextPage && (
-            <Hb.Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+            <Hb.Box
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                marginTop: 16,
+              }}
+            >
               <Hb.Button
                 variant="ghost"
                 size="small"

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorContent.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorContent.tsx
@@ -4,6 +4,75 @@ import { Hb } from "@/shared/ui";
 import { PageEditorToolbar } from "./PageEditorToolbar";
 import type { Editor } from "@tiptap/react";
 
+// StyleX is atomic and cannot express descendant selectors, so the prose /
+// tiptap styling is rendered as a scoped <style> tag instead.
+const PROSE_CLASS = "wiki-page-editor-prose";
+const PROSE_CSS = `
+.${PROSE_CLASS} {
+  flex: 1;
+  overflow: auto;
+  padding-left: 24px;
+  padding-right: 24px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+.${PROSE_CLASS} .tiptap {
+  outline: none;
+  min-height: 300px;
+}
+.${PROSE_CLASS} .tiptap > * + * { margin-top: 4px; }
+.${PROSE_CLASS} .tiptap h1 { font-size: 1.75rem; font-weight: 700; margin-top: 24px; margin-bottom: 8px; }
+.${PROSE_CLASS} .tiptap h2 { font-size: 1.375rem; font-weight: 600; margin-top: 20px; margin-bottom: 6px; }
+.${PROSE_CLASS} .tiptap h3 { font-size: 1.125rem; font-weight: 600; margin-top: 16px; margin-bottom: 4px; }
+.${PROSE_CLASS} .tiptap p { line-height: 1.7; }
+.${PROSE_CLASS} .tiptap blockquote {
+  border-left: 3px solid var(--hb-color-accent);
+  padding-left: 16px;
+  margin-left: 0;
+  color: var(--hb-color-text-secondary);
+  font-style: italic;
+}
+.${PROSE_CLASS} .tiptap pre {
+  background-color: var(--hb-color-canvas);
+  border-radius: 8px;
+  padding: 16px;
+  overflow: auto;
+}
+.${PROSE_CLASS} .tiptap pre code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+}
+.${PROSE_CLASS} .tiptap code {
+  background-color: var(--hb-color-canvas);
+  border-radius: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+}
+.${PROSE_CLASS} .tiptap a {
+  color: var(--hb-color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.${PROSE_CLASS} .tiptap ul, .${PROSE_CLASS} .tiptap ol { padding-left: 24px; }
+.${PROSE_CLASS} .tiptap hr {
+  border: 0;
+  border-top: 1px solid var(--hb-color-border);
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+.${PROSE_CLASS} .tiptap .is-empty::before {
+  content: attr(data-placeholder);
+  color: var(--hb-color-text-disabled);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+`;
+
 interface PageEditorContentProps {
   editor: Editor | null;
   title: string;
@@ -32,16 +101,24 @@ export const PageEditorContent = ({
   };
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          gap: 2,
-          px: 3,
-          py: 2,
+          gap: 16,
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingTop: 16,
+          paddingBottom: 16,
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
         }}
       >
         <Hb.TextField
@@ -65,78 +142,9 @@ export const PageEditorContent = ({
           저장
         </Hb.Button>
       </Hb.Box>
-
       <PageEditorToolbar editor={editor} />
-
-      <Hb.Box
-        sx={(theme) => ({
-          flex: 1,
-          overflow: "auto",
-          px: 3,
-          py: 2,
-          "& .tiptap": {
-            outline: "none",
-            minHeight: 300,
-            "& > * + *": { mt: 0.5 },
-            "& h1": { fontSize: "1.75rem", fontWeight: 700, mt: 3, mb: 1 },
-            "& h2": {
-              fontSize: "1.375rem",
-              fontWeight: 600,
-              mt: 2.5,
-              mb: 0.75,
-            },
-            "& h3": { fontSize: "1.125rem", fontWeight: 600, mt: 2, mb: 0.5 },
-            "& p": { lineHeight: 1.7 },
-            "& blockquote": {
-              borderLeft: "3px solid",
-              borderColor: "primary.main",
-              pl: 2,
-              ml: 0,
-              color: "text.secondary",
-              fontStyle: "italic",
-            },
-            "& pre": {
-              bgcolor: "grey.100",
-              ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-              borderRadius: 1,
-              p: 2,
-              overflow: "auto",
-              "& code": {
-                fontFamily: "'JetBrains Mono', monospace",
-                fontSize: "0.875rem",
-              },
-            },
-            "& code": {
-              bgcolor: "grey.100",
-              ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-              borderRadius: 0.5,
-              px: 0.5,
-              py: 0.25,
-              fontFamily: "'JetBrains Mono', monospace",
-              fontSize: "0.875rem",
-            },
-            "& a": {
-              color: "primary.main",
-              textDecoration: "underline",
-              cursor: "pointer",
-            },
-            "& ul, & ol": { pl: 3 },
-            "& hr": {
-              border: 0,
-              borderTop: "1px solid",
-              borderColor: "divider",
-              my: 2,
-            },
-            "& .is-empty::before": {
-              content: "attr(data-placeholder)",
-              color: "text.disabled",
-              float: "left",
-              height: 0,
-              pointerEvents: "none",
-            },
-          },
-        })}
-      >
+      <style dangerouslySetInnerHTML={{ __html: PROSE_CSS }} />
+      <Hb.Box className={PROSE_CLASS}>
         <EditorContent editor={editor} />
       </Hb.Box>
     </Hb.Box>

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
@@ -113,14 +113,16 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
   return (
     <>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          gap: 0.25,
-          px: 1,
-          py: 0.5,
+          gap: 2,
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 4,
+          paddingBottom: 4,
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           flexWrap: "wrap",
         }}
       >

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageViewer.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageViewer.tsx
@@ -2,6 +2,66 @@ import { useMemo } from "react";
 import { Hb } from "@/shared/ui";
 import { sanitizeHtml } from "../lib/sanitize-html.lib";
 
+// StyleX is atomic and cannot express descendant selectors, so the prose
+// styling is rendered as a scoped <style> tag instead.
+const PROSE_CLASS = "wiki-page-viewer-prose";
+const PROSE_CSS = `
+.${PROSE_CLASS} {
+  padding-left: 28px;
+  padding-right: 28px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  line-height: 1.7;
+  font-size: 0.9375rem;
+  color: var(--hb-color-text-primary);
+}
+.${PROSE_CLASS} h1 { font-size: 1.75rem; font-weight: 700; margin-top: 24px; margin-bottom: 8px; }
+.${PROSE_CLASS} h2 { font-size: 1.375rem; font-weight: 600; margin-top: 20px; margin-bottom: 6px; }
+.${PROSE_CLASS} h3 { font-size: 1.125rem; font-weight: 600; margin-top: 16px; margin-bottom: 4px; }
+.${PROSE_CLASS} p { margin-bottom: 8px; }
+.${PROSE_CLASS} blockquote {
+  border-left: 3px solid var(--hb-color-accent);
+  padding-left: 16px;
+  margin-left: 0;
+  color: var(--hb-color-text-secondary);
+  font-style: italic;
+}
+.${PROSE_CLASS} pre {
+  background-color: var(--hb-color-canvas);
+  border: 1px solid var(--hb-color-border);
+  border-radius: 8px;
+  padding: 16px;
+  overflow: auto;
+}
+.${PROSE_CLASS} pre code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8125rem;
+}
+.${PROSE_CLASS} code {
+  background-color: var(--hb-color-canvas);
+  border-radius: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8125rem;
+}
+.${PROSE_CLASS} a {
+  color: var(--hb-color-accent);
+  text-decoration: none;
+}
+.${PROSE_CLASS} a:hover { text-decoration: underline; }
+.${PROSE_CLASS} ul, .${PROSE_CLASS} ol { padding-left: 24px; margin-bottom: 8px; }
+.${PROSE_CLASS} li { margin-bottom: 2px; }
+.${PROSE_CLASS} hr {
+  border: 0;
+  border-top: 1px solid var(--hb-color-border);
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+`;
+
 interface PageViewerProps {
   content: string;
 }
@@ -10,67 +70,9 @@ export const PageViewer = ({ content }: PageViewerProps) => {
   const sanitized = useMemo(() => sanitizeHtml(content), [content]);
 
   return (
-    <Hb.Box
-      dangerouslySetInnerHTML={{ __html: sanitized }}
-      sx={(theme) => ({
-        px: 3.5,
-        py: 2,
-        lineHeight: 1.7,
-        fontSize: "0.9375rem",
-        color: "text.primary",
-        "& h1": { fontSize: "1.75rem", fontWeight: 700, mt: 3, mb: 1 },
-        "& h2": {
-          fontSize: "1.375rem",
-          fontWeight: 600,
-          mt: 2.5,
-          mb: 0.75,
-        },
-        "& h3": { fontSize: "1.125rem", fontWeight: 600, mt: 2, mb: 0.5 },
-        "& p": { mb: 1 },
-        "& blockquote": {
-          borderLeft: "3px solid",
-          borderColor: "primary.main",
-          pl: 2,
-          ml: 0,
-          color: "text.secondary",
-          fontStyle: "italic",
-        },
-        "& pre": {
-          bgcolor: "grey.50",
-          ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 1,
-          p: 2,
-          overflow: "auto",
-          "& code": {
-            fontFamily: "'JetBrains Mono', monospace",
-            fontSize: "0.8125rem",
-          },
-        },
-        "& code": {
-          bgcolor: "grey.100",
-          ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-          borderRadius: 0.5,
-          px: 0.5,
-          py: 0.25,
-          fontFamily: "'JetBrains Mono', monospace",
-          fontSize: "0.8125rem",
-        },
-        "& a": {
-          color: "primary.main",
-          textDecoration: "none",
-          "&:hover": { textDecoration: "underline" },
-        },
-        "& ul, & ol": { pl: 3, mb: 1 },
-        "& li": { mb: 0.25 },
-        "& hr": {
-          border: 0,
-          borderTop: "1px solid",
-          borderColor: "divider",
-          my: 2,
-        },
-      })}
-    />
+    <>
+      <style dangerouslySetInnerHTML={{ __html: PROSE_CSS }} />
+      <Hb.Box className={PROSE_CLASS} dangerouslySetInnerHTML={{ __html: sanitized }} />
+    </>
   );
 };

--- a/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
@@ -28,7 +28,14 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
 
   return (
     <Hb.Box>
-      <Hb.Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+      <Hb.Box
+        style={{
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 12,
+          paddingBottom: 4,
+        }}
+      >
         <Hb.Text variant="caption" fontWeight={600} color="text.secondary">
           삭제된 페이지 ({totalCount})
         </Hb.Text>
@@ -43,7 +50,12 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
               borderColor: "divider",
             }}
             secondaryAction={
-              <Hb.Box sx={{ display: "flex", gap: 0.5 }}>
+              <Hb.Box
+                style={{
+                  display: "flex",
+                  gap: 4,
+                }}
+              >
                 <Hb.Tooltip title="복원">
                   <Hb.Button.Icon
                     size="small"
@@ -83,7 +95,14 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
           </Hb.List.Item>
         ))}
         {hasNextPage && (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 1 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 8,
+              paddingBottom: 8,
+            }}
+          >
             <Hb.Button
               variant="ghost"
               size="small"
@@ -97,7 +116,6 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
           </Hb.Box>
         )}
       </Hb.List.Root>
-
       <Hb.Dialog.Root
         open={confirmDeleteId !== null}
         onClose={() => setConfirmDeleteId(null)}

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/CopyPageDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/CopyPageDialog.tsx
@@ -34,7 +34,14 @@ export const CopyPageDialog = ({
   };
 
   const suspenseFallback = (
-    <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <Hb.Progress.Circular size={20} />
     </Hb.Box>
   );
@@ -43,7 +50,14 @@ export const CopyPageDialog = ({
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>페이지 복사</Hb.Dialog.Title>
       <Hb.Dialog.Content>
-        <Hb.Box sx={{ mt: 1, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Hb.Box
+          style={{
+            marginTop: 8,
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+          }}
+        >
           <Suspense fallback={suspenseFallback}>
             <SpaceSelect selectedSpaceKey={targetSpaceKey} onSelect={setTargetSpaceKey} />
           </Suspense>

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/MovePageDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/MovePageDialog.tsx
@@ -36,7 +36,14 @@ export const MovePageDialog = ({
   };
 
   const suspenseFallback = (
-    <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <Hb.Progress.Circular size={20} />
     </Hb.Box>
   );
@@ -45,7 +52,14 @@ export const MovePageDialog = ({
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>페이지 이동</Hb.Dialog.Title>
       <Hb.Dialog.Content>
-        <Hb.Box sx={{ mt: 1, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Hb.Box
+          style={{
+            marginTop: 8,
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+          }}
+        >
           <Suspense fallback={suspenseFallback}>
             <SpaceSelect selectedSpaceKey={targetSpaceKey} onSelect={setTargetSpaceKey} />
           </Suspense>

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/PageTreeNode.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/PageTreeNode.tsx
@@ -69,7 +69,12 @@ export const PageTreeNode = ({
             )}
           </Hb.Button.Icon>
         ) : (
-          <Hb.Box sx={{ width: 24, mr: 0.5 }} />
+          <Hb.Box
+            style={{
+              width: 24,
+              marginRight: 4,
+            }}
+          />
         )}
         <Hb.List.ItemIcon sx={{ minWidth: 24, color: "inherit" }}>
           <ArticleOutlined sx={{ fontSize: 16 }} />
@@ -106,7 +111,6 @@ export const PageTreeNode = ({
           </Hb.Button.Icon>
         </Hb.Tooltip>
       </Hb.List.ItemButton>
-
       {hasChildren && (
         <Hb.Collapse in={isExpanded} unmountOnExit>
           {node.children.map((child) => (

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionDiffView.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionDiffView.tsx
@@ -1,6 +1,13 @@
 import { useSuspenseQuery } from "hobom-data";
+import * as stylex from "@stylexjs/stylex";
 import { wikiPageQueries, type DiffChangeType, type DiffEntryType } from "@/entities/wiki-page";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  row: {
+    ":hover": { filter: "brightness(0.97)" },
+  },
+});
 
 interface VersionDiffViewProps {
   spaceKey: string;
@@ -24,23 +31,25 @@ const DiffLine = ({ entry }: { entry: DiffEntryType }) => {
   return (
     <Hb.Box
       component="tr"
-      sx={{
-        bgcolor: style.bgcolor,
-        "&:hover": { filter: "brightness(0.97)" },
+      {...stylex.props(styles.row)}
+      style={{
+        backgroundColor: style.bgcolor,
       }}
     >
       <Hb.Box
         component="td"
-        sx={{
-          px: 1.5,
-          py: 0.25,
+        style={{
+          paddingLeft: 12,
+          paddingRight: 12,
+          paddingTop: 2,
+          paddingBottom: 2,
           textAlign: "right",
-          color: "text.disabled",
+          color: "var(--hb-color-text-disabled)",
           fontSize: "0.75rem",
           fontFamily: "monospace",
           userSelect: "none",
           borderRight: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
           minWidth: 40,
         }}
       >
@@ -48,9 +57,11 @@ const DiffLine = ({ entry }: { entry: DiffEntryType }) => {
       </Hb.Box>
       <Hb.Box
         component="td"
-        sx={{
-          px: 1,
-          py: 0.25,
+        style={{
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 2,
+          paddingBottom: 2,
           color: style.color,
           fontSize: "0.75rem",
           fontFamily: "monospace",
@@ -63,9 +74,11 @@ const DiffLine = ({ entry }: { entry: DiffEntryType }) => {
       </Hb.Box>
       <Hb.Box
         component="td"
-        sx={{
-          px: 1,
-          py: 0.25,
+        style={{
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 2,
+          paddingBottom: 2,
           fontSize: "0.8125rem",
           fontFamily: "monospace",
           whiteSpace: "pre-wrap",
@@ -91,8 +104,22 @@ export const VersionDiffView = ({
   const entries = data.items;
 
   return (
-    <Hb.Box sx={{ px: 2.5, py: 2 }}>
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 16,
+        }}
+      >
         <Hb.Chip
           label={`v${fromVersion}`}
           size="small"
@@ -118,12 +145,12 @@ export const VersionDiffView = ({
       <Hb.Box
         component="table"
         aria-label={`v${fromVersion}에서 v${toVersion}으로의 변경 사항`}
-        sx={{
+        style={{
           width: "100%",
           borderCollapse: "collapse",
           border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 1,
+          borderColor: "var(--hb-color-border)",
+          borderRadius: 8,
           overflow: "hidden",
         }}
       >

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionHistoryDrawer.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionHistoryDrawer.tsx
@@ -34,14 +34,16 @@ export const VersionHistoryDrawer = ({
       }}
     >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          px: 2.5,
-          py: 2,
+          paddingLeft: 20,
+          paddingRight: 20,
+          paddingTop: 16,
+          paddingBottom: 16,
           borderBottom: "1px solid",
-          borderColor: "divider",
+          borderColor: "var(--hb-color-border)",
         }}
       >
         <Hb.Text variant="h6" fontWeight={700}>
@@ -51,11 +53,17 @@ export const VersionHistoryDrawer = ({
           <CloseOutlined fontSize="small" />
         </Hb.Button.Icon>
       </Hb.Box>
-
       <ErrorBoundary inline resetKey={`${spaceKey}/${pageId}`}>
         <Suspense
           fallback={
-            <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+            <Hb.Box
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                paddingTop: 48,
+                paddingBottom: 48,
+              }}
+            >
               <Hb.Progress.Circular size={28} />
             </Hb.Box>
           }

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
@@ -35,8 +35,21 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
   }
 
   return (
-    <Hb.Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <Hb.Box sx={{ px: 2, pt: 1.5, pb: 0.5 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <Hb.Box
+        style={{
+          paddingLeft: 16,
+          paddingRight: 16,
+          paddingTop: 12,
+          paddingBottom: 4,
+        }}
+      >
         <Hb.Text variant="caption" fontWeight={600} color="text.secondary">
           버전 목록 ({totalCount})
         </Hb.Text>
@@ -118,7 +131,14 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
           );
         })}
         {hasNextPage && (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 1 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 8,
+              paddingBottom: 8,
+            }}
+          >
             <Hb.Button
               variant="ghost"
               size="small"
@@ -137,18 +157,25 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
         )}
       </Hb.List.Root>
       <Hb.Divider />
-      <Hb.Box sx={{ flex: 1, overflow: "auto" }}>
+      <Hb.Box
+        style={{
+          flex: 1,
+          overflow: "auto",
+        }}
+      >
         {selectedVersion ? (
           <>
             <Hb.Box
-              sx={{
+              style={{
                 display: "flex",
                 alignItems: "center",
-                gap: 0.5,
-                px: 2,
-                py: 1,
+                gap: 4,
+                paddingLeft: 16,
+                paddingRight: 16,
+                paddingTop: 8,
+                paddingBottom: 8,
                 borderBottom: "1px solid",
-                borderColor: "divider",
+                borderColor: "var(--hb-color-border)",
               }}
             >
               <Hb.Tooltip title="미리보기">
@@ -194,7 +221,14 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
             </Hb.Box>
             <Suspense
               fallback={
-                <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                <Hb.Box
+                  style={{
+                    display: "flex",
+                    justifyContent: "center",
+                    paddingTop: 32,
+                    paddingBottom: 32,
+                  }}
+                >
                   <Hb.Progress.Circular size={20} />
                 </Hb.Box>
               }
@@ -216,7 +250,12 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
             </Suspense>
           </>
         ) : (
-          <Hb.Box sx={{ p: 4, textAlign: "center" }}>
+          <Hb.Box
+            style={{
+              padding: 32,
+              textAlign: "center",
+            }}
+          >
             <Hb.Text variant="body2" color="text.disabled">
               버전을 선택하여 미리보기
             </Hb.Text>

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionPreview.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionPreview.tsx
@@ -4,6 +4,38 @@ import { wikiPageQueries } from "@/entities/wiki-page";
 import { sanitizeHtml } from "@/shared/lib/sanitize-html.lib";
 import { Hb } from "@/shared/ui";
 
+// StyleX is atomic and cannot express descendant selectors, so the prose
+// styling is rendered as a scoped <style> tag instead.
+const PROSE_CLASS = "wiki-version-preview-prose";
+const PROSE_CSS = `
+.${PROSE_CLASS} {
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--hb-color-text-primary);
+  padding: 16px;
+  background-color: var(--hb-color-canvas);
+  border: 1px solid var(--hb-color-border);
+  border-radius: 8px;
+}
+.${PROSE_CLASS} h1, .${PROSE_CLASS} h2, .${PROSE_CLASS} h3 { margin-top: 12px; margin-bottom: 4px; }
+.${PROSE_CLASS} p { margin-bottom: 4px; }
+.${PROSE_CLASS} a { color: var(--hb-color-accent); }
+.${PROSE_CLASS} pre {
+  background-color: var(--hb-color-canvas);
+  border: 1px solid var(--hb-color-border);
+  padding: 8px;
+  border-radius: 8px;
+  overflow: auto;
+}
+.${PROSE_CLASS} code {
+  background-color: var(--hb-color-canvas);
+  padding-left: 4px;
+  padding-right: 4px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+`;
+
 interface VersionPreviewProps {
   spaceKey: string;
   pageId: string;
@@ -16,13 +48,20 @@ export const VersionPreview = ({ spaceKey, pageId, versionNumber }: VersionPrevi
   const sanitizedContent = useMemo(() => sanitizeHtml(version.content), [version.content]);
 
   return (
-    <Hb.Box sx={{ px: 2.5, py: 2 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          gap: 1,
-          mb: 2,
+          gap: 8,
+          marginBottom: 16,
         }}
       >
         <Hb.Chip
@@ -38,39 +77,8 @@ export const VersionPreview = ({ spaceKey, pageId, versionNumber }: VersionPrevi
           {version.title}
         </Hb.Text>
       </Hb.Box>
-      <Hb.Box
-        dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-        sx={(theme) => ({
-          fontSize: "0.8125rem",
-          lineHeight: 1.6,
-          color: "text.primary",
-          p: 2,
-          bgcolor: "grey.50",
-          ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: 1,
-          "& h1, & h2, & h3": { mt: 1.5, mb: 0.5 },
-          "& p": { mb: 0.5 },
-          "& a": { color: "primary.main" },
-          "& pre": {
-            bgcolor: "grey.100",
-            ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-            border: "1px solid",
-            borderColor: "divider",
-            p: 1,
-            borderRadius: 1,
-            overflow: "auto",
-          },
-          "& code": {
-            bgcolor: "grey.100",
-            ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-            px: 0.5,
-            borderRadius: 0.5,
-            fontSize: "0.75rem",
-          },
-        })}
-      />
+      <style dangerouslySetInnerHTML={{ __html: PROSE_CSS }} />
+      <Hb.Box className={PROSE_CLASS} dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/pages/admin-users/ui/AdminUsersPage.tsx
+++ b/apps/hobom-system/src/pages/admin-users/ui/AdminUsersPage.tsx
@@ -4,7 +4,11 @@ import { ErrorBoundary, Hb, SuspenseLoader } from "@/shared/ui";
 
 export default function AdminUsersPage() {
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <ErrorBoundary inline>
         <Suspense fallback={<SuspenseLoader />}>
           <PendingUsersTable />

--- a/apps/hobom-system/src/pages/auth-login/ui/AuthLoginPage.tsx
+++ b/apps/hobom-system/src/pages/auth-login/ui/AuthLoginPage.tsx
@@ -6,26 +6,32 @@ export default function AuthLoginPage() {
   return (
     <Hb.Box
       component="main"
-      width="100%"
-      height="100%"
-      display="flex"
-      justifyContent="center"
-      alignItems="center"
-      sx={{ bgcolor: "background.default" }}
+      style={{
+        backgroundColor: "var(--hb-color-canvas)",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
     >
       {/* 카드 래퍼 */}
       <Hb.Box
-        sx={{
+        style={{
           width: "100%",
           maxWidth: 420,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
-          gap: 3,
+          gap: 24,
         }}
       >
         {/* 로고 / 브랜드 */}
-        <Hb.Box sx={{ textAlign: "center" }}>
+        <Hb.Box
+          style={{
+            textAlign: "center",
+          }}
+        >
           <Hb.Text
             variant="h4"
             style={{
@@ -44,12 +50,12 @@ export default function AuthLoginPage() {
 
         {/* 폼 카드 */}
         <Hb.Box
-          sx={{
+          style={{
             width: "100%",
-            bgcolor: "background.paper",
-            borderRadius: 3,
+            backgroundColor: "var(--hb-color-surface)",
+            borderRadius: 24,
             boxShadow: "0 4px 24px rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
-            p: 4,
+            padding: 32,
           }}
         >
           <ErrorBoundary fallback={<AuthLoginPage.Fallback />}>
@@ -63,7 +69,13 @@ export default function AuthLoginPage() {
 
 AuthLoginPage.Fallback = () => {
   return (
-    <Hb.Box sx={{ textAlign: "center", py: 2 }}>
+    <Hb.Box
+      style={{
+        textAlign: "center",
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <ErrorOutline color="error" sx={{ fontSize: 48, mb: 1 }} />
       <Hb.Text variant="h6" fontWeight={600} gutterBottom>
         앗!

--- a/apps/hobom-system/src/pages/auth-signup/ui/AuthSignUpPage.tsx
+++ b/apps/hobom-system/src/pages/auth-signup/ui/AuthSignUpPage.tsx
@@ -6,24 +6,30 @@ export default function AuthSignUpPage() {
   return (
     <Hb.Box
       component="main"
-      width="100%"
-      height="100%"
-      display="flex"
-      justifyContent="center"
-      alignItems="center"
-      sx={{ bgcolor: "background.default" }}
+      style={{
+        backgroundColor: "var(--hb-color-canvas)",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
     >
       <Hb.Box
-        sx={{
+        style={{
           width: "100%",
           maxWidth: 420,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
-          gap: 3,
+          gap: 24,
         }}
       >
-        <Hb.Box sx={{ textAlign: "center" }}>
+        <Hb.Box
+          style={{
+            textAlign: "center",
+          }}
+        >
           <Hb.Text
             variant="h4"
             style={{
@@ -41,12 +47,12 @@ export default function AuthSignUpPage() {
         </Hb.Box>
 
         <Hb.Box
-          sx={{
+          style={{
             width: "100%",
-            bgcolor: "background.paper",
-            borderRadius: 3,
+            backgroundColor: "var(--hb-color-surface)",
+            borderRadius: 24,
             boxShadow: "0 4px 24px rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
-            p: 4,
+            padding: 32,
           }}
         >
           <ErrorBoundary fallback={<AuthSignUpPage.Fallback />}>
@@ -60,7 +66,13 @@ export default function AuthSignUpPage() {
 
 AuthSignUpPage.Fallback = () => {
   return (
-    <Hb.Box sx={{ textAlign: "center", py: 2 }}>
+    <Hb.Box
+      style={{
+        textAlign: "center",
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       <ErrorOutline color="error" sx={{ fontSize: 48, mb: 1 }} />
       <Hb.Text variant="h6" fontWeight={600} gutterBottom>
         앗!

--- a/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
+++ b/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
@@ -18,13 +18,13 @@ export default function FutureMessageSendPage() {
 
   return (
     <Hb.Box
-      sx={{
+      style={{
         width: "100%",
         height: "100%",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        p: 4,
+        padding: 32,
       }}
     >
       <FormProvider {...formMethods}>

--- a/apps/hobom-system/src/pages/not-found/ui/NotFoundPage.tsx
+++ b/apps/hobom-system/src/pages/not-found/ui/NotFoundPage.tsx
@@ -16,7 +16,7 @@ export default function NotFoundPage() {
       }}
     >
       <div>
-        <Hb.Box sx={{ mx: "auto", textAlign: "center" }}>
+        <Hb.Box style={{ marginLeft: "auto", marginRight: "auto", textAlign: "center" }}>
           <StopScreenShareOutlined sx={{ fontSize: 48 }} />
           <Hb.Text variant="h5" gutterBottom>
             404
@@ -26,8 +26,8 @@ export default function NotFoundPage() {
           </Hb.Text>
         </Hb.Box>
         <Hb.Box
-          sx={{
-            mt: 1,
+          style={{
+            marginTop: 8,
             display: "flex",
             justifyContent: "center",
             alignItems: "center",

--- a/apps/hobom-system/src/pages/privacy-law-chat/ui/PrivacyLawChatPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-chat/ui/PrivacyLawChatPage.tsx
@@ -13,7 +13,6 @@ const PrivacyLawChatPage = () => {
           제한이 적용됩니다. 응답이 느리거나 실패할 수 있어요.
         </Hb.Text>
       </Hb.Alert>
-
       <Hb.Stack direction="row" justifyContent="flex-end" mb={1}>
         {messages.length > 0 && (
           <Hb.Tooltip title="대화 초기화">
@@ -23,10 +22,14 @@ const PrivacyLawChatPage = () => {
           </Hb.Tooltip>
         )}
       </Hb.Stack>
-
       <ChatMessageList messages={messages} isPending={isPending} />
-
-      <Hb.Box sx={{ pt: 2, borderTop: 1, borderColor: "divider" }}>
+      <Hb.Box
+        style={{
+          paddingTop: 16,
+          borderTop: 1,
+          borderColor: "var(--hb-color-border)",
+        }}
+      >
         <ChatInput onSend={sendMessage} disabled={isPending} />
       </Hb.Box>
     </Hb.Stack>

--- a/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
@@ -31,7 +31,11 @@ const PrivacyLawLayoutPage = () => {
   const currentTab = TABS.findIndex((tab) => pathname.startsWith(tab.path));
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Stack direction="row" alignItems="center" spacing={1.5} mb={3}>
         <Hb.Text variant="h5" fontWeight={600}>
           개인정보보호법
@@ -40,7 +44,6 @@ const PrivacyLawLayoutPage = () => {
           CPPG 학습 플랫폼
         </Hb.Text>
       </Hb.Stack>
-
       <Hb.Tabs.Root
         value={currentTab === -1 ? 0 : currentTab}
         onChange={(_, idx) => navigate(TABS[idx].path)}
@@ -50,7 +53,6 @@ const PrivacyLawLayoutPage = () => {
           <Hb.Tabs.Item key={tab.path} icon={tab.icon} iconPosition="start" label={tab.label} />
         ))}
       </Hb.Tabs.Root>
-
       <Outlet />
     </Hb.Box>
   );

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -140,7 +140,11 @@ export default function WorkspacePage() {
               onCommit={(name) => renameFolder(folder.id, name)}
               textSx={{ fontSize: 14 }}
             />
-            <Hb.Box sx={{ flex: 1 }} />
+            <Hb.Box
+              style={{
+                flex: 1,
+              }}
+            />
             <Hb.Button.Icon
               size="small"
               className="row-action"
@@ -153,7 +157,14 @@ export default function WorkspacePage() {
           </Hb.Stack>
         ))}
       </Hb.Stack>
-      <Hb.Box sx={{ flex: 1, minWidth: 0, p: 3, overflow: "auto" }}>
+      <Hb.Box
+        style={{
+          flex: 1,
+          minWidth: 0,
+          padding: 24,
+          overflow: "auto",
+        }}
+      >
         <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
           <Hb.Text variant="h6">{activeFolder?.name ?? "워크스페이스"}</Hb.Text>
           <Hb.Button variant="primary" startIcon={<AddOutlined />} onClick={handleNewDesign}>
@@ -166,7 +177,13 @@ export default function WorkspacePage() {
             아직 디자인이 없어요. "새 디자인"으로 시작하세요.
           </Hb.Text>
         ) : (
-          <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 16,
+            }}
+          >
             {items.map((item) => {
               const favorite = favorites.find((entry) => entry.designId === item.id);
 
@@ -231,7 +248,12 @@ export default function WorkspacePage() {
                     <DeleteOutline sx={{ fontSize: 16 }} />
                   </Hb.Button.Icon>
                   <Hb.Box
-                    sx={{ height: 120, bgcolor: "background.default", borderRadius: 1, mb: 1 }}
+                    style={{
+                      height: 120,
+                      backgroundColor: "var(--hb-color-canvas)",
+                      borderRadius: 8,
+                      marginBottom: 8,
+                    }}
                   />
                   <Hb.Text
                     variant="body2"

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -129,15 +129,15 @@ function StudioEditor({ itemId, name, document }: StudioEditorProps) {
             Frame
           </Hb.Text>
           <Hb.Box
-            sx={{
+            style={{
               flex: 1,
               minHeight: 320,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              p: 4,
-              bgcolor: "#ffffff",
-              borderRadius: 1,
+              padding: 32,
+              backgroundColor: "#ffffff",
+              borderRadius: 8,
               boxShadow: "0 8px 30px rgba(0, 0, 0, 0.35)",
             }}
           >
@@ -158,7 +158,11 @@ function StudioEditor({ itemId, name, document }: StudioEditorProps) {
             onDelete={deleteSelected}
           />
           <Hb.Divider />
-          <Hb.Box sx={{ p: 1.5 }}>
+          <Hb.Box
+            style={{
+              padding: 12,
+            }}
+          >
             <CodePanel document={document} />
           </Hb.Box>
         </Panel>
@@ -195,7 +199,16 @@ function Panel({ width, side, children }: PanelProps) {
 /** 패널 내 섹션 헤더(작은 대문자 라벨). */
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
-    <Hb.Box sx={{ px: 1.5, py: 1, borderBottom: 1, borderColor: "divider" }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 12,
+        paddingRight: 12,
+        paddingTop: 8,
+        paddingBottom: 8,
+        borderBottom: 1,
+        borderColor: "var(--hb-color-border)",
+      }}
+    >
       <Hb.Text
         style={{
           fontSize: 11,

--- a/apps/hobom-system/src/pages/wiki-space-home/ui/WikiSpaceHomePage.tsx
+++ b/apps/hobom-system/src/pages/wiki-space-home/ui/WikiSpaceHomePage.tsx
@@ -13,7 +13,14 @@ const SpaceHomeContent = ({ spaceKey }: { spaceKey: string }) => {
   const space = data.items;
 
   return (
-    <Hb.Box sx={{ px: 3, py: 3 }}>
+    <Hb.Box
+      style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingTop: 24,
+        paddingBottom: 24,
+      }}
+    >
       <Hb.Text
         variant="h5"
         fontWeight={700}

--- a/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
+++ b/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
@@ -56,9 +56,11 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
 
       return (
         <Hb.Box
-          sx={{
+          style={{
             width: "100%",
-            ...(inline ? { flex: 1, minHeight: 120, py: 4 } : { height: "100vh" }),
+            ...(inline
+              ? { flex: 1, minHeight: 120, paddingTop: 32, paddingBottom: 32 }
+              : { height: "100vh" }),
             display: "flex",
             justifyContent: "center",
             alignItems: "center",
@@ -78,16 +80,17 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
             }}
           >
             <Hb.Box
-              sx={{
+              style={{
                 width: 48,
                 height: 48,
                 borderRadius: "50%",
-                bgcolor: "error.main",
+                backgroundColor: "var(--hb-color-danger)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                mx: "auto",
-                mb: 2,
+                marginLeft: "auto",
+                marginRight: "auto",
+                marginBottom: 16,
               }}
             >
               <ReportProblemOutlined sx={{ color: "#fff", fontSize: 24 }} />
@@ -115,13 +118,13 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
             </Hb.Text>
             {error?.message ? (
               <Hb.Box
-                sx={{
-                  mt: 2,
-                  p: 1.5,
-                  bgcolor: "grey.50",
-                  borderRadius: 1,
+                style={{
+                  marginTop: 16,
+                  padding: 12,
+                  backgroundColor: "#fafafa",
+                  borderRadius: 8,
                   border: "1px solid",
-                  borderColor: "divider",
+                  borderColor: "var(--hb-color-border)",
                 }}
               >
                 <Hb.Text

--- a/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
+++ b/apps/hobom-system/src/widgets/canvas/ui/Canvas.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, MouseEvent, PointerEvent } from "react";
+import type { ComponentType, CSSProperties, MouseEvent, PointerEvent } from "react";
 import { Hb } from "@/shared/ui";
 import { getManifest } from "@/entities/manifest";
 import {
@@ -27,13 +27,16 @@ type ResizeAxis = "x" | "y" | "both";
  * 흐름 레이아웃에서 의미 있는 핸들 세트.
  * 위/왼쪽은 레이아웃이 고정하므로 오른쪽(너비)·아래(높이)·우하단(둘 다)만 둔다.
  */
-const HANDLES: { axis: ResizeAxis; sx: Record<string, unknown> }[] = [
-  { axis: "x", sx: { right: -10, top: "50%", transform: "translateY(-50%)", cursor: "ew-resize" } },
+const HANDLES: { axis: ResizeAxis; style: CSSProperties }[] = [
+  {
+    axis: "x",
+    style: { right: -10, top: "50%", transform: "translateY(-50%)", cursor: "ew-resize" },
+  },
   {
     axis: "y",
-    sx: { bottom: -10, left: "50%", transform: "translateX(-50%)", cursor: "ns-resize" },
+    style: { bottom: -10, left: "50%", transform: "translateX(-50%)", cursor: "ns-resize" },
   },
-  { axis: "both", sx: { right: -10, bottom: -10, cursor: "nwse-resize" } },
+  { axis: "both", style: { right: -10, bottom: -10, cursor: "nwse-resize" } },
 ];
 
 interface NodeViewProps {
@@ -109,11 +112,11 @@ function NodeView({ node, selectedId, onSelect, onResize }: NodeViewProps) {
     <Hb.Box
       component="span"
       onClick={handleSelect}
-      sx={{
+      style={{
         position: "relative",
         display: "inline-flex",
         cursor: "pointer",
-        borderRadius: 1,
+        borderRadius: 8,
         outline: "2px solid",
         outlineColor: isSelected ? "primary.main" : "transparent",
         outlineOffset: 2,
@@ -130,7 +133,6 @@ function NodeView({ node, selectedId, onSelect, onResize }: NodeViewProps) {
           />
         ))}
       </Component>
-
       {isSelected &&
         onResize &&
         HANDLES.map((handle) => (
@@ -138,7 +140,7 @@ function NodeView({ node, selectedId, onSelect, onResize }: NodeViewProps) {
             key={handle.axis}
             onPointerDown={startResize(handle.axis)}
             onClick={(event) => event.stopPropagation()}
-            sx={{
+            style={{
               position: "absolute",
               width: 20,
               height: 20,
@@ -147,16 +149,16 @@ function NodeView({ node, selectedId, onSelect, onResize }: NodeViewProps) {
               justifyContent: "center",
               touchAction: "none",
               zIndex: 3,
-              ...handle.sx,
+              ...handle.style,
             }}
           >
             <Hb.Box
-              sx={{
+              style={{
                 width: 10,
                 height: 10,
-                bgcolor: "primary.main",
+                backgroundColor: "var(--hb-color-accent)",
                 border: "2px solid",
-                borderColor: "background.paper",
+                borderColor: "var(--hb-color-surface)",
                 borderRadius: "2px",
               }}
             />

--- a/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
+++ b/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
@@ -38,13 +38,13 @@ export function CodePanel({ document }: CodePanelProps) {
       </Hb.Stack>
       <Hb.Box
         component="pre"
-        sx={{
-          m: 0,
-          p: 1.5,
+        style={{
+          margin: 0,
+          padding: 12,
           minWidth: 0,
           maxWidth: "100%",
-          bgcolor: "background.default",
-          borderRadius: 1,
+          backgroundColor: "var(--hb-color-canvas)",
+          borderRadius: 8,
           fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
           fontSize: "0.75rem",
           lineHeight: 1.6,

--- a/apps/hobom-system/src/widgets/daily-todo-workspace/ui/DailyTodoWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/daily-todo-workspace/ui/DailyTodoWorkspace.tsx
@@ -12,11 +12,13 @@ const DateHeader = () => {
 
   return (
     <Hb.Box
-      sx={{
-        px: 3,
-        py: 2,
+      style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingTop: 16,
+        paddingBottom: 16,
         borderBottom: "1px solid",
-        borderColor: "divider",
+        borderColor: "var(--hb-color-border)",
         flexShrink: 0,
       }}
     >
@@ -46,13 +48,13 @@ const DateHeader = () => {
 export const DailyTodoWorkspace = () => {
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         flexDirection: "row",
         width: "100%",
         height: "100%",
-        p: 3,
-        gap: 2,
+        padding: 24,
+        gap: 16,
       }}
     >
       <Hb.Paper
@@ -85,7 +87,13 @@ export const DailyTodoWorkspace = () => {
         }}
       >
         <DateHeader />
-        <Hb.Box sx={{ flexGrow: 1, overflowY: "auto", minHeight: 0 }}>
+        <Hb.Box
+          style={{
+            flexGrow: 1,
+            overflowY: "auto",
+            minHeight: 0,
+          }}
+        >
           <DailyTodoList.WithSuspense>
             <DailyTodoList />
           </DailyTodoList.WithSuspense>

--- a/apps/hobom-system/src/widgets/dashboard-workspace/ui/DashboardWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/dashboard-workspace/ui/DashboardWorkspace.tsx
@@ -39,22 +39,32 @@ export const DashboardWorkspace = () => {
   };
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 3,
+          marginBottom: 24,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 40,
               height: 40,
-              borderRadius: 2,
-              bgcolor: "primary.main",
+              borderRadius: 16,
+              backgroundColor: "var(--hb-color-accent)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/apps/hobom-system/src/widgets/error-monitoring-workspace/ui/ErrorMonitoringWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/error-monitoring-workspace/ui/ErrorMonitoringWorkspace.tsx
@@ -5,22 +5,32 @@ import { Hb, ErrorBoundary, SuspenseLoader } from "@/shared/ui";
 
 export const ErrorMonitoringWorkspace = () => {
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 3,
+          marginBottom: 24,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 40,
               height: 40,
-              borderRadius: 2,
-              bgcolor: "warning.main",
+              borderRadius: 16,
+              backgroundColor: "var(--hb-color-warning)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/apps/hobom-system/src/widgets/future-message-workspace/ui/FutureMessageWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/future-message-workspace/ui/FutureMessageWorkspace.tsx
@@ -8,13 +8,13 @@ import { Hb } from "@/shared/ui";
 export const FutureMessageWorkspace = () => {
   return (
     <Hb.Box
-      sx={{
+      style={{
         width: "100%",
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        p: 3,
-        gap: 2,
+        padding: 24,
+        gap: 16,
       }}
     >
       <FutureMessageHeader />
@@ -32,7 +32,7 @@ export const FutureMessageWorkspace = () => {
       >
         <FutureMessageStatusTab />
         <Hb.Box
-          sx={{
+          style={{
             flex: 1,
             overflow: "hidden",
             minHeight: 0,

--- a/apps/hobom-system/src/widgets/insert-palette/ui/InsertPalette.tsx
+++ b/apps/hobom-system/src/widgets/insert-palette/ui/InsertPalette.tsx
@@ -1,5 +1,25 @@
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
 import { listManifests, type ComponentKey } from "@/entities/manifest";
+
+const styles = stylex.create({
+  chip: {
+    border: "1px solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 8,
+    backgroundColor: "transparent",
+    color: "var(--hb-color-text-primary)",
+    fontFamily: "inherit",
+    fontSize: 12,
+    paddingLeft: 8,
+    paddingRight: 8,
+    paddingTop: 4,
+    paddingBottom: 4,
+    cursor: "pointer",
+    transition: "background-color 0.12s",
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
 
 interface InsertPaletteProps {
   onInsert: (key: ComponentKey) => void;
@@ -8,26 +28,20 @@ interface InsertPaletteProps {
 /** 등록된 컴포넌트를 칩 목록으로 보여준다. 클릭하면 선택된 컨테이너(또는 루트)에 추가. */
 export function InsertPalette({ onInsert }: InsertPaletteProps) {
   return (
-    <Hb.Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, p: 1.5 }}>
+    <Hb.Box
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 4,
+        padding: 12,
+      }}
+    >
       {listManifests().map((manifest) => (
         <Hb.Box
           key={manifest.name}
           component="button"
           onClick={() => onInsert(manifest.name)}
-          sx={{
-            border: 1,
-            borderColor: "divider",
-            borderRadius: 1,
-            bgcolor: "transparent",
-            color: "text.primary",
-            fontFamily: "inherit",
-            fontSize: 12,
-            px: 1,
-            py: 0.5,
-            cursor: "pointer",
-            transition: "background-color 0.12s",
-            "&:hover": { bgcolor: "action.hover" },
-          }}
+          {...stylex.props(styles.chip)}
         >
           {manifest.name.replace(/^Hb\./, "")}
         </Hb.Box>

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -1,3 +1,4 @@
+import * as stylex from "@stylexjs/stylex";
 import { DeleteOutline } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
 import { getManifest, type PropSpec } from "@/entities/manifest";
@@ -19,7 +20,11 @@ interface InspectorProps {
 export function Inspector({ node, onChange, onStyleChange, onDelete }: InspectorProps) {
   if (!node || !isComponentNode(node)) {
     return (
-      <Hb.Box sx={{ p: 2 }}>
+      <Hb.Box
+        style={{
+          padding: 16,
+        }}
+      >
         <Hb.Text
           style={{
             fontSize: 12,
@@ -35,7 +40,11 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
   const manifest = getManifest(node.type);
 
   return (
-    <Hb.Box sx={{ p: 1.5 }}>
+    <Hb.Box
+      style={{
+        padding: 12,
+      }}
+    >
       <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
         <Hb.Text
           style={{
@@ -150,6 +159,26 @@ interface PropFieldProps {
 const labelStyle = { fontSize: 11, color: "var(--hb-color-text-secondary)" } as const;
 const inputSx = { "& .MuiInputBase-input": { fontSize: 12, py: 0.75 } } as const;
 
+const styles = stylex.create({
+  segment: {
+    flex: 1,
+    paddingTop: 4,
+    paddingBottom: 4,
+    paddingLeft: 4,
+    paddingRight: 4,
+    fontSize: 11,
+    fontFamily: "inherit",
+    cursor: "pointer",
+    transition: "background-color 0.12s",
+  },
+  segmentSelectedHover: {
+    ":hover": { backgroundColor: "var(--hb-color-accent)" },
+  },
+  segmentUnselectedHover: {
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
+
 /** prop 한 개를 spec.kind에 맞는 컨트롤로 렌더한다. slot은 편집 대상이 아니다. */
 function PropField({ name, spec, value, onChange }: PropFieldProps) {
   if (spec.kind === "slot") {
@@ -213,12 +242,13 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
     <Hb.Stack gap={0.5} sx={{ minWidth: 0 }}>
       <Hb.Text style={labelStyle}>{name}</Hb.Text>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
-          borderRadius: 1,
+          borderRadius: 8,
           overflow: "hidden",
-          border: 1,
-          borderColor: "divider",
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderColor: "var(--hb-color-border)",
         }}
       >
         {spec.values.map((option, index) => (
@@ -226,22 +256,19 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
             key={option}
             component="button"
             onClick={() => onChange(name, option)}
-            sx={{
-              flex: 1,
+            {...stylex.props(
+              styles.segment,
+              value === option ? styles.segmentSelectedHover : styles.segmentUnselectedHover,
+            )}
+            style={{
               border: 0,
-              borderLeft: index === 0 ? 0 : 1,
-              borderColor: "divider",
-              py: 0.5,
-              px: 0.5,
-              fontSize: 11,
-              fontFamily: "inherit",
-              cursor: "pointer",
-              transition: "background-color 0.12s",
-              bgcolor: value === option ? "primary.main" : "transparent",
-              color: value === option ? "primary.contrastText" : "text.secondary",
-              "&:hover": {
-                bgcolor: value === option ? "primary.main" : "action.hover",
-              },
+              borderLeft: index === 0 ? 0 : "1px solid",
+              borderColor: "var(--hb-color-border)",
+              backgroundColor: value === option ? "var(--hb-color-accent)" : "transparent",
+              color:
+                value === option
+                  ? "var(--hb-color-accent-contrast)"
+                  : "var(--hb-color-text-secondary)",
             }}
           >
             {option}

--- a/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
+++ b/apps/hobom-system/src/widgets/layers-panel/ui/LayersPanel.tsx
@@ -1,4 +1,5 @@
 import { Bom } from "hobom-utils";
+import * as stylex from "@stylexjs/stylex";
 import { DragIndicatorOutlined } from "hobom-design-system/icons";
 import { Hb, Sortable } from "@/shared/ui";
 import {
@@ -9,6 +10,18 @@ import {
   type StudioDocument,
 } from "@/entities/document";
 import type { DragEndEvent } from "hobom-design-system";
+
+const styles = stylex.create({
+  row: {
+    display: "flex",
+    alignItems: "center",
+    gap: 4,
+    paddingRight: 8,
+    paddingTop: 4,
+    paddingBottom: 4,
+    ":hover": { backgroundColor: "var(--hb-color-border)" },
+  },
+});
 
 interface LayersPanelProps {
   document: StudioDocument;
@@ -47,7 +60,12 @@ export function LayersPanel({ document, selectedId, onSelect, onReorder }: Layer
   return (
     <Sortable.Root onDragEnd={handleDragEnd}>
       <Sortable.List items={layers.map((layer) => layer.node.id)} strategy="vertical">
-        <Hb.Box sx={{ py: 0.5 }}>
+        <Hb.Box
+          style={{
+            paddingTop: 4,
+            paddingBottom: 4,
+          }}
+        >
           {layers.map(({ node, depth }) => (
             <Sortable.Item key={node.id} id={node.id} useHandle>
               <LayerRow node={node} depth={depth} selectedId={selectedId} onSelect={onSelect} />
@@ -72,15 +90,10 @@ function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
 
   return (
     <Hb.Box
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        gap: 0.5,
-        pl: `${4 + depth * 14}px`,
-        pr: 1,
-        py: 0.5,
-        bgcolor: isSelected ? "action.selected" : "transparent",
-        "&:hover": { bgcolor: isSelected ? "action.selected" : "action.hover" },
+      {...stylex.props(styles.row)}
+      style={{
+        paddingLeft: `${4 + depth * 14}px`,
+        backgroundColor: isSelected ? "var(--hb-color-border)" : "transparent",
       }}
     >
       <Sortable.Handle>
@@ -90,7 +103,7 @@ function LayerRow({ node, depth, selectedId, onSelect }: LayerRowProps) {
       </Sortable.Handle>
       <Hb.Box
         onClick={() => onSelect(node.id)}
-        sx={{
+        style={{
           flex: 1,
           minWidth: 0,
           fontSize: 12,

--- a/apps/hobom-system/src/widgets/log-dashboard-workspace/ui/LogDashboardWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/log-dashboard-workspace/ui/LogDashboardWorkspace.tsx
@@ -9,22 +9,32 @@ export const LogDashboardWorkspace = () => {
   const [period, setPeriod] = useState<SystemPeriodType>(SystemPeriodModel.LAST_24H);
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 3,
+          marginBottom: 24,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 40,
               height: 40,
-              borderRadius: 2,
-              bgcolor: "error.main",
+              borderRadius: 16,
+              backgroundColor: "var(--hb-color-danger)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/apps/hobom-system/src/widgets/menu-recommendation-workspace/ui/MenuRecommendationWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/menu-recommendation-workspace/ui/MenuRecommendationWorkspace.tsx
@@ -5,7 +5,7 @@ import { Hb } from "@/shared/ui";
 export const MenuRecommendationWorkspace = () => {
   return (
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         flexDirection: "column",
         height: "100%",

--- a/apps/hobom-system/src/widgets/note-workspace/ui/NoteWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/note-workspace/ui/NoteWorkspace.tsx
@@ -7,7 +7,7 @@ export const NoteWorkspace = () => {
   const [status, setStatus] = useState<NoteStatus | undefined>(undefined);
 
   return (
-    <Hb.Box sx={{ p: 3, maxWidth: 1200, mx: "auto" }}>
+    <Hb.Box style={{ padding: 24, maxWidth: 1200, marginLeft: "auto", marginRight: "auto" }}>
       <Note.StatusTabs value={status} onChange={setStatus} />
 
       <ErrorBoundary inline>

--- a/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
+++ b/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
@@ -1,9 +1,30 @@
+import * as stylex from "@stylexjs/stylex";
 import { NotificationsNoneOutlined } from "hobom-design-system/icons";
 import { NotificationItem } from "@/entities/notification/ui";
 import { EMPTY_MESSAGES } from "@/features/notification";
-import { SUBTLE_SCROLLBAR_SX } from "@/shared/config";
 import { Hb } from "@/shared/ui";
 import { useNotificationCenter } from "../model/useNotificationCenter";
+
+// Ported from SUBTLE_SCROLLBAR_SX (light mode) — Hb.Box no longer accepts sx.
+const styles = stylex.create({
+  scrollArea: {
+    maxHeight: "calc(100vh - 200px)",
+    overflowY: "auto",
+    scrollbarGutter: "stable",
+    scrollbarWidth: "thin",
+    scrollbarColor: {
+      default: "transparent transparent",
+      ":hover": "rgba(0,0,0,0.15) transparent",
+    },
+    "::-webkit-scrollbar": { width: 6 },
+    "::-webkit-scrollbar-track": { background: "transparent" },
+    "::-webkit-scrollbar-thumb": {
+      background: { default: "transparent", ":hover": "rgba(0,0,0,0.25)" },
+      borderRadius: 3,
+      transition: "background-color 0.2s ease",
+    },
+  },
+});
 
 export const NotificationCenter = () => {
   const {
@@ -21,7 +42,14 @@ export const NotificationCenter = () => {
   const renderGroups = () => {
     if (isPending) {
       return (
-        <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            paddingTop: 64,
+            paddingBottom: 64,
+          }}
+        >
           <Hb.Progress.Circular size={28} />
         </Hb.Box>
       );
@@ -29,12 +57,13 @@ export const NotificationCenter = () => {
     if (dateGroups.length === 0) {
       return (
         <Hb.Box
-          sx={{
-            py: 8,
+          style={{
+            paddingTop: 64,
+            paddingBottom: 64,
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
-            gap: 1.5,
+            gap: 12,
           }}
         >
           <NotificationsNoneOutlined sx={{ fontSize: 48, color: "text.disabled" }} />
@@ -55,7 +84,15 @@ export const NotificationCenter = () => {
       <>
         {dateGroups.map((group) => (
           <Hb.Box key={group.label}>
-            <Hb.Box sx={{ px: 2, py: 1, bgcolor: "rgba(0,0,0,0.02)" }}>
+            <Hb.Box
+              style={{
+                paddingLeft: 16,
+                paddingRight: 16,
+                paddingTop: 8,
+                paddingBottom: 8,
+                backgroundColor: "rgba(0,0,0,0.02)",
+              }}
+            >
               <Hb.Text
                 variant="caption"
                 style={{
@@ -79,7 +116,14 @@ export const NotificationCenter = () => {
           </Hb.Box>
         ))}
         {isFetchingNextPage && (
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 16,
+              paddingBottom: 16,
+            }}
+          >
             <Hb.Progress.Circular size={24} />
           </Hb.Box>
         )}
@@ -88,8 +132,12 @@ export const NotificationCenter = () => {
   };
 
   return (
-    <Hb.Box sx={{ p: 3, maxWidth: 800, mx: "auto" }}>
-      <Hb.Box sx={{ mb: 2.5 }}>
+    <Hb.Box style={{ padding: 24, maxWidth: 800, marginLeft: "auto", marginRight: "auto" }}>
+      <Hb.Box
+        style={{
+          marginBottom: 20,
+        }}
+      >
         <Hb.Text
           variant="h6"
           style={{
@@ -107,7 +155,12 @@ export const NotificationCenter = () => {
           overflow: "hidden",
         }}
       >
-        <Hb.Box sx={{ px: 2 }}>
+        <Hb.Box
+          style={{
+            paddingLeft: 16,
+            paddingRight: 16,
+          }}
+        >
           <Hb.Tabs.Root
             value={tab}
             onChange={(_, v) => setTab(v)}
@@ -128,14 +181,7 @@ export const NotificationCenter = () => {
           </Hb.Tabs.Root>
         </Hb.Box>
         <Hb.Divider />
-        <Hb.Box
-          onScroll={handleScroll}
-          sx={{
-            maxHeight: "calc(100vh - 200px)",
-            overflowY: "auto",
-            ...SUBTLE_SCROLLBAR_SX,
-          }}
-        >
+        <Hb.Box onScroll={handleScroll} {...stylex.props(styles.scrollArea)}>
           {renderGroups()}
         </Hb.Box>
       </Hb.Paper>

--- a/apps/hobom-system/src/widgets/pick-menu-workspace/ui/PickMenuWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/pick-menu-workspace/ui/PickMenuWorkspace.tsx
@@ -4,7 +4,13 @@ import { Hb } from "@/shared/ui";
 
 export const PickMenuWorkspace = () => {
   return (
-    <Hb.Box sx={{ width: "100%", height: "100%", overflowY: "hidden" }}>
+    <Hb.Box
+      style={{
+        width: "100%",
+        height: "100%",
+        overflowY: "hidden",
+      }}
+    >
       <TodayMenuIdContextProvider>
         <PickMenuFunnel />
       </TodayMenuIdContextProvider>

--- a/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
+++ b/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
@@ -58,9 +58,20 @@ export const ProjectLayout = () => {
 
   return (
     <ProjectContext.Provider value={projectCtx}>
-      <Hb.Box sx={{ p: 3 }}>
+      <Hb.Box
+        style={{
+          padding: 24,
+        }}
+      >
         {/* Breadcrumb */}
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            marginBottom: 8,
+          }}
+        >
           <Hb.Text
             variant="caption"
             {...stylex.props(styles.crumb)}
@@ -85,7 +96,14 @@ export const ProjectLayout = () => {
         </Hb.Text>
 
         {/* Tab Navigation + Action Buttons */}
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            marginBottom: 4,
+          }}
+        >
           {TABS.map((tab) => {
             const isActive = currentPath === tab.path;
 
@@ -114,7 +132,11 @@ export const ProjectLayout = () => {
             );
           })}
 
-          <Hb.Box sx={{ flex: 1 }} />
+          <Hb.Box
+            style={{
+              flex: 1,
+            }}
+          />
 
           {showSprintButton && (
             <Hb.Button

--- a/apps/hobom-system/src/widgets/project-list-workspace/ui/ProjectListWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/project-list-workspace/ui/ProjectListWorkspace.tsx
@@ -13,13 +13,17 @@ export const ProjectListWorkspace = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 4,
+          marginBottom: 32,
         }}
       >
         <Hb.Box>

--- a/apps/hobom-system/src/widgets/system-dashboard-workspace/ui/SystemDashboardWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/system-dashboard-workspace/ui/SystemDashboardWorkspace.tsx
@@ -9,22 +9,32 @@ export const SystemDashboardWorkspace = () => {
   const [period, setPeriod] = useState<SystemPeriodType>(SystemPeriodModel.LAST_24H);
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 3,
+          marginBottom: 24,
         }}
       >
-        <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Hb.Box
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
           <Hb.Box
-            sx={{
+            style={{
               width: 40,
               height: 40,
-              borderRadius: 2,
-              bgcolor: "warning.main",
+              borderRadius: 16,
+              backgroundColor: "var(--hb-color-warning)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageContent.tsx
@@ -50,7 +50,11 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
   }
 
   return (
-    <Hb.Box sx={{ p: 2 }}>
+    <Hb.Box
+      style={{
+        padding: 16,
+      }}
+    >
       <Hb.Paper
         elevation={0}
         style={{
@@ -61,16 +65,22 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
         }}
       >
         <Hb.Box
-          sx={{
+          style={{
             display: "flex",
             alignItems: "flex-start",
             justifyContent: "space-between",
-            px: 3.5,
-            pt: 3,
-            pb: 1,
+            paddingLeft: 28,
+            paddingRight: 28,
+            paddingTop: 24,
+            paddingBottom: 8,
           }}
         >
-          <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+          <Hb.Box
+            style={{
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             <Hb.Text
               variant="h4"
               style={{
@@ -81,7 +91,14 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
             >
               {page.title}
             </Hb.Text>
-            <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            <Hb.Box
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "wrap",
+              }}
+            >
               <Hb.Text
                 variant="caption"
                 color="text.disabled"
@@ -107,7 +124,14 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
               </ErrorBoundary>
             </Hb.Box>
           </Hb.Box>
-          <Hb.Box sx={{ display: "flex", gap: 0.5, ml: 2, flexShrink: 0 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              gap: 4,
+              marginLeft: 16,
+              flexShrink: 0,
+            }}
+          >
             <Hb.Tooltip title="버전 히스토리">
               <Hb.Button.Icon
                 size="small"
@@ -183,7 +207,14 @@ export const PageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId: st
       >
         <Suspense
           fallback={
-            <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <Hb.Box
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                paddingTop: 32,
+                paddingBottom: 32,
+              }}
+            >
               <Hb.Progress.Circular size={20} />
             </Hb.Box>
           }

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageEditor.tsx
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/ui/PageEditor.tsx
@@ -1,10 +1,26 @@
 import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { VisibilityOutlined } from "hobom-design-system/icons";
 import { useUpdatePage, UpdatePageSchema } from "@/entities/wiki-page";
 import { validateWithSchema } from "@/shared/lib";
 import { useToast } from "@/shared/model";
 import { usePageEditor, PageEditorContent } from "@/features/wiki-page-editor";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  prose: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingTop: 8,
+    paddingBottom: 8,
+    borderBottom: "1px solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-canvas)",
+  },
+});
 
 const validatePageUpdate = validateWithSchema(UpdatePageSchema);
 
@@ -57,19 +73,7 @@ export const PageEditor = ({
         minHeight: "calc(100vh - 280px)",
       }}
     >
-      <Hb.Box
-        sx={(theme) => ({
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "flex-end",
-          px: 2,
-          py: 1,
-          borderBottom: "1px solid",
-          borderColor: "divider",
-          bgcolor: "grey.50",
-          ...theme.applyStyles("dark", { bgcolor: "background.default" }),
-        })}
-      >
+      <Hb.Box {...stylex.props(styles.prose)}>
         <Hb.Button
           size="small"
           variant="ghost"

--- a/apps/hobom-system/src/widgets/wiki-space-layout/ui/WikiSpaceLayout.tsx
+++ b/apps/hobom-system/src/widgets/wiki-space-layout/ui/WikiSpaceLayout.tsx
@@ -63,14 +63,16 @@ const TrashDrawer = ({
     slotProps={{ paper: { sx: { width: 400 } } }}
   >
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        px: 2.5,
-        py: 2,
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingTop: 16,
+        paddingBottom: 16,
         borderBottom: "1px solid",
-        borderColor: "divider",
+        borderColor: "var(--hb-color-border)",
       }}
     >
       <Hb.Text variant="h6" fontWeight={700}>
@@ -83,7 +85,14 @@ const TrashDrawer = ({
     <ErrorBoundary inline resetKey={spaceKey}>
       <Suspense
         fallback={
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 48,
+              paddingBottom: 48,
+            }}
+          >
             <Hb.Progress.Circular size={28} />
           </Hb.Box>
         }
@@ -110,14 +119,16 @@ const LabelDrawer = ({
     slotProps={{ paper: { sx: { width: 360 } } }}
   >
     <Hb.Box
-      sx={{
+      style={{
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        px: 2.5,
-        py: 2,
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingTop: 16,
+        paddingBottom: 16,
         borderBottom: "1px solid",
-        borderColor: "divider",
+        borderColor: "var(--hb-color-border)",
       }}
     >
       <Hb.Text variant="h6" fontWeight={700}>
@@ -130,7 +141,14 @@ const LabelDrawer = ({
     <ErrorBoundary inline resetKey={spaceKey}>
       <Suspense
         fallback={
-          <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+          <Hb.Box
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: 48,
+              paddingBottom: 48,
+            }}
+          >
             <Hb.Progress.Circular size={28} />
           </Hb.Box>
         }
@@ -161,8 +179,19 @@ export const WikiSpaceLayout = () => {
   if (!spaceKey) return null;
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
-      <Hb.Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
+      <Hb.Box
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          marginBottom: 8,
+        }}
+      >
         <Hb.Text variant="caption" {...stylex.props(styles.crumb)} onClick={handleNavigateToWiki}>
           위키
         </Hb.Text>
@@ -172,11 +201,11 @@ export const WikiSpaceLayout = () => {
         </Hb.Text>
       </Hb.Box>
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          mb: 2,
+          marginBottom: 16,
         }}
       >
         <Hb.Text variant="h5" fontWeight={700}>
@@ -189,21 +218,34 @@ export const WikiSpaceLayout = () => {
           marginBottom: 0,
         }}
       />
-      <Hb.Box sx={{ display: "flex", minHeight: "calc(100vh - 200px)" }}>
+      <Hb.Box
+        style={{
+          display: "flex",
+          minHeight: "calc(100vh - 200px)",
+        }}
+      >
         <Hb.Box
-          sx={{
+          style={{
             width: SIDEBAR_WIDTH,
             flexShrink: 0,
             borderRight: "1px solid",
-            borderColor: "divider",
-            py: 1.5,
-            pr: 1,
+            borderColor: "var(--hb-color-border)",
+            paddingTop: 12,
+            paddingBottom: 12,
+            paddingRight: 8,
             overflow: "auto",
           }}
         >
           <Suspense
             fallback={
-              <Hb.Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <Hb.Box
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  paddingTop: 32,
+                  paddingBottom: 32,
+                }}
+              >
                 <Hb.Progress.Circular size={24} />
               </Hb.Box>
             }
@@ -216,7 +258,16 @@ export const WikiSpaceLayout = () => {
             />
           </Suspense>
 
-          <Hb.Box sx={{ px: 1, mt: 1, display: "flex", flexDirection: "column", gap: 0.25 }}>
+          <Hb.Box
+            style={{
+              paddingLeft: 8,
+              paddingRight: 8,
+              marginTop: 8,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
             <Hb.Button
               variant="ghost"
               size="small"
@@ -268,7 +319,12 @@ export const WikiSpaceLayout = () => {
           </Hb.Box>
         </Hb.Box>
 
-        <Hb.Box sx={{ flex: 1, minWidth: 0 }}>
+        <Hb.Box
+          style={{
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
           <Outlet context={{ spaceKey }} />
         </Hb.Box>
       </Hb.Box>

--- a/apps/hobom-system/src/widgets/wiki-space-list-workspace/ui/WikiSpaceListWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/wiki-space-list-workspace/ui/WikiSpaceListWorkspace.tsx
@@ -41,13 +41,17 @@ export const WikiSpaceListWorkspace = () => {
   };
 
   return (
-    <Hb.Box sx={{ p: 3 }}>
+    <Hb.Box
+      style={{
+        padding: 24,
+      }}
+    >
       <Hb.Box
-        sx={{
+        style={{
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          mb: 4,
+          marginBottom: 32,
         }}
       >
         <Hb.Box>

--- a/packages/hobom-design-system/src/components/Box/Box.stories.tsx
+++ b/packages/hobom-design-system/src/components/Box/Box.stories.tsx
@@ -1,0 +1,35 @@
+import { Box } from "./Box";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Box",
+  component: Box,
+} satisfies Meta<typeof Box>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const cell = (label: string) => (
+  <div style={{ padding: 8, background: "var(--hb-color-surface)", border: "1px solid var(--hb-color-border)", borderRadius: 6 }}>
+    {label}
+  </div>
+);
+
+export const AsFlexRow: Story = {
+  render: () => (
+    <Box style={{ display: "flex", gap: 8, alignItems: "center" }}>
+      {cell("one")}
+      {cell("two")}
+      {cell("three")}
+    </Box>
+  ),
+};
+
+export const Polymorphic: Story = {
+  render: () => (
+    <Box component="section" style={{ padding: 16, border: "1px dashed var(--hb-color-border)" }}>
+      rendered as &lt;section&gt;
+    </Box>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Box/Box.tsx
+++ b/packages/hobom-design-system/src/components/Box/Box.tsx
@@ -1,1 +1,19 @@
-export { Box } from "@mui/material";
+import { createElement, type AllHTMLAttributes, type ElementType, type Ref } from "react";
+
+// `AllHTMLAttributes` (not `HTMLAttributes`) so a polymorphic Box can carry
+// element-specific attributes for whatever `component` renders — e.g. `noValidate`
+// on a `form`, `href` on an `a`.
+interface BoxProps extends AllHTMLAttributes<HTMLElement> {
+  /** Element to render. Defaults to `"div"`. */
+  component?: ElementType;
+  /** Forwarded to the rendered element (React 19 ref-as-prop). */
+  ref?: Ref<HTMLElement>;
+}
+
+/**
+ * Unstyled layout primitive: a polymorphic element (a `div` by default) that
+ * passes `style`, `className`, `children`, and every DOM prop straight through.
+ * All styling comes from the consumer's `style` — the MUI `sx` prop is
+ * codemodded to `style` at the call sites.
+ */
+export const Box = ({ component = "div", ...rest }: BoxProps) => createElement(component, rest);

--- a/scripts/codemods/hoist-system-props.cjs
+++ b/scripts/codemods/hoist-system-props.cjs
@@ -1,0 +1,159 @@
+/**
+ * Codemod: hoist MUI system props passed directly on a target component into a
+ * plain `style` object (merging into an existing `style` if present).
+ *
+ * The in-house layout primitives (Box, …) no longer accept MUI system props
+ * (`display`, `gap`, `p`, `bgcolor`, …) — those must move to `style`. This is
+ * the companion to `sx-to-style.cjs`: run that first (converts `sx`), then this
+ * (converts leftover direct system props).
+ *
+ *   CODEMOD_TARGET=Box pnpm dlx jscodeshift -t scripts/codemods/hoist-system-props.cjs \
+ *     --parser tsx --extensions tsx apps/hobom-system/src
+ */
+const COMPONENT = { object: "Hb", property: process.env.CODEMOD_TARGET || "Box" };
+const UNIT = 8;
+const SPACING = {
+  m: ["margin"], mt: ["marginTop"], mb: ["marginBottom"], ml: ["marginLeft"], mr: ["marginRight"],
+  mx: ["marginLeft", "marginRight"], my: ["marginTop", "marginBottom"],
+  p: ["padding"], pt: ["paddingTop"], pb: ["paddingBottom"], pl: ["paddingLeft"], pr: ["paddingRight"],
+  px: ["paddingLeft", "paddingRight"], py: ["paddingTop", "paddingBottom"],
+  gap: ["gap"], rowGap: ["rowGap"], columnGap: ["columnGap"],
+};
+// Non-spacing system props copied through as-is (value unchanged).
+const PASSTHROUGH = new Set([
+  "display", "flex", "flexDirection", "flexWrap", "flexShrink", "flexGrow", "flexBasis",
+  "alignItems", "alignSelf", "alignContent", "justifyContent", "justifySelf", "order",
+  "width", "height", "minWidth", "maxWidth", "minHeight", "maxHeight",
+  "position", "top", "right", "bottom", "left", "zIndex",
+  "overflow", "overflowX", "overflowY", "textAlign", "whiteSpace", "wordBreak",
+  "boxShadow", "opacity", "cursor",
+]);
+const COLOR_KEYS = { bgcolor: "backgroundColor", color: "color", borderColor: "borderColor" };
+const THEME_COLOR = {
+  divider: "var(--hb-color-border)",
+  "background.paper": "var(--hb-color-surface)",
+  "background.default": "var(--hb-color-canvas)",
+  "text.primary": "var(--hb-color-text-primary)",
+  "text.secondary": "var(--hb-color-text-secondary)",
+  "text.disabled": "var(--hb-color-text-disabled)",
+  "primary.main": "var(--hb-color-accent)",
+  "error.main": "var(--hb-color-danger)",
+  "success.main": "var(--hb-color-success)",
+  "warning.main": "var(--hb-color-warning)",
+};
+
+module.exports = function transformer(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let changed = false;
+
+  const numNode = (n) =>
+    n < 0 ? j.unaryExpression("-", j.numericLiteral(-n), true) : j.numericLiteral(n);
+  const prop = (k, v) => j.objectProperty(j.identifier(k), v);
+
+  // Unwrap a JSX attribute value into an expression node (or null to skip).
+  const valueOf = (attrValue) => {
+    if (!attrValue) return null; // bare boolean attr — not a style prop
+    if (attrValue.type === "StringLiteral") return attrValue;
+    if (attrValue.type === "JSXExpressionContainer") {
+      const e = attrValue.expression;
+      return e.type === "JSXEmptyExpression" ? null : e;
+    }
+    return null;
+  };
+
+  const staticValue = (node) => {
+    if (node.type === "NumericLiteral") return { num: node.value };
+    if (node.type === "StringLiteral") return { str: node.value };
+    if (node.type === "UnaryExpression" && node.operator === "-" && node.argument.type === "NumericLiteral")
+      return { num: -node.argument.value };
+    return null;
+  };
+
+  // Convert one (key, valueNode) → array of ObjectProperty, or null to skip the prop.
+  const convert = (key, valueNode) => {
+    const sv = staticValue(valueNode);
+    if (SPACING[key]) {
+      if (!sv || sv.num == null) return null; // dynamic spacing — leave the prop in place
+      return SPACING[key].map((t) => prop(t, numNode(sv.num * UNIT)));
+    }
+    if (COLOR_KEYS[key]) {
+      const outKey = COLOR_KEYS[key];
+      if (sv && sv.str != null) {
+        let v = sv.str;
+        if (THEME_COLOR[v]) v = THEME_COLOR[v];
+        else if (!/^(#|rgb|hsl|[a-z]+$)/.test(v)) return null;
+        return [prop(outKey, j.stringLiteral(v))];
+      }
+      return [j.objectProperty(j.identifier(outKey), valueNode)];
+    }
+    if (PASSTHROUGH.has(key)) return [j.objectProperty(j.identifier(key), valueNode)];
+    return null; // not a system prop — leave untouched
+  };
+
+  root
+    .find(j.JSXOpeningElement)
+    .filter((p) => {
+      const n = p.node.name;
+      return (
+        n.type === "JSXMemberExpression" &&
+        n.object.type === "JSXIdentifier" &&
+        n.object.name === COMPONENT.object &&
+        n.property.name === COMPONENT.property
+      );
+    })
+    .forEach((p) => {
+      const attrs = p.node.attributes || [];
+      const hoisted = [];
+      const remaining = [];
+
+      for (const a of attrs) {
+        if (a.type !== "JSXAttribute" || !a.name || typeof a.name.name !== "string") {
+          remaining.push(a);
+          continue;
+        }
+        const key = a.name.name;
+        if (!SPACING[key] && !PASSTHROUGH.has(key) && !COLOR_KEYS[key]) {
+          remaining.push(a);
+          continue;
+        }
+        const valueNode = valueOf(a.value);
+        if (!valueNode) {
+          remaining.push(a);
+          continue;
+        }
+        const converted = convert(key, valueNode);
+        if (!converted) {
+          remaining.push(a); // dynamic/unknown — keep as prop (will surface in tsc)
+          continue;
+        }
+        hoisted.push(...converted);
+      }
+
+      if (hoisted.length === 0) return;
+
+      // Merge into an existing object `style`, or create one.
+      const styleAttr = remaining.find(
+        (a) => a.type === "JSXAttribute" && a.name.name === "style",
+      );
+      if (styleAttr) {
+        const expr = styleAttr.value && styleAttr.value.type === "JSXExpressionContainer"
+          ? styleAttr.value.expression
+          : null;
+        if (!expr || expr.type !== "ObjectExpression") return; // non-object style — bail this tag
+        expr.properties.push(...hoisted);
+        p.node.attributes = remaining;
+      } else {
+        remaining.push(
+          j.jsxAttribute(
+            j.jsxIdentifier("style"),
+            j.jsxExpressionContainer(j.objectExpression(hoisted)),
+          ),
+        );
+        p.node.attributes = remaining;
+      }
+      changed = true;
+    });
+
+  return changed ? root.toSource({ quote: "double" }) : null;
+};


### PR DESCRIPTION
Replaces the MUI `Box` re-export (`Hb.Box`, ~470 call sites) with a tiny unstyled polymorphic element and moves all consumer styling off `sx`. Follows the de-MUI pattern (in-house → codemod `sx` → contract enforced by `tsc -b`).

## Component
`Hb.Box` is now `({ component = "div", ...rest }) => createElement(component, rest)` — a bare polymorphic element passing `style`, `className`, `children`, `ref`, and every DOM prop through. Props extend `AllHTMLAttributes<HTMLElement>` so a polymorphic Box keeps element-specific attributes (`noValidate` on a `form`, `href` on an `a`) plus a React-19 `ref`.

## Consumers (~130 files)
- **`sx-to-style` codemod** → `sx` to `style` (spacing ×8, theme color paths → `var(--hb-*)`).
- **New `hoist-system-props` codemod** → moves direct MUI system props (`display`, `gap`, `bgcolor`, `p`, …) into `style`.
- **`&:hover` / `:focus-within`** → StyleX in the app source (the documented escape hatch).
- **Descendant / child selectors** — prose rendered via `dangerouslySetInnerHTML` (`& h1`, `& .tiptap`, …) and row hover-reveal (`&:hover .move-btn`, `.comment-actions`) can't be expressed by atomic StyleX, so they use a **scoped `<style>` tag**. The list-row ones use **React 19 `<style href precedence>`** for automatic head-hoist + de-dupe.

## Verification
- DS & app: **0 lint problems**, `tsc -b` **0 errors**, app **build passes**.
- App tests: **582** green.
- `Hb.Box` is MUI-free; the app still has **0** direct `@mui` imports.

## Note
Migrating Box surfaced that MUI's `sx` engine was doing three things atomic StyleX can't: descendant selectors (handled via scoped `<style>`), and per-instance dynamic colors (kept inline). Remaining MUI components: 27 (down from 29).