### PR TITLE
feat: in-house Stack, drop MUI Stack

### DIFF
--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -50,7 +50,13 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
       <Hb.List.Item
         disablePadding
         secondaryAction={
-          <Hb.Stack direction="row" alignItems="center" spacing={0.5}>
+          <Hb.Stack
+            direction="row"
+            spacing={0.5}
+            style={{
+              alignItems: "center",
+            }}
+          >
             {item.reaction && (
               <Hb.Button.Icon
                 size="small"
@@ -82,7 +88,13 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                       <Hb.Text gutterBottom variant="subtitle1" style={{ fontWeight: "bold" }}>
                         {formatDate(normalizeTodoDateToUtcMidnight(item.date))}
                       </Hb.Text>
-                      <Hb.Stack direction="row" mt={1} spacing={1}>
+                      <Hb.Stack
+                        direction="row"
+                        spacing={1}
+                        style={{
+                          marginTop: 8,
+                        }}
+                      >
                         <Hb.Chip
                           color={isCompleteStatus(item.progress) ? "success" : "warning"}
                           variant="outlined"

--- a/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
+++ b/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
@@ -43,8 +43,21 @@ export const PendingUsersTable = () => {
 
   return (
     <Hb.Box>
-      <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 3 }}>
-        <Hb.Stack direction="row" alignItems="center" spacing={1.5}>
+      <Hb.Stack
+        direction="row"
+        style={{
+          marginBottom: 24,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <Hb.Stack
+          direction="row"
+          spacing={1.5}
+          style={{
+            alignItems: "center",
+          }}
+        >
           <Hb.Text variant="h6" fontWeight={700}>
             승인 대기 사용자
           </Hb.Text>
@@ -94,7 +107,13 @@ export const PendingUsersTable = () => {
               {users.map((user) => (
                 <Hb.Table.Row key={user.id} sx={{ "&:last-child td": { borderBottom: 0 } }}>
                   <Hb.Table.Cell>
-                    <Hb.Stack direction="row" alignItems="center" spacing={1.5}>
+                    <Hb.Stack
+                      direction="row"
+                      spacing={1.5}
+                      style={{
+                        alignItems: "center",
+                      }}
+                    >
                       <Hb.Avatar sx={{ width: 32, height: 32, bgcolor: "primary.main" }}>
                         <PersonOutline sx={{ fontSize: 18 }} />
                       </Hb.Avatar>
@@ -112,7 +131,13 @@ export const PendingUsersTable = () => {
                     </Hb.Text>
                   </Hb.Table.Cell>
                   <Hb.Table.Cell align="right">
-                    <Hb.Stack direction="row" spacing={1} justifyContent="flex-end">
+                    <Hb.Stack
+                      direction="row"
+                      spacing={1}
+                      style={{
+                        justifyContent: "flex-end",
+                      }}
+                    >
                       <Hb.Button
                         size="small"
                         variant="secondary"

--- a/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/SelectedMenuContent.tsx
@@ -53,14 +53,26 @@ const Inner = () => {
           }}
         >
           {showProgressCircle ? (
-            <Hb.Stack direction="column" alignItems="center" spacing={1.5}>
+            <Hb.Stack
+              direction="column"
+              spacing={1.5}
+              style={{
+                alignItems: "center",
+              }}
+            >
               <Hb.Progress.Circular size="48px" />
               <Hb.Text variant="body2" color="text.secondary">
                 메뉴를 추첨할 동안 잠시만 기다려 주세요.
               </Hb.Text>
             </Hb.Stack>
           ) : (
-            <Hb.Stack direction="column" alignItems="center" spacing={1}>
+            <Hb.Stack
+              direction="column"
+              spacing={1}
+              style={{
+                alignItems: "center",
+              }}
+            >
               <Hb.Text
                 variant="body2"
                 style={{

--- a/apps/hobom-system/src/features/privacy-law-chat/ui/ChatInput.tsx
+++ b/apps/hobom-system/src/features/privacy-law-chat/ui/ChatInput.tsx
@@ -26,7 +26,13 @@ export const ChatInput = ({ onSend, disabled }: Props) => {
   };
 
   return (
-    <Hb.Stack direction="row" spacing={1} alignItems="flex-end">
+    <Hb.Stack
+      direction="row"
+      spacing={1}
+      style={{
+        alignItems: "flex-end",
+      }}
+    >
       <Hb.TextField
         fullWidth
         multiline

--- a/apps/hobom-system/src/features/privacy-law-chat/ui/ChatMessageList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-chat/ui/ChatMessageList.tsx
@@ -18,7 +18,15 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
 
   if (messages.length === 0 && !isPending) {
     return (
-      <Hb.Stack alignItems="center" justifyContent="center" sx={{ flex: 1, py: 8 }}>
+      <Hb.Stack
+        style={{
+          flex: 1,
+          paddingTop: 64,
+          paddingBottom: 64,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
         <GavelOutlined sx={{ fontSize: 48, color: "text.disabled", mb: 2 }} />
         <Hb.Text variant="h6" color="text.secondary" gutterBottom>
           개인정보보호법 AI 상담
@@ -31,15 +39,23 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
   }
 
   return (
-    <Hb.Stack spacing={2} sx={{ flex: 1, overflow: "auto", py: 2 }}>
+    <Hb.Stack
+      spacing={2}
+      style={{
+        flex: 1,
+        overflow: "auto",
+        paddingTop: 16,
+        paddingBottom: 16,
+      }}
+    >
       {messages.map((msg) => (
         <Hb.Stack
           key={msg.id}
           direction="row"
           spacing={1.5}
-          alignItems="flex-start"
-          sx={{
+          style={{
             flexDirection: msg.role === "user" ? "row-reverse" : "row",
+            alignItems: "flex-start",
           }}
         >
           <Hb.Avatar
@@ -83,7 +99,13 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
         </Hb.Stack>
       ))}
       {isPending && (
-        <Hb.Stack direction="row" spacing={1.5} alignItems="flex-start">
+        <Hb.Stack
+          direction="row"
+          spacing={1.5}
+          style={{
+            alignItems: "flex-start",
+          }}
+        >
           <Hb.Avatar sx={{ width: 32, height: 32, bgcolor: "grey.700" }}>
             <GavelOutlined fontSize="small" />
           </Hb.Avatar>
@@ -97,7 +119,13 @@ export const ChatMessageList = ({ messages, isPending }: Props) => {
               borderRadius: 16,
             }}
           >
-            <Hb.Stack direction="row" spacing={1} alignItems="center">
+            <Hb.Stack
+              direction="row"
+              spacing={1}
+              style={{
+                alignItems: "center",
+              }}
+            >
               <Hb.Progress.Circular size={16} />
               <Hb.Text variant="body2" color="text.secondary">
                 답변 생성 중...

--- a/apps/hobom-system/src/features/privacy-law-chat/ui/ReferencedArticles.tsx
+++ b/apps/hobom-system/src/features/privacy-law-chat/ui/ReferencedArticles.tsx
@@ -6,7 +6,15 @@ interface Props {
 }
 
 export const ReferencedArticles = ({ articles }: Props) => (
-  <Hb.Stack direction="row" spacing={0.5} flexWrap="wrap" mt={1.5} gap={0.5}>
+  <Hb.Stack
+    direction="row"
+    spacing={0.5}
+    style={{
+      flexWrap: "wrap",
+      marginTop: 12,
+      gap: 4,
+    }}
+  >
     <Hb.Text
       variant="caption"
       color="text.secondary"

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffList.tsx
@@ -31,10 +31,28 @@ export const LawDiffList = () => {
           <Hb.Card.Root key={diff.id} variant="outlined">
             <Hb.Card.Clickable onClick={() => navigate(`/privacy-law/diffs/${diff.id}`)}>
               <Hb.Card.Content>
-                <Hb.Stack direction="row" alignItems="center" justifyContent="space-between">
-                  <Hb.Stack direction="row" alignItems="center" spacing={1.5}>
+                <Hb.Stack
+                  direction="row"
+                  style={{
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <Hb.Stack
+                    direction="row"
+                    spacing={1.5}
+                    style={{
+                      alignItems: "center",
+                    }}
+                  >
                     <CompareArrowsOutlined color="primary" fontSize="small" />
-                    <Hb.Stack direction="row" alignItems="center" spacing={0.5}>
+                    <Hb.Stack
+                      direction="row"
+                      spacing={0.5}
+                      style={{
+                        alignItems: "center",
+                      }}
+                    >
                       <Hb.Text variant="subtitle2">{diff.fromProclamationDate}</Hb.Text>
                       <ArrowForwardOutlined fontSize="small" sx={{ color: "text.secondary" }} />
                       <Hb.Text variant="subtitle2">{diff.toProclamationDate}</Hb.Text>

--- a/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-diff/ui/LawDiffViewer.tsx
@@ -44,7 +44,14 @@ const ChangeCard = ({ change }: { change: ArticleChange }) => {
         padding: 16,
       }}
     >
-      <Hb.Stack direction="row" alignItems="center" spacing={1} mb={1.5}>
+      <Hb.Stack
+        direction="row"
+        spacing={1}
+        style={{
+          alignItems: "center",
+          marginBottom: 12,
+        }}
+      >
         <Hb.Chip
           label={change.articleNo}
           size="small"
@@ -160,7 +167,14 @@ export const LawDiffViewer = ({ diffId }: Props) => {
 
   return (
     <Hb.Box>
-      <Hb.Stack direction="row" alignItems="center" spacing={1} mb={3}>
+      <Hb.Stack
+        direction="row"
+        spacing={1}
+        style={{
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
         <Hb.Text variant="h6">{diff.fromProclamationDate}</Hb.Text>
         <ArrowForwardOutlined sx={{ color: "text.secondary" }} />
         <Hb.Text variant="h6">{diff.toProclamationDate}</Hb.Text>

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamList.tsx
@@ -41,13 +41,24 @@ export const ExamList = () => {
       >
         {isPending ? "생성 중..." : "모의고사 생성"}
       </Hb.Button>
-
       {exams.map((exam) => (
         <Hb.Card.Root key={exam.id} variant="outlined">
           <Hb.Card.Clickable onClick={() => navigate(`/privacy-law/exams/${exam.id}`)}>
             <Hb.Card.Content>
-              <Hb.Stack direction="row" alignItems="flex-start" justifyContent="space-between">
-                <Hb.Stack direction="row" spacing={1.5} alignItems="flex-start">
+              <Hb.Stack
+                direction="row"
+                style={{
+                  alignItems: "flex-start",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Hb.Stack
+                  direction="row"
+                  spacing={1.5}
+                  style={{
+                    alignItems: "flex-start",
+                  }}
+                >
                   <AssignmentOutlined color="primary" fontSize="small" sx={{ mt: 0.25 }} />
                   <div>
                     <Hb.Text variant="subtitle2" gutterBottom>
@@ -70,7 +81,6 @@ export const ExamList = () => {
           </Hb.Card.Clickable>
         </Hb.Card.Root>
       ))}
-
       {exams.length === 0 && (
         <Hb.Text
           color="text.secondary"

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
@@ -142,7 +142,13 @@ const MultipleChoiceInput = ({
           disabled={disabled}
           control={<Hb.Radio.Root size="small" />}
           label={
-            <Hb.Stack direction="row" alignItems="center" spacing={1}>
+            <Hb.Stack
+              direction="row"
+              spacing={1}
+              style={{
+                alignItems: "center",
+              }}
+            >
               <Hb.Text
                 variant="body2"
                 style={{
@@ -231,7 +237,14 @@ export const ExamQuestionCard = ({ questions }: Props) => {
   return (
     <Hb.Card.Root variant="outlined">
       <Hb.Card.Content>
-        <Hb.Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+        <Hb.Stack
+          direction="row"
+          style={{
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
           <Hb.Stack direction="row" spacing={1}>
             <Hb.Chip label={`${currentIndex + 1} / ${total}`} size="small" color="primary" />
             <Hb.Chip

--- a/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
@@ -142,7 +142,13 @@ const MultipleChoiceInput = ({
           disabled={disabled}
           control={<Hb.Radio.Root size="small" />}
           label={
-            <Hb.Stack direction="row" alignItems="center" spacing={1}>
+            <Hb.Stack
+              direction="row"
+              spacing={1}
+              style={{
+                alignItems: "center",
+              }}
+            >
               <Hb.Text
                 variant="body2"
                 style={{
@@ -231,7 +237,14 @@ export const QuizCard = ({ quizzes }: Props) => {
   return (
     <Hb.Card.Root variant="outlined">
       <Hb.Card.Content>
-        <Hb.Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+        <Hb.Stack
+          direction="row"
+          style={{
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
           <Hb.Stack direction="row" spacing={1}>
             <Hb.Chip label={`${currentIndex + 1} / ${total}`} size="small" color="primary" />
             <Hb.Chip

--- a/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
@@ -20,7 +20,14 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
           marginBottom: 24,
         }}
       >
-        <Hb.Stack direction="row" alignItems="center" spacing={1} mb={2}>
+        <Hb.Stack
+          direction="row"
+          spacing={1}
+          style={{
+            alignItems: "center",
+            marginBottom: 16,
+          }}
+        >
           <LightbulbOutlined color="warning" />
           <Hb.Text variant="h6">요약</Hb.Text>
         </Hb.Stack>
@@ -54,7 +61,14 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
         ))}
       </Hb.List.Root>
       {material.quizzes.length > 0 && (
-        <Hb.Stack direction="row" alignItems="center" spacing={1} mt={3}>
+        <Hb.Stack
+          direction="row"
+          spacing={1}
+          style={{
+            alignItems: "center",
+            marginTop: 24,
+          }}
+        >
           <CheckCircleOutline color="primary" fontSize="small" />
           <Hb.Text variant="subtitle2" color="text.secondary">
             이 학습 자료에 {material.quizzes.length}개의 퀴즈가 있어요. 아래에서 풀어보세요.

--- a/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialList.tsx
@@ -15,8 +15,20 @@ export const StudyMaterialList = () => {
         <Hb.Card.Root key={m.id} variant="outlined">
           <Hb.Card.Clickable onClick={() => navigate(`/privacy-law/study/${m.id}`)}>
             <Hb.Card.Content>
-              <Hb.Stack direction="row" alignItems="flex-start" justifyContent="space-between">
-                <Hb.Stack direction="row" spacing={1.5} alignItems="flex-start">
+              <Hb.Stack
+                direction="row"
+                style={{
+                  alignItems: "flex-start",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Hb.Stack
+                  direction="row"
+                  spacing={1.5}
+                  style={{
+                    alignItems: "flex-start",
+                  }}
+                >
                   <SchoolOutlined color="primary" fontSize="small" sx={{ mt: 0.25 }} />
                   <Hb.Box>
                     <Hb.Text variant="subtitle2" gutterBottom>

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
@@ -21,7 +21,12 @@ const ArticleContent = ({ article }: { article: LawArticle }) => (
       {article.content}
     </Hb.Text>
     {article.paragraphs.length > 0 && (
-      <Hb.Stack spacing={0.5} sx={{ pl: 2 }}>
+      <Hb.Stack
+        spacing={0.5}
+        style={{
+          paddingLeft: 16,
+        }}
+      >
         {article.paragraphs.map((p) => (
           <Hb.Text key={p.no} variant="body2" color="text.secondary">
             <Hb.Text component="span" variant="body2" fontWeight={600} color="text.primary">
@@ -29,7 +34,15 @@ const ArticleContent = ({ article }: { article: LawArticle }) => (
             </Hb.Text>{" "}
             {p.content}
             {p.subItems.length > 0 && (
-              <Hb.Stack component="span" spacing={0.25} sx={{ display: "block", pl: 2, mt: 0.5 }}>
+              <Hb.Stack
+                component="span"
+                spacing={0.25}
+                style={{
+                  display: "block",
+                  paddingLeft: 16,
+                  marginTop: 4,
+                }}
+              >
                 {p.subItems.map((sub) => (
                   <Hb.Text
                     key={sub.no}
@@ -61,10 +74,23 @@ export const LawArticleViewer = ({ versionId }: Props) => {
 
   return (
     <Hb.Box>
-      <Hb.Stack direction="row" alignItems="center" spacing={2} mb={3}>
+      <Hb.Stack
+        direction="row"
+        spacing={2}
+        style={{
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
         <Hb.Box>
           <Hb.Text variant="h6">{version.lawName}</Hb.Text>
-          <Hb.Stack direction="row" spacing={1} mt={0.5}>
+          <Hb.Stack
+            direction="row"
+            spacing={1}
+            style={{
+              marginTop: 4,
+            }}
+          >
             <Hb.Chip label={`공포일 ${version.proclamationDate}`} size="small" variant="outlined" />
             <Hb.Chip
               label={`시행일 ${version.enforcementDate}`}
@@ -94,7 +120,13 @@ export const LawArticleViewer = ({ versionId }: Props) => {
         {filtered.map((article) => (
           <Hb.Accordion.Root key={article.articleNo} disableGutters variant="outlined">
             <Hb.Accordion.Summary expandIcon={<ExpandMore />}>
-              <Hb.Stack direction="row" alignItems="center" spacing={1}>
+              <Hb.Stack
+                direction="row"
+                spacing={1}
+                style={{
+                  alignItems: "center",
+                }}
+              >
                 <Hb.Chip
                   label={article.articleNo}
                   size="small"

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
@@ -55,8 +55,20 @@ export const LawVersionList = () => {
         <Hb.Card.Root key={version.id} variant="outlined">
           <Hb.Card.Clickable onClick={() => navigate(`/privacy-law/versions/${version.id}`)}>
             <Hb.Card.Content>
-              <Hb.Stack direction="row" alignItems="center" justifyContent="space-between">
-                <Hb.Stack direction="row" alignItems="center" spacing={1.5}>
+              <Hb.Stack
+                direction="row"
+                style={{
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Hb.Stack
+                  direction="row"
+                  spacing={1.5}
+                  style={{
+                    alignItems: "center",
+                  }}
+                >
                   <GavelOutlined color="primary" fontSize="small" />
                   <Hb.Box>
                     <Hb.Text variant="subtitle2">{version.lawName}</Hb.Text>

--- a/apps/hobom-system/src/features/wiki-space-list/ui/CreateSpaceDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-space-list/ui/CreateSpaceDialog.tsx
@@ -43,7 +43,12 @@ export const CreateSpaceDialog = ({
     <Hb.Dialog.Root open={open} onClose={handleClose} size="sm">
       <Hb.Dialog.Title>새 스페이스</Hb.Dialog.Title>
       <Hb.Dialog.Content>
-        <Hb.Stack spacing={2} sx={{ mt: 1 }}>
+        <Hb.Stack
+          spacing={2}
+          style={{
+            marginTop: 8,
+          }}
+        >
           <Hb.TextField
             autoFocus
             fullWidth

--- a/apps/hobom-system/src/features/wiki-space-list/ui/EditSpaceDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-space-list/ui/EditSpaceDialog.tsx
@@ -40,7 +40,12 @@ export const EditSpaceDialog = ({
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>스페이스 수정</Hb.Dialog.Title>
       <Hb.Dialog.Content>
-        <Hb.Stack spacing={2} sx={{ mt: 1 }}>
+        <Hb.Stack
+          spacing={2}
+          style={{
+            marginTop: 8,
+          }}
+        >
           <Hb.TextField
             fullWidth
             label="스페이스 키"

--- a/apps/hobom-system/src/pages/privacy-law-chat/ui/PrivacyLawChatPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-chat/ui/PrivacyLawChatPage.tsx
@@ -6,14 +6,25 @@ const PrivacyLawChatPage = () => {
   const { messages, sendMessage, clearMessages, isPending } = useChatSession();
 
   return (
-    <Hb.Stack sx={{ height: "calc(100vh - 240px)", minHeight: 400 }}>
+    <Hb.Stack
+      style={{
+        height: "calc(100vh - 240px)",
+        minHeight: 400,
+      }}
+    >
       <Hb.Alert severity="info" variant="outlined" sx={{ mb: 1.5 }}>
         <Hb.Text variant="caption" component="div">
           <strong>Gemini Free Plan</strong> 사용 중 — 분당 15회 요청 / 일 1,500회 / 분당 100만 토큰
           제한이 적용됩니다. 응답이 느리거나 실패할 수 있어요.
         </Hb.Text>
       </Hb.Alert>
-      <Hb.Stack direction="row" justifyContent="flex-end" mb={1}>
+      <Hb.Stack
+        direction="row"
+        style={{
+          justifyContent: "flex-end",
+          marginBottom: 8,
+        }}
+      >
         {messages.length > 0 && (
           <Hb.Tooltip title="대화 초기화">
             <Hb.Button.Icon size="small" onClick={clearMessages}>

--- a/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
@@ -36,7 +36,14 @@ const PrivacyLawLayoutPage = () => {
         padding: 24,
       }}
     >
-      <Hb.Stack direction="row" alignItems="center" spacing={1.5} mb={3}>
+      <Hb.Stack
+        direction="row"
+        spacing={1.5}
+        style={{
+          alignItems: "center",
+          marginBottom: 24,
+        }}
+      >
         <Hb.Text variant="h5" fontWeight={600}>
           개인정보보호법
         </Hb.Text>

--- a/apps/hobom-system/src/pages/privacy-law-study-detail/ui/PrivacyLawStudyDetailPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-study-detail/ui/PrivacyLawStudyDetailPage.tsx
@@ -13,11 +13,16 @@ const StudyDetailContent = ({ materialId }: { materialId: string }) => {
   return (
     <Hb.Stack spacing={3}>
       <StudyMaterialContent materialId={materialId} />
-
       {material.quizzes.length > 0 && (
         <>
           <Hb.Divider />
-          <Hb.Stack direction="row" alignItems="center" spacing={1}>
+          <Hb.Stack
+            direction="row"
+            spacing={1}
+            style={{
+              alignItems: "center",
+            }}
+          >
             <QuizOutlined color="primary" />
             <Hb.Text variant="h6">퀴즈</Hb.Text>
           </Hb.Stack>

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -12,6 +12,42 @@ import { Hb, EditableLabel } from "@/shared/ui";
 import { useWorkspace } from "@/features/workspace";
 import type { FolderId, ItemId } from "@/entities/workspace";
 
+// StyleX/inline styles cannot express the hover-reveal descendant selectors, so
+// these rows are styled via scoped <style> tags with a stable class each. React 19
+// hoists and de-dupes them by `href`, so each rule is emitted once despite the .map.
+const FOLDER_ROW_CLASS = "workspace-folder-row";
+const FOLDER_ROW_ACTIVE_CLASS = "is-active";
+// The base background depends on the active folder. It is toggled via a modifier
+// class (not inline) so the :hover rule can still override it.
+const FOLDER_ROW_CSS = `
+.${FOLDER_ROW_CLASS} {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  border-radius: 8px;
+  cursor: pointer;
+  background-color: transparent;
+}
+.${FOLDER_ROW_CLASS}.${FOLDER_ROW_ACTIVE_CLASS} { background-color: var(--hb-color-border); }
+.${FOLDER_ROW_CLASS}:hover { background-color: var(--hb-color-border); }
+.${FOLDER_ROW_CLASS}:hover .row-action { opacity: 1; }
+`;
+
+const FAV_ROW_CLASS = "workspace-fav-row";
+const FAV_ROW_CSS = `
+.${FAV_ROW_CLASS} {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.${FAV_ROW_CLASS}:hover { background-color: var(--hb-color-border); }
+.${FAV_ROW_CLASS}:hover .fav-action { opacity: 1; }
+`;
+
 /** 워크스페이스 브라우저 — 좌측 즐겨찾기·폴더 / 우측 아이템 그리드. */
 export default function WorkspacePage() {
   const navigate = useNavigate();
@@ -60,15 +96,21 @@ export default function WorkspacePage() {
   };
 
   return (
-    <Hb.Stack direction="row" sx={{ height: "100%", minHeight: 0 }}>
+    <Hb.Stack
+      direction="row"
+      style={{
+        height: "100%",
+        minHeight: 0,
+      }}
+    >
       <Hb.Stack
-        sx={{
+        style={{
           width: 240,
           flexShrink: 0,
           borderRight: 1,
-          borderColor: "divider",
-          p: 1.5,
-          gap: 0.25,
+          borderColor: "var(--hb-color-border)",
+          padding: 12,
+          gap: 2,
           overflow: "auto",
         }}
       >
@@ -102,7 +144,14 @@ export default function WorkspacePage() {
           </>
         )}
 
-        <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Hb.Stack
+          direction="row"
+          style={{
+            marginBottom: 8,
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           <Hb.Text
             variant="caption"
             color="text.secondary"
@@ -117,21 +166,22 @@ export default function WorkspacePage() {
           </Hb.Button.Icon>
         </Hb.Stack>
 
+        <style href={FOLDER_ROW_CLASS} precedence="default">
+          {FOLDER_ROW_CSS}
+        </style>
         {folders.map((folder) => (
           <Hb.Stack
             key={folder.id}
+            className={
+              folder.id === activeFolder?.id
+                ? `${FOLDER_ROW_CLASS} ${FOLDER_ROW_ACTIVE_CLASS}`
+                : FOLDER_ROW_CLASS
+            }
             direction="row"
-            alignItems="center"
-            gap={1}
             onClick={() => setActiveFolderId(folder.id)}
-            sx={{
-              px: 1,
-              py: 0.75,
-              borderRadius: 1,
-              cursor: "pointer",
-              bgcolor: folder.id === activeFolder?.id ? "action.selected" : "transparent",
-              "&:hover": { bgcolor: "action.hover" },
-              "&:hover .row-action": { opacity: 1 },
+            style={{
+              alignItems: "center",
+              gap: 8,
             }}
           >
             <FolderOutlined sx={{ fontSize: 18, color: "text.secondary" }} />
@@ -165,7 +215,14 @@ export default function WorkspacePage() {
           overflow: "auto",
         }}
       >
-        <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+        <Hb.Stack
+          direction="row"
+          style={{
+            marginBottom: 16,
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           <Hb.Text variant="h6">{activeFolder?.name ?? "워크스페이스"}</Hb.Text>
           <Hb.Button variant="primary" startIcon={<AddOutlined />} onClick={handleNewDesign}>
             새 디자인
@@ -325,58 +382,58 @@ function FavoriteRow({ label, onOpen, onRename, onRemove }: FavoriteRowProps) {
   }
 
   return (
-    <Hb.Stack
-      direction="row"
-      alignItems="center"
-      gap={1}
-      onClick={onOpen}
-      sx={{
-        px: 1,
-        py: 0.75,
-        borderRadius: 1,
-        cursor: "pointer",
-        "&:hover": { bgcolor: "action.hover" },
-        "&:hover .fav-action": { opacity: 1 },
-      }}
-    >
-      <PushPin sx={{ fontSize: 16, color: "primary.main" }} />
-      <Hb.Text
+    <>
+      <style href={FAV_ROW_CLASS} precedence="default">
+        {FAV_ROW_CSS}
+      </style>
+      <Hb.Stack
+        className={FAV_ROW_CLASS}
+        direction="row"
+        onClick={onOpen}
         style={{
-          flex: 1,
-          minWidth: 0,
-          fontSize: 14,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
+          alignItems: "center",
+          gap: 8,
         }}
       >
-        {label}
-      </Hb.Text>
-      <Hb.Button.Icon
-        size="small"
-        className="fav-action"
-        aria-label="즐겨찾기 이름변경"
-        onClick={(event) => {
-          event.stopPropagation();
-          setDraft(label);
-          setEditing(true);
-        }}
-        sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
-      >
-        <EditOutlined sx={{ fontSize: 15 }} />
-      </Hb.Button.Icon>
-      <Hb.Button.Icon
-        size="small"
-        className="fav-action"
-        aria-label="즐겨찾기 해제"
-        onClick={(event) => {
-          event.stopPropagation();
-          onRemove();
-        }}
-        sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
-      >
-        <DeleteOutline sx={{ fontSize: 15 }} />
-      </Hb.Button.Icon>
-    </Hb.Stack>
+        <PushPin sx={{ fontSize: 16, color: "primary.main" }} />
+        <Hb.Text
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: 14,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {label}
+        </Hb.Text>
+        <Hb.Button.Icon
+          size="small"
+          className="fav-action"
+          aria-label="즐겨찾기 이름변경"
+          onClick={(event) => {
+            event.stopPropagation();
+            setDraft(label);
+            setEditing(true);
+          }}
+          sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
+        >
+          <EditOutlined sx={{ fontSize: 15 }} />
+        </Hb.Button.Icon>
+        <Hb.Button.Icon
+          size="small"
+          className="fav-action"
+          aria-label="즐겨찾기 해제"
+          onClick={(event) => {
+            event.stopPropagation();
+            onRemove();
+          }}
+          sx={{ p: 0.25, opacity: 0, transition: "opacity 0.12s" }}
+        >
+          <DeleteOutline sx={{ fontSize: 15 }} />
+        </Hb.Button.Icon>
+      </Hb.Stack>
+    </>
   );
 }

--- a/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
+++ b/apps/hobom-system/src/pages/studio/ui/StudioPage.tsx
@@ -66,19 +66,26 @@ function StudioEditor({ itemId, name, document }: StudioEditorProps) {
     <Hb.ThemeProvider theme={studioTheme}>
       <Hb.Stack
         direction="row"
-        sx={{
+        style={{
           height: "100%",
           minHeight: 0,
-          bgcolor: "background.default",
-          color: "text.primary",
+          backgroundColor: "var(--hb-color-canvas)",
+          color: "var(--hb-color-text-primary)",
         }}
       >
         <Panel width={232} side="right">
           <Hb.Stack
             direction="row"
-            alignItems="center"
-            gap={0.5}
-            sx={{ px: 1, py: 1, borderBottom: 1, borderColor: "divider" }}
+            style={{
+              paddingLeft: 8,
+              paddingRight: 8,
+              paddingTop: 8,
+              paddingBottom: 8,
+              borderBottom: "1px solid",
+              borderColor: "var(--hb-color-border)",
+              alignItems: "center",
+              gap: 4,
+            }}
           >
             <Hb.Button.Icon
               size="small"
@@ -110,12 +117,12 @@ function StudioEditor({ itemId, name, document }: StudioEditorProps) {
 
         <Hb.Stack
           onClick={clearSelection}
-          sx={{
+          style={{
             flex: 1,
             minWidth: 0,
             minHeight: 0,
-            p: 4,
-            gap: 1,
+            padding: 32,
+            gap: 8,
             overflow: "auto",
           }}
         >
@@ -181,13 +188,13 @@ interface PanelProps {
 function Panel({ width, side, children }: PanelProps) {
   return (
     <Hb.Stack
-      sx={{
+      style={{
         width,
         flexShrink: 0,
         minWidth: 0,
-        bgcolor: "background.paper",
-        [side === "right" ? "borderRight" : "borderLeft"]: 1,
-        borderColor: "divider",
+        backgroundColor: "var(--hb-color-surface)",
+        [side === "right" ? "borderRight" : "borderLeft"]: "1px solid",
+        borderColor: "var(--hb-color-border)",
         overflow: "auto",
       }}
     >

--- a/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
+++ b/apps/hobom-system/src/widgets/code-panel/ui/CodePanel.tsx
@@ -14,8 +14,19 @@ export function CodePanel({ document }: CodePanelProps) {
   const { copied, copy } = useCopyToClipboard();
 
   return (
-    <Hb.Stack gap={1} sx={{ minWidth: 0 }}>
-      <Hb.Stack direction="row" alignItems="center" gap={0.5}>
+    <Hb.Stack
+      style={{
+        minWidth: 0,
+        gap: 8,
+      }}
+    >
+      <Hb.Stack
+        direction="row"
+        style={{
+          alignItems: "center",
+          gap: 4,
+        }}
+      >
         <Hb.Text
           style={{
             fontSize: 11,

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -45,7 +45,14 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
         padding: 12,
       }}
     >
-      <Hb.Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+      <Hb.Stack
+        direction="row"
+        style={{
+          marginBottom: 12,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
         <Hb.Text
           style={{
             fontSize: 13,
@@ -73,7 +80,11 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
           미등록 컴포넌트: {node.type}
         </Hb.Text>
       ) : (
-        <Hb.Stack gap={1.25}>
+        <Hb.Stack
+          style={{
+            gap: 10,
+          }}
+        >
           {Object.entries(manifest.props).map(([name, spec]) => (
             <PropField
               key={name}
@@ -103,7 +114,11 @@ export function Inspector({ node, onChange, onStyleChange, onDelete }: Inspector
       >
         사이징
       </Hb.Text>
-      <Hb.Stack gap={1.25}>
+      <Hb.Stack
+        style={{
+          gap: 10,
+        }}
+      >
         <SizeField
           label="W"
           value={node.style?.width}
@@ -130,9 +145,11 @@ function SizeField({ label, value, onChange }: SizeFieldProps) {
   return (
     <Hb.Stack
       direction="row"
-      alignItems="center"
-      justifyContent="space-between"
-      sx={{ minHeight: 24 }}
+      style={{
+        minHeight: 24,
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
     >
       <Hb.Text style={labelStyle}>{label}</Hb.Text>
       <Hb.TextField
@@ -189,9 +206,11 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
     return (
       <Hb.Stack
         direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ minHeight: 24 }}
+        style={{
+          minHeight: 24,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
       >
         <Hb.Text style={labelStyle}>{name}</Hb.Text>
         <Hb.Checkbox
@@ -206,7 +225,12 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
 
   if (spec.kind === "string") {
     return (
-      <Hb.Stack gap={0.5} sx={{ minWidth: 0 }}>
+      <Hb.Stack
+        style={{
+          minWidth: 0,
+          gap: 4,
+        }}
+      >
         <Hb.Text style={labelStyle}>{name}</Hb.Text>
         <Hb.TextField
           size="small"
@@ -222,9 +246,11 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
     return (
       <Hb.Stack
         direction="row"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ minHeight: 24 }}
+        style={{
+          minHeight: 24,
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
       >
         <Hb.Text style={labelStyle}>{name}</Hb.Text>
         <Hb.TextField
@@ -239,7 +265,12 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
   }
 
   return (
-    <Hb.Stack gap={0.5} sx={{ minWidth: 0 }}>
+    <Hb.Stack
+      style={{
+        minWidth: 0,
+        gap: 4,
+      }}
+    >
       <Hb.Text style={labelStyle}>{name}</Hb.Text>
       <Hb.Box
         style={{

--- a/memory/stylex-no-descendant-selectors.md
+++ b/memory/stylex-no-descendant-selectors.md
@@ -1,0 +1,23 @@
+---
+name: stylex-no-descendant-selectors
+description: StyleX는 descendant/child selector(& h1, & .child) 불가 — pseudo/media만. de-MUI 시 주입 HTML·자식 hover-reveal은 scoped <style>로.
+metadata:
+  type: reference
+---
+
+**StyleX는 atomic이라 descendant/child combinator selector를 지원하지 않는다.** `stylex.create`에서 허용되는 조건부 키는 **pseudo-class(`:hover`, `:focus-within`), pseudo-element(`::before`), media/container query**뿐. `"& h1"`, `"& .move-btn"`, `"& > * + *"` 같은 키는 빌드 시 `@stylexjs/babel-plugin: Invalid pseudo or at-rule`로 **터진다**(tsc는 통과, vite build에서 실패).
+
+**de-MUI 이관 시 sx가 이런 걸 쓰는 두 경우**:
+1. **주입 HTML의 prose 스타일** — `dangerouslySetInnerHTML`로 넣은 위키/tiptap 콘텐츠의 `& h1`, `& p`, `& .tiptap` 등.
+2. **자식 hover-reveal** — `&:hover .move-btn { opacity: 1 }`(행 hover 시 액션 버튼 노출).
+
+**해결: scoped `<style>` 태그 + 고유 class** (`ColorSchemeVars`가 `<style dangerouslySetInnerHTML>`로 css-vars 주입하는 선례와 동일).
+```tsx
+const CLS = "wiki-prose-view";
+const CSS = `.${CLS} h1 { font-size: 1.75rem; margin-top: 24px; } ...`;
+return (<><style href={CLS} precedence="default">{CSS}</style><Hb.Box className={CLS} .../></>);
+```
+- **리스트에서 여러 번 렌더되는 행**(IssueRow 등)은 `<style href precedence>`(React 19)로 → head-hoist + 자동 dedup(중복 `<style>` 방지). 단일 인스턴스 prose는 어느 쪽이든 무방.
+- CSS 문자열은 `var(--hb-color-*)`를 그대로 참조(런타임 주입된 전역 vars와 결합).
+
+⚠️ **주의**: StyleX 동적 색/surface도 여전히 인라인 style로([[design-system-overhaul]] Chip 교훈). 즉 atomic StyleX는 (a)정적 pseudo만, 동적 색·descendant는 각각 인라인·scoped `<style>`. Box 이관(#133)에서 이 셋 다 등장. Stack/Grid/List 이관 때도 동일 대비.

--- a/packages/hobom-design-system/src/components/Stack/Stack.stories.tsx
+++ b/packages/hobom-design-system/src/components/Stack/Stack.stories.tsx
@@ -1,0 +1,56 @@
+import { Stack } from "./Stack";
+import { Divider } from "../Divider/Divider";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Stack",
+  component: Stack,
+  args: { spacing: 2 },
+} satisfies Meta<typeof Stack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const cell = (label: string) => (
+  <div
+    style={{
+      padding: 8,
+      background: "var(--hb-color-surface)",
+      border: "1px solid var(--hb-color-border)",
+      borderRadius: 6,
+    }}
+  >
+    {label}
+  </div>
+);
+
+export const Column: Story = {
+  render: (args) => (
+    <Stack {...args}>
+      {cell("one")}
+      {cell("two")}
+      {cell("three")}
+    </Stack>
+  ),
+};
+
+export const Row: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1.5} alignItems="center">
+      {cell("one")}
+      {cell("two")}
+      {cell("three")}
+    </Stack>
+  ),
+};
+
+export const WithDivider: Story = {
+  render: () => (
+    <Stack direction="row" spacing={2} divider={<Divider orientation="vertical" flexItem />}>
+      {cell("one")}
+      {cell("two")}
+      {cell("three")}
+    </Stack>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Stack/Stack.tsx
+++ b/packages/hobom-design-system/src/components/Stack/Stack.tsx
@@ -1,1 +1,75 @@
-export { Stack } from "@mui/material";
+import {
+  Children,
+  cloneElement,
+  createElement,
+  isValidElement,
+  type CSSProperties,
+  type ElementType,
+  type HTMLAttributes,
+  type ReactElement,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
+
+type StackDirection = "row" | "column" | "row-reverse" | "column-reverse";
+
+interface StackProps extends HTMLAttributes<HTMLElement> {
+  /** Element to render. Defaults to `"div"`. */
+  component?: ElementType;
+  /** Flex direction. Defaults to `"column"` (matching MUI). */
+  direction?: StackDirection;
+  /** Gap between children, in 8px units (`spacing={2}` → 16px). */
+  spacing?: number;
+  alignItems?: CSSProperties["alignItems"];
+  justifyContent?: CSSProperties["justifyContent"];
+  flexWrap?: CSSProperties["flexWrap"];
+  /** Element rendered between each child. */
+  divider?: ReactElement;
+}
+
+const styles = stylex.create({
+  root: { display: "flex", boxSizing: "border-box" },
+});
+
+const SPACING_UNIT = 8;
+
+// Interleave `divider` between children, matching MUI's Stack behavior.
+const withDividers = (children: StackProps["children"], divider: ReactElement) =>
+  Children.toArray(children)
+    .filter((child) => child !== null && child !== undefined)
+    .flatMap((child, index) =>
+      index === 0 ? [child] : [cloneElement(divider, { key: `divider-${index}` }), child],
+    );
+
+export const Stack = ({
+  component = "div",
+  direction = "column",
+  spacing,
+  alignItems,
+  justifyContent,
+  flexWrap,
+  divider,
+  className,
+  style,
+  children,
+  ...rest
+}: StackProps) => {
+  const sx = stylex.props(styles.root);
+
+  const dynamic: CSSProperties = {
+    flexDirection: direction,
+    gap: spacing != null ? spacing * SPACING_UNIT : undefined,
+    alignItems,
+    justifyContent,
+    flexWrap,
+  };
+
+  return createElement(
+    component,
+    {
+      ...rest,
+      className: [sx.className, className].filter(Boolean).join(" ") || undefined,
+      style: { ...sx.style, ...dynamic, ...style },
+    },
+    divider && isValidElement(divider) ? withDividers(children, divider) : children,
+  );
+};


### PR DESCRIPTION
Replaces the MUI `Stack` re-export (`Hb.Stack`, ~86 call sites) with a StyleX flex container. Continues the layout-primitive sweep after Box.

## Component
`Hb.Stack` renders a flex element (`display: flex` via StyleX) with:
- `direction` (default `column`), `spacing` (×8 → `gap`), `alignItems`, `justifyContent`, `flexWrap`
- polymorphic `component`, a `divider` interleaved between children (MUI parity)
- full `style` / `className` / `ref` / rest passthrough, no `sx`

## Consumers
- `sx-to-style` + `hoist-system-props` codemods move `sx` / direct system props to `style`; `direction`/`spacing`/`alignItems`/… stay as real Stack props.
- The two Studio pages' list rows use `&:hover .row-action` / `.fav-action` reveals — atomic StyleX can't express descendant selectors, so they use a scoped **`<style href precedence>`** tag (React 19 hoist + de-dupe). The dynamic active-row background became a modifier class so `:hover` can override it.

## Verification
- DS & app: **0 lint problems**, `tsc -b` **0 errors**, app **build passes**.
- App tests: **582** green.
- `Hb.Stack` is MUI-free; the app still has **0** direct `@mui` imports.

Remaining MUI components: 26 (Box+Stack+Text+Chip+Paper+Divider+Badge+Tooltip now in-house).