### PR TITLE
feat: in-house Progress, drop MUI Circular/LinearProgress

### DIFF
--- a/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
@@ -155,15 +155,8 @@ export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) =>
                 <Hb.Progress.Linear
                   variant="determinate"
                   value={pct}
-                  sx={{
-                    height: 4,
-                    borderRadius: 2,
-                    bgcolor: "grey.100",
-                    "& .MuiLinearProgress-bar": {
-                      borderRadius: 2,
-                      bgcolor: color,
-                    },
-                  }}
+                  color={color}
+                  style={{ height: 4, borderRadius: 16, backgroundColor: "#f5f5f5" }}
                 />
               </Hb.Box>
             );

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
@@ -291,7 +291,10 @@ export const ExamQuestionCard = ({ questions }: Props) => {
         <Hb.Progress.Linear
           variant="determinate"
           value={((currentIndex + 1) / total) * 100}
-          sx={{ mb: 3, borderRadius: 1 }}
+          style={{
+            marginBottom: 24,
+            borderRadius: 8,
+          }}
         />
 
         <Hb.Text variant="subtitle1" fontWeight={600} gutterBottom>

--- a/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
@@ -285,7 +285,10 @@ export const QuizCard = ({ quizzes }: Props) => {
         <Hb.Progress.Linear
           variant="determinate"
           value={((currentIndex + 1) / total) * 100}
-          sx={{ mb: 3, borderRadius: 1 }}
+          style={{
+            marginBottom: 24,
+            borderRadius: 8,
+          }}
         />
 
         <Hb.Text variant="subtitle1" fontWeight={600} gutterBottom>

--- a/apps/hobom-system/src/features/project-dashboard/ui/IssueDashboardSection.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/IssueDashboardSection.tsx
@@ -73,12 +73,7 @@ export const IssueDashboardSection = ({ data }: IssueDashboardSectionProps) => {
           <Hb.Progress.Linear
             variant="determinate"
             value={completionPercent}
-            sx={{
-              height: 10,
-              borderRadius: 5,
-              bgcolor: "action.hover",
-              "& .MuiLinearProgress-bar": { borderRadius: 5 },
-            }}
+            style={{ height: 10, borderRadius: 40, backgroundColor: "var(--hb-color-border)" }}
           />
         </DashboardPaper>
       </Hb.Grid>

--- a/apps/hobom-system/src/features/submit-auth-login/ui/LoginTransitionOverlay.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/LoginTransitionOverlay.tsx
@@ -36,12 +36,8 @@ export const LoginTransitionOverlay = () => (
       HoBom
     </Hb.Text>
     <Hb.Progress.Linear
-      sx={{
-        width: 240,
-        borderRadius: 1,
-        bgcolor: "rgba(255,255,255,0.2)",
-        "& .MuiLinearProgress-bar": { bgcolor: "white" },
-      }}
+      color="white"
+      style={{ width: 240, borderRadius: 8, backgroundColor: "rgba(255,255,255,0.2)" }}
     />
     <Hb.Text
       variant="body2"

--- a/apps/hobom-system/src/features/wiki-page-comments/ui/CommentsSection.tsx
+++ b/apps/hobom-system/src/features/wiki-page-comments/ui/CommentsSection.tsx
@@ -86,7 +86,14 @@ export const CommentsSection = ({ spaceKey, pageId, userInfo }: CommentsSectionP
                   color: "var(--hb-color-text-secondary)",
                 }}
               >
-                {isFetchingNextPage ? <Hb.Progress.Circular size={16} sx={{ mr: 1 }} /> : null}
+                {isFetchingNextPage ? (
+                  <Hb.Progress.Circular
+                    size={16}
+                    style={{
+                      marginRight: 8,
+                    }}
+                  />
+                ) : null}
                 댓글 더보기 ({loadedCount}/{totalCount})
               </Hb.Button>
             </Hb.Box>

--- a/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
@@ -116,7 +116,14 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
                 fontSize: "0.75rem",
               }}
             >
-              {isFetchingNextPage ? <Hb.Progress.Circular size={14} sx={{ mr: 0.5 }} /> : null}
+              {isFetchingNextPage ? (
+                <Hb.Progress.Circular
+                  size={14}
+                  style={{
+                    marginRight: 4,
+                  }}
+                />
+              ) : null}
               더보기 ({pages.length}/{totalCount})
             </Hb.Button>
           </Hb.Box>

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
@@ -150,7 +150,14 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
                 fontSize: "0.75rem",
               }}
             >
-              {isFetchingNextPage ? <Hb.Progress.Circular size={14} sx={{ mr: 0.5 }} /> : null}
+              {isFetchingNextPage ? (
+                <Hb.Progress.Circular
+                  size={14}
+                  style={{
+                    marginRight: 4,
+                  }}
+                />
+              ) : null}
               이전 버전 더보기 ({versions.length}/{totalCount})
             </Hb.Button>
           </Hb.Box>

--- a/packages/hobom-design-system/src/components/Progress/Progress.stories.tsx
+++ b/packages/hobom-design-system/src/components/Progress/Progress.stories.tsx
@@ -1,0 +1,29 @@
+import { Progress } from "./Progress";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Progress",
+  component: Progress.Circular,
+} satisfies Meta<typeof Progress.Circular>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Circular: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+      <Progress.Circular size={24} />
+      <Progress.Circular size={40} />
+      <Progress.Circular size={56} />
+    </div>
+  ),
+};
+
+export const Linear: Story = {
+  render: () => (
+    <div style={{ width: 280 }}>
+      <Progress.Linear />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Progress/Progress.tsx
+++ b/packages/hobom-design-system/src/components/Progress/Progress.tsx
@@ -1,9 +1,117 @@
-import {
-  CircularProgress as MuiCircularProgress,
-  LinearProgress as MuiLinearProgress,
-} from "@mui/material";
+import type { CSSProperties, HTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
 
-const Circular = MuiCircularProgress;
-const Linear = MuiLinearProgress;
+const spin = stylex.keyframes({
+  from: { transform: "rotate(0deg)" },
+  to: { transform: "rotate(360deg)" },
+});
+
+// A single bar sweeping across the track — an indeterminate LinearProgress.
+const slide = stylex.keyframes({
+  "0%": { left: "-40%", width: "40%" },
+  "50%": { left: "20%", width: "60%" },
+  "100%": { left: "100%", width: "40%" },
+});
+
+const styles = stylex.create({
+  circular: {
+    display: "inline-block",
+    boxSizing: "border-box",
+    borderRadius: "50%",
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-accent)",
+    borderTopColor: "transparent",
+    animationName: spin,
+    animationDuration: "0.8s",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "linear",
+  },
+  linearTrack: {
+    position: "relative",
+    overflow: "hidden",
+    width: "100%",
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 24%, transparent)",
+  },
+  linearBar: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    borderRadius: "inherit",
+  },
+  indeterminate: {
+    animationName: slide,
+    animationDuration: "1.4s",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "ease-in-out",
+  },
+  determinate: { left: 0 },
+});
+
+interface CircularProps extends HTMLAttributes<HTMLSpanElement> {
+  /** Diameter (px number, or any CSS length). Defaults to `40`. */
+  size?: number | string;
+}
+
+const Circular = ({ size = 40, className, style, ...rest }: CircularProps) => {
+  const sx = stylex.props(styles.circular);
+  const dynamic: CSSProperties = {
+    width: size,
+    height: size,
+    borderWidth: typeof size === "number" ? Math.max(2, Math.round(size / 10)) : 4,
+  };
+
+  return (
+    <span
+      role="progressbar"
+      aria-label="로딩 중"
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...dynamic, ...style }}
+    />
+  );
+};
+
+interface LinearProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: "indeterminate" | "determinate";
+  /** Percent filled (0–100) for the determinate variant. */
+  value?: number;
+  /** Bar color. Defaults to the accent. */
+  color?: string;
+}
+
+const Linear = ({
+  variant = "indeterminate",
+  value = 0,
+  color = "var(--hb-color-accent)",
+  className,
+  style,
+  ...rest
+}: LinearProps) => {
+  const track = stylex.props(styles.linearTrack);
+  const determinate = variant === "determinate";
+  const bar = stylex.props(styles.linearBar, determinate ? styles.determinate : styles.indeterminate);
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="로딩 중"
+      aria-valuenow={determinate ? value : undefined}
+      {...rest}
+      className={[track.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...track.style, ...style }}
+    >
+      <span
+        className={bar.className}
+        style={{
+          ...bar.style,
+          backgroundColor: color,
+          ...(determinate ? { width: `${value}%` } : null),
+        }}
+      />
+    </div>
+  );
+};
 
 export const Progress = { Circular, Linear };


### PR DESCRIPTION
Replaces the MUI `CircularProgress`/`LinearProgress` re-exports (`Hb.Progress.Circular` ×25, `.Linear` ×5) with StyleX.

## Component
- **`Progress.Circular`** — a CSS border spinner (keyframe rotation), sized by `size` (px number **or** any CSS length like `"48px"`), accent-colored.
- **`Progress.Linear`** — a track + bar: `variant="indeterminate"` (default, a sweeping bar) or `"determinate"` with `value` (0–100 → bar width). Bar color via the `color` prop; track styling via `style`.

## Consumers
- `sx` codemodded to `style`. The determinate progress bars and the `& .MuiLinearProgress-bar` sx (used to color the inner bar) were migrated by hand to `variant`/`value`/`color` props.

## Verification
- DS & app: **0 lint problems**, `tsc -b` **0 errors**, app **build passes**, **582 tests** green, Progress **Storybook a11y passes** (verified locally pre-push).
- `Hb.Progress` MUI-free; app has **0** direct `@mui` imports.

Remaining MUI components: 22.