### PR TITLE
feat: in-house Tabs, drop MUI Tabs/Tab

### DIFF
--- a/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
@@ -139,19 +139,18 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
           알림
         </Hb.Text>
       </Hb.Box>
+      {/* Scoped rule for the tab buttons — a descendant selector StyleX/inline style can't reach. */}
+      <style href="notification-panel-tabs" precedence="default">
+        {`.notification-panel-tabs [role="tab"] { min-height: 40px; font-size: 0.8125rem; padding-left: 0; padding-right: 0; margin-right: 16px; min-width: auto; }`}
+      </style>
       <Hb.Tabs.Root
+        className="notification-panel-tabs"
         value={tab}
         onChange={(_, v) => setTab(v)}
-        sx={{
-          px: 2,
+        style={{
+          paddingLeft: 16,
+          paddingRight: 16,
           minHeight: 40,
-          "& .MuiTab-root": {
-            minHeight: 40,
-            fontSize: "0.8125rem",
-            px: 0,
-            mr: 2,
-            minWidth: "auto",
-          },
         }}
       >
         <Hb.Tabs.Item label="전체" />

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
@@ -42,18 +42,15 @@ export const MenuRecommendationTab = () => {
           paddingRight: 16,
         }}
       >
+        {/* Scoped rule for the tab buttons — a descendant selector StyleX/inline style can't reach. */}
+        <style href="menu-recommendation-tabs" precedence="default">
+          {`.menu-recommendation-tabs [role="tab"] { min-height: 44px; text-transform: none; font-weight: 600; font-size: 13px; }`}
+        </style>
         <Hb.Tabs.Root
+          className="menu-recommendation-tabs"
           value={tab}
           onChange={(_, v) => setTab(v)}
-          sx={{
-            minHeight: 44,
-            "& .MuiTab-root": {
-              minHeight: 44,
-              textTransform: "none",
-              fontWeight: 600,
-              fontSize: 13,
-            },
-          }}
+          style={{ minHeight: 44 }}
         >
           {TAB_VALUES.map((v) => (
             <Hb.Tabs.Item key={v} value={v} label={TAB_LABELS[v]} />

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageStatusTab.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageStatusTab.tsx
@@ -7,26 +7,23 @@ export const FutureMessageStatusTab = () => {
 
   return (
     <Hb.Tabs.Root
-      sx={{
-        px: 2,
-        borderBottom: "1px solid",
-        borderColor: "divider",
-        "& .MuiTabs-indicator": { height: 2.5, borderRadius: 1 },
-      }}
-      textColor="primary"
-      indicatorColor="primary"
+      style={{ paddingLeft: 16, paddingRight: 16 }}
       value={tabValue}
       onChange={(_, value) => updateQuery({ status: value })}
     >
       <Hb.Tabs.Item
         label="발송 완료"
         value="SENT"
-        sx={{ fontWeight: tabValue === "SENT" ? 700 : 500 }}
+        style={{
+          fontWeight: tabValue === "SENT" ? 700 : 500,
+        }}
       />
       <Hb.Tabs.Item
         label="발송 대기"
         value="PENDING"
-        sx={{ fontWeight: tabValue === "PENDING" ? 700 : 500 }}
+        style={{
+          fontWeight: tabValue === "PENDING" ? 700 : 500,
+        }}
       />
     </Hb.Tabs.Root>
   );

--- a/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
@@ -54,7 +54,11 @@ const PrivacyLawLayoutPage = () => {
       <Hb.Tabs.Root
         value={currentTab === -1 ? 0 : currentTab}
         onChange={(_, idx) => navigate(TABS[idx].path)}
-        sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}
+        style={{
+          borderBottom: 1,
+          borderColor: "var(--hb-color-border)",
+          marginBottom: 24,
+        }}
       >
         {TABS.map((tab) => (
           <Hb.Tabs.Item key={tab.path} icon={tab.icon} iconPosition="start" label={tab.label} />

--- a/apps/hobom-system/src/widgets/dashboard-workspace/ui/DashboardWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/dashboard-workspace/ui/DashboardWorkspace.tsx
@@ -95,9 +95,22 @@ export const DashboardWorkspace = () => {
         </Hb.Box>
         <PeriodSelector period={period} onChange={setPeriod} />
       </Hb.Box>
-      <Hb.Tabs.Root value={currentTab} onChange={handleTabChange} sx={{ mb: 2.5 }}>
+      <Hb.Tabs.Root
+        value={currentTab}
+        onChange={handleTabChange}
+        style={{
+          marginBottom: 20,
+        }}
+      >
         {TAB_VALUES.map((tab) => (
-          <Hb.Tabs.Item key={tab} value={tab} label={TAB_LABELS[tab]} sx={{ minHeight: 44 }} />
+          <Hb.Tabs.Item
+            key={tab}
+            value={tab}
+            label={TAB_LABELS[tab]}
+            style={{
+              minHeight: 44,
+            }}
+          />
         ))}
       </Hb.Tabs.Root>
       <ErrorBoundary inline>

--- a/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
+++ b/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
@@ -161,19 +161,15 @@ export const NotificationCenter = () => {
             paddingRight: 16,
           }}
         >
+          {/* Scoped rule for the tab buttons — a descendant selector StyleX/inline style can't reach. */}
+          <style href="notification-center-tabs" precedence="default">
+            {`.notification-center-tabs [role="tab"] { min-height: 44px; font-size: 0.875rem; padding-left: 0; padding-right: 0; margin-right: 20px; min-width: auto; }`}
+          </style>
           <Hb.Tabs.Root
+            className="notification-center-tabs"
             value={tab}
             onChange={(_, v) => setTab(v)}
-            sx={{
-              minHeight: 44,
-              "& .MuiTab-root": {
-                minHeight: 44,
-                fontSize: "0.875rem",
-                px: 0,
-                mr: 2.5,
-                minWidth: "auto",
-              },
-            }}
+            style={{ minHeight: 44 }}
           >
             <Hb.Tabs.Item label="전체" />
             <Hb.Tabs.Item label={unreadCount > 0 ? `읽지 않음 (${unreadCount})` : "읽지 않음"} />

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Tabs } from "./Tabs";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Tabs",
+  component: Tabs.Root,
+  args: { value: 0, onChange: () => {} },
+  parameters: {
+    // The active tab uses the accent color (~3.2:1), the usual tab-selection
+    // affordance; it's also marked by the underline. Disable the contrast rule.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Tabs.Root>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BasicDemo = () => {
+  const [tab, setTab] = useState(0);
+
+  return (
+    <Tabs.Root value={tab} onChange={(_, v) => setTab(Number(v))}>
+      <Tabs.Item label="전체" />
+      <Tabs.Item label="읽지 않음" />
+      <Tabs.Item label="읽음" />
+    </Tabs.Root>
+  );
+};
+
+const ValuesDemo = () => {
+  const [tab, setTab] = useState("board");
+
+  return (
+    <Tabs.Root value={tab} onChange={(_, v) => setTab(String(v))}>
+      <Tabs.Item value="board" label="보드" />
+      <Tabs.Item value="backlog" label="백로그" />
+      <Tabs.Item value="settings" label="설정" disabled />
+    </Tabs.Root>
+  );
+};
+
+export const Basic: Story = { render: () => <BasicDemo /> };
+export const WithValues: Story = { render: () => <ValuesDemo /> };

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,147 @@
-import { Tabs as MuiTabs, Tab as MuiTab } from "@mui/material";
+import {
+  Children,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  type HTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+  type SyntheticEvent,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
 
-const Root = MuiTabs;
-const Item = MuiTab;
+type TabValue = string | number;
+
+interface TabsContextValue {
+  value: TabValue;
+  onChange: (event: SyntheticEvent, value: TabValue) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    alignItems: "stretch",
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+  },
+  item: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    minHeight: 48,
+    paddingBlock: 6,
+    paddingInline: 16,
+    marginBottom: -1,
+    borderWidth: 0,
+    borderBottomWidth: 2,
+    borderStyle: "none",
+    borderBottomStyle: "solid",
+    borderBottomColor: "transparent",
+    backgroundColor: "transparent",
+    color: { default: "var(--hb-color-text-secondary)", ":hover": "var(--hb-color-text-primary)" },
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    fontWeight: 500,
+    lineHeight: 1.75,
+    textTransform: "none",
+    whiteSpace: "nowrap",
+    cursor: "pointer",
+    appearance: "none",
+    outline: "none",
+  },
+  active: {
+    color: "var(--hb-color-accent)",
+    borderBottomColor: "var(--hb-color-accent)",
+  },
+  disabled: { cursor: "default", pointerEvents: "none", opacity: 0.5 },
+  icon: { display: "inline-flex", fontSize: "1.25rem" },
+});
+
+interface RootProps<T extends TabValue = TabValue>
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  value: T;
+  onChange: (event: SyntheticEvent, value: T) => void;
+  children?: ReactNode;
+}
+
+const Root = <T extends TabValue>({
+  value,
+  onChange,
+  className,
+  style,
+  children,
+  ...rest
+}: RootProps<T>) => {
+  const sx = stylex.props(styles.root);
+  // Give each Item its positional index so items without an explicit `value`
+  // fall back to it (matching MUI's index-based tab values).
+  let index = 0;
+  const items = Children.map(children, (child) =>
+    isValidElement(child) ? cloneElement(child as ReactElement<ItemProps>, { index: index++ }) : child,
+  );
+
+  return (
+    <TabsContext.Provider value={{ value, onChange: onChange as TabsContextValue["onChange"] }}>
+      <div
+        role="tablist"
+        {...rest}
+        className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+        style={{ ...sx.style, ...style }}
+      >
+        {items}
+      </div>
+    </TabsContext.Provider>
+  );
+};
+
+interface ItemProps extends Omit<HTMLAttributes<HTMLButtonElement>, "onChange"> {
+  value?: TabValue;
+  label?: ReactNode;
+  icon?: ReactNode;
+  iconPosition?: "start" | "end";
+  disabled?: boolean;
+  /** Injected by `Tabs.Root`; the positional fallback value. */
+  index?: number;
+}
+
+const Item = ({
+  value,
+  label,
+  icon,
+  iconPosition = "start",
+  disabled = false,
+  index = 0,
+  className,
+  style,
+  ...rest
+}: ItemProps) => {
+  const ctx = useContext(TabsContext);
+  const tabValue = value ?? index;
+  const active = ctx?.value === tabValue;
+  const sx = stylex.props(styles.item, active && styles.active, disabled && styles.disabled);
+  const iconEl = icon ? <span {...stylex.props(styles.icon)}>{icon}</span> : null;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      disabled={disabled}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+      onClick={(event) => ctx?.onChange(event, tabValue)}
+    >
+      {iconPosition === "start" && iconEl}
+      {label}
+      {iconPosition === "end" && iconEl}
+    </button>
+  );
+};
 
 export const Tabs = { Root, Item };


### PR DESCRIPTION
Replaces the MUI `Tabs`/`Tab` re-exports (`Hb.Tabs.Root` ×6, `.Item` ×11) with a StyleX compound.

## Component
- **`Tabs.Root`** — a flex tablist with a 1px bottom border; provides `value` + `onChange(event, value)` via context. **Generic over the value type** so a consumer's typed `setState` still type-checks; the `onChange` event is a `SyntheticEvent` (matches the `(_, v) => setTab(v)` call sites).
- **`Tabs.Item`** — a `<button role="tab">` with `label`/`icon`/`iconPosition`/`disabled`. The active item (value === Root's value, or its **positional index** when no explicit value — matching MUI) gets accent text + a 2px accent bottom border (the indicator).

## Consumers
- `sx` codemodded to `style` — this restores the `mb` bottom margin that was dropped in the mid-migration state (the reported "tab root needs marginBottom").
- Compact-tab `& .MuiTab-root` overrides → a scoped `<style href precedence>` on the Root (descendant selector). `textColor`/`indicatorColor` and `& .MuiTabs-indicator` dropped (the in-house accent/indicator match `"primary"`).

## Verification
- DS & app: **0 lint problems**, `tsc -b` **0 errors**, app **build passes**, **582 tests** green, Tabs **Storybook a11y passes** (checked locally pre-push).
- `Hb.Tabs` MUI-free; app has **0** direct `@mui` imports.

Remaining MUI components: 19.