### PR TITLE
feat: in-house Checkbox, drop MUI Checkbox

### DIFF
--- a/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
+++ b/apps/hobom-system/src/entities/note/ui/NoteCard.tsx
@@ -211,11 +211,7 @@ export const NoteCard = ({
                     size="small"
                     checked={item.checked}
                     disabled
-                    sx={{
-                      p: 0.25,
-                      color: "action.disabled",
-                      "&.Mui-checked": { color: "action.disabled" },
-                    }}
+                    style={{ accentColor: "var(--hb-color-text-disabled)" }}
                   />
                   <Hb.Text
                     variant="body2"

--- a/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
@@ -65,7 +65,9 @@ export const LabelPickerPopover = ({
                       size="small"
                       checked={selectedIds.has(label.id)}
                       disableRipple
-                      sx={{ p: 0.25 }}
+                      style={{
+                        padding: 2,
+                      }}
                     />
                   </Hb.List.ItemIcon>
                   <Hb.List.ItemText

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -110,7 +110,9 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
                   size="small"
                   checked={item.checked}
                   onChange={(e) => updateChecklistItem(idx, "checked", e.target.checked)}
-                  sx={{ p: 0.5 }}
+                  style={{
+                    padding: 4,
+                  }}
                 />
                 <Hb.InputBase
                   value={item.text}

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -218,7 +218,9 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
         <Hb.Text style={labelStyle}>{name}</Hb.Text>
         <Hb.Checkbox
           size="small"
-          sx={{ p: 0 }}
+          style={{
+            padding: 0,
+          }}
           checked={Boolean(value)}
           onChange={(event) => onChange(name, event.target.checked)}
         />

--- a/packages/hobom-design-system/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/hobom-design-system/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,22 @@
+import { Checkbox } from "./Checkbox";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Checkbox",
+  component: Checkbox,
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const States: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+      <Checkbox aria-label="unchecked" />
+      <Checkbox aria-label="checked" defaultChecked />
+      <Checkbox aria-label="small" size="small" defaultChecked />
+      <Checkbox aria-label="disabled" disabled defaultChecked />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/hobom-design-system/src/components/Checkbox/Checkbox.tsx
@@ -1,1 +1,55 @@
-export { Checkbox } from "@mui/material";
+import type { InputHTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+type CheckboxSize = "small" | "medium";
+
+interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
+  /** Box size. Defaults to `"medium"`. */
+  size?: CheckboxSize;
+  /** Pull toward the start/end edge. */
+  edge?: "start" | "end" | false;
+  /** No-op kept for API compatibility (a native checkbox has no ripple). */
+  disableRipple?: boolean;
+}
+
+const styles = stylex.create({
+  root: {
+    accentColor: "var(--hb-color-accent)",
+    cursor: "pointer",
+    margin: 0,
+    flexShrink: 0,
+  },
+  small: { width: 16, height: 16 },
+  medium: { width: 20, height: 20 },
+  disabled: { cursor: "default" },
+  edgeStart: { marginLeft: -2 },
+  edgeEnd: { marginRight: -2 },
+});
+
+export const Checkbox = ({
+  size = "medium",
+  edge = false,
+  disabled = false,
+  disableRipple: _disableRipple,
+  className,
+  style,
+  ...rest
+}: CheckboxProps) => {
+  const sx = stylex.props(
+    styles.root,
+    size === "small" ? styles.small : styles.medium,
+    edge === "start" && styles.edgeStart,
+    edge === "end" && styles.edgeEnd,
+    disabled && styles.disabled,
+  );
+
+  return (
+    <input
+      type="checkbox"
+      disabled={disabled}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    />
+  );
+};


### PR DESCRIPTION
Replaces the MUI `Checkbox` re-export (7 uses, all standalone) with a native `<input type="checkbox">` styled via **`accent-color`** (accent by default).

## Component
- `size` small/medium, `edge` start/end, full `checked`/`onChange`/`disabled`/`tabIndex` passthrough. `disableRipple` accepted as a no-op (a native checkbox has no ripple). Native input = correct semantics + a11y for free.

## Consumers
- `sx` codemodded to `style`; the disabled note-checklist box's `&.Mui-checked` color → `style={{ accentColor: "var(--hb-color-text-disabled)" }}`.

## Deferred
- **Radio** is coupled to the still-MUI `Form.ControlLabel` context (`control={<Radio.Root/>}` inside a `RadioGroup`), so it migrates together with **Form**.

## Verification
- DS & app: **0 lint problems**, `tsc -b` **0 errors**, app **build passes**, **582 tests** green, Checkbox **Storybook a11y passes** (checked locally pre-push).
- `Hb.Checkbox` MUI-free; app has **0** direct `@mui` imports.

Remaining MUI components: 18.