### PR TITLE
Replace Grid with in-house component

### DIFF
--- a/packages/hobom-design-system/src/components/Grid/Grid.stories.tsx
+++ b/packages/hobom-design-system/src/components/Grid/Grid.stories.tsx
@@ -1,0 +1,61 @@
+import { Grid } from "./Grid";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Grid",
+  component: Grid,
+} satisfies Meta<typeof Grid>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Cell = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      padding: 16,
+      backgroundColor: "var(--hb-color-border)",
+      borderRadius: 8,
+      textAlign: "center",
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const EqualColumns: Story = {
+  render: () => (
+    <Grid container spacing={2}>
+      {[1, 2, 3, 4].map((n) => (
+        <Grid key={n} size={3}>
+          <Cell>size 3</Cell>
+        </Grid>
+      ))}
+    </Grid>
+  ),
+};
+
+export const Responsive: Story = {
+  render: () => (
+    <Grid container spacing={2.5}>
+      {[1, 2, 3, 4].map((n) => (
+        <Grid key={n} size={{ xs: 12, sm: 6, md: 3 }}>
+          <Cell>xs 12 / sm 6 / md 3</Cell>
+        </Grid>
+      ))}
+    </Grid>
+  ),
+};
+
+export const Mixed: Story = {
+  render: () => (
+    <Grid container spacing={2}>
+      <Grid size={{ xs: 12, md: 8 }}>
+        <Cell>xs 12 / md 8</Cell>
+      </Grid>
+      <Grid size={{ xs: 12, md: 4 }}>
+        <Cell>xs 12 / md 4</Cell>
+      </Grid>
+    </Grid>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Grid/Grid.tsx
+++ b/packages/hobom-design-system/src/components/Grid/Grid.tsx
@@ -1,1 +1,119 @@
-export { Grid } from "@mui/material";
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+type Breakpoint = "xs" | "sm" | "md" | "lg" | "xl";
+
+type GridSize = number | Partial<Record<Breakpoint, number>>;
+
+interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  /** Lay children out as a flex row with gutters. */
+  container?: boolean;
+  /** Gutter between children, in theme spacing units (× 8px). */
+  spacing?: number;
+  /** Column span out of 12 — a number, or per-breakpoint values. */
+  size?: GridSize;
+  children?: ReactNode;
+}
+
+const COLUMNS = 12;
+const BREAKPOINT_ORDER: Breakpoint[] = ["xs", "sm", "md", "lg", "xl"];
+const BREAKPOINT_MIN: Record<Breakpoint, number> = {
+  xs: 0,
+  sm: 600,
+  md: 900,
+  lg: 1200,
+  xl: 1536,
+};
+
+const styles = stylex.create({
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+  },
+  item: {
+    flexGrow: 0,
+    boxSizing: "border-box",
+    minWidth: 0,
+    maxWidth: "100%",
+    // Width accounts for the container gutter so a row of spans summing to 12
+    // fits exactly. `--hb-grid-span` is set per breakpoint; `--hb-grid-gap`
+    // comes from the container.
+    flexBasis:
+      "calc(var(--hb-grid-span, 12) / 12 * 100% - (12 - var(--hb-grid-span, 12)) / 12 * var(--hb-grid-gap, 0px))",
+  },
+});
+
+interface ResponsiveSpan {
+  className: string;
+  css: string;
+}
+
+/** Build the per-breakpoint `--hb-grid-span` rules for a responsive `size`. */
+const responsiveSpan = (size: Partial<Record<Breakpoint, number>>): ResponsiveSpan => {
+  const entries = BREAKPOINT_ORDER.filter((bp) => size[bp] != null).map(
+    (bp) => [bp, size[bp] as number] as const,
+  );
+  const className = `hb-grid-${entries.map(([bp, v]) => `${bp}${v}`).join("-")}`;
+
+  let base = COLUMNS;
+  let media = "";
+
+  for (const [bp, v] of entries) {
+    if (BREAKPOINT_MIN[bp] === 0) {
+      base = v;
+    } else {
+      media += `@media (min-width:${BREAKPOINT_MIN[bp]}px){.${className}{--hb-grid-span:${v}}}`;
+    }
+  }
+
+  return { className, css: `.${className}{--hb-grid-span:${base}}${media}` };
+};
+
+export const Grid = ({
+  container = false,
+  spacing,
+  size,
+  className,
+  style,
+  children,
+  ...rest
+}: GridProps) => {
+  const dynamic: CSSProperties = {};
+  let spanClass: string | undefined;
+  let spanCss: string | undefined;
+
+  if (container && spacing != null) {
+    const gap = `${spacing * 8}px`;
+
+    dynamic.gap = gap;
+    (dynamic as Record<string, string>)["--hb-grid-gap"] = gap;
+  }
+
+  if (size != null) {
+    if (typeof size === "number") {
+      (dynamic as Record<string, string>)["--hb-grid-span"] = String(size);
+    } else {
+      const responsive = responsiveSpan(size);
+
+      spanClass = responsive.className;
+      spanCss = responsive.css;
+    }
+  }
+
+  const sx = stylex.props(container && styles.container, size != null && styles.item);
+
+  return (
+    <div
+      {...rest}
+      className={[sx.className, spanClass, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...dynamic, ...style }}
+    >
+      {spanCss && (
+        <style href={spanClass} precedence="medium">
+          {spanCss}
+        </style>
+      )}
+      {children}
+    </div>
+  );
+};


### PR DESCRIPTION
## What

Removes the `@mui/material` re-export for `Grid` and replaces it with a native flex-based implementation.

## How

- **Container** (`container` + `spacing`): `display:flex; flex-wrap:wrap; gap: spacing×8px`, and exposes the gutter as a `--hb-grid-gap` CSS variable.
- **Item** (`size`): computes a gutter-aware `flex-basis` — `calc(span/12·100% − (12−span)/12·gap)` — so spans summing to 12 fit exactly one row regardless of gutter.
- **Responsive** (`size={{ xs, sm, md, lg, xl }}`): emits `min-width` breakpoint rules through a React-hoisted, `href`-deduplicated `<style>` that toggles the item's `--hb-grid-span`. Identical size objects share a single stylesheet.

Breakpoints match the previous defaults: xs 0 / sm 600 / md 900 / lg 1200 / xl 1536.

## Consumers

The `container` / `spacing` / `size` API is unchanged — all 10 call sites (61 items) work without edits.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- Storybook a11y (Chromium) pass — equal-columns, responsive, mixed stories