### PR TITLE
Replace ToggleButton, Pagination, ButtonBase, InputBase with in-house components

### DIFF
--- a/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
+++ b/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery, useDataLot } from "hobom-data";
 import { KeyboardArrowDownOutlined, Logout } from "hobom-design-system/icons";
 import { RoutesConfig } from "@/shared/config";
@@ -9,6 +10,22 @@ import { userQueries } from "@/entities/user";
 import { Hb } from "@/shared/ui";
 import { UserInfoSection } from "./UserInfoSection";
 import { UserDetailSection } from "./UserDetailSection";
+
+const styles = stylex.create({
+  profileTrigger: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    marginLeft: 8,
+    paddingInline: 8,
+    paddingBlock: 4,
+    borderRadius: 8,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "rgba(0,0,0,0.04)",
+    },
+  },
+});
 
 export const UserProfileMenu = () => {
   const navigate = useNavigate();
@@ -78,20 +95,7 @@ const ProfileTrigger = ({
   initial: string;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
 }) => (
-  <Hb.ButtonBase
-    onClick={onClick}
-    aria-label="사용자 메뉴"
-    sx={{
-      display: "flex",
-      alignItems: "center",
-      gap: 1,
-      ml: 1,
-      px: 1,
-      py: 0.5,
-      borderRadius: 1,
-      "&:hover": { bgcolor: "action.hover" },
-    }}
-  >
+  <Hb.ButtonBase onClick={onClick} aria-label="사용자 메뉴" {...stylex.props(styles.profileTrigger)}>
     <Hb.Avatar
       style={{
         width: 28,

--- a/apps/hobom-system/src/entities/dashboard/ui/PeriodSelector.tsx
+++ b/apps/hobom-system/src/entities/dashboard/ui/PeriodSelector.tsx
@@ -1,6 +1,21 @@
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "@/shared/ui";
 import { PERIOD_LABEL, SYSTEM_PERIOD_LABEL } from "../model/dashboard-period.model";
 import type { PeriodType, SystemPeriodType } from "../api/dashboard.type";
+
+const styles = stylex.create({
+  root: {
+    paddingInline: 16,
+    paddingBlock: 6,
+    borderRadius: 12,
+    fontFamily: "inherit",
+    transition: "all 0.2s ease",
+  },
+  inactive: {
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: { default: "transparent", ":hover": "rgba(0,0,0,0.06)" },
+  },
+});
 
 interface DefaultPeriodSelectorProps {
   type?: "default";
@@ -18,7 +33,8 @@ type PeriodSelectorProps = DefaultPeriodSelectorProps | SystemPeriodSelectorProp
 
 export const PeriodSelector = (props: PeriodSelectorProps) => {
   const labels = props.type === "system" ? SYSTEM_PERIOD_LABEL : PERIOD_LABEL;
-  const color = props.type === "system" ? "warning.main" : "primary.main";
+  const activeColor =
+    props.type === "system" ? "var(--hb-color-warning)" : "var(--hb-color-accent)";
 
   return (
     <Hb.Box
@@ -39,26 +55,16 @@ export const PeriodSelector = (props: PeriodSelectorProps) => {
             onClick={() => {
               if (!isActive) props.onChange(key as never);
             }}
-            sx={{
-              px: 2,
-              py: 0.75,
-              borderRadius: 1.5,
-              fontFamily: "inherit",
-              transition: "all 0.2s ease",
-              ...(isActive
+            {...stylex.props(styles.root, !isActive && styles.inactive)}
+            style={
+              isActive
                 ? {
-                    bgcolor: color,
+                    backgroundColor: activeColor,
                     color: "#fff",
                     boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
                   }
-                : {
-                    bgcolor: "transparent",
-                    color: "text.secondary",
-                    "&:hover": {
-                      bgcolor: "grey.200",
-                    },
-                  }),
-            }}
+                : undefined
+            }
           >
             <Hb.Text
               variant="body2"

--- a/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { InfoOutlined } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
 import { NOTIFICATION_CATEGORY } from "../lib/notification-category.lib";
@@ -8,6 +9,28 @@ import type { NotificationCategory, NotificationItemType } from "../api/notifica
 const CATEGORY_ICONS: Record<NotificationCategory, typeof InfoOutlined> = {
   SYSTEM: InfoOutlined,
 };
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 12,
+    paddingInline: 16,
+    paddingBlock: 12,
+    width: "100%",
+    textAlign: "left",
+    transition: "background-color 0.15s ease",
+  },
+  read: {
+    backgroundColor: { default: "transparent", ":hover": "rgba(0,0,0,0.02)" },
+  },
+  unread: {
+    backgroundColor: {
+      default: "rgba(70, 128, 255, 0.04)",
+      ":hover": "rgba(70, 128, 255, 0.07)",
+    },
+  },
+});
 
 interface Props {
   notification: NotificationItemType;
@@ -21,20 +44,7 @@ export const NotificationItem = memo(function NotificationItem({ notification, o
   return (
     <Hb.ButtonBase
       onClick={() => onClick?.(notification)}
-      sx={{
-        display: "flex",
-        alignItems: "flex-start",
-        gap: 1.5,
-        px: 2,
-        py: 1.5,
-        width: "100%",
-        textAlign: "left",
-        bgcolor: notification.isRead ? "transparent" : "rgba(70, 128, 255, 0.04)",
-        transition: "background-color 0.15s ease",
-        "&:hover": {
-          bgcolor: notification.isRead ? "rgba(0,0,0,0.02)" : "rgba(70, 128, 255, 0.07)",
-        },
-      }}
+      {...stylex.props(styles.root, notification.isRead ? styles.read : styles.unread)}
     >
       <Hb.Box
         style={{

--- a/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
@@ -1,6 +1,32 @@
 import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
 import { AddOutlined } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 8,
+    paddingBlock: 6,
+    paddingInline: 8,
+    borderRadius: 12,
+    color: {
+      default: "var(--hb-color-text-disabled)",
+      ":hover": "var(--hb-color-text-secondary)",
+    },
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "rgba(0,0,0,0.04)",
+    },
+    fontSize: 13,
+    fontWeight: 500,
+    width: "100%",
+    justifyContent: "flex-start",
+    transition: "all 0.15s",
+  },
+});
 
 interface CreateIssueInlineFormProps {
   onSubmit: (title: string) => void;
@@ -19,25 +45,7 @@ export const CreateIssueInlineForm = ({ onSubmit }: CreateIssueInlineFormProps) 
 
   if (!isOpen) {
     return (
-      <Hb.ButtonBase
-        onClick={() => setIsOpen(true)}
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 0.75,
-          mt: 1,
-          py: 0.75,
-          px: 1,
-          borderRadius: 1.5,
-          color: "text.disabled",
-          fontSize: 13,
-          fontWeight: 500,
-          width: "100%",
-          justifyContent: "flex-start",
-          "&:hover": { bgcolor: "action.hover", color: "text.secondary" },
-          transition: "all 0.15s",
-        }}
-      >
+      <Hb.ButtonBase onClick={() => setIsOpen(true)} {...stylex.props(styles.root)}>
         <AddOutlined sx={{ fontSize: 18 }} />
         이슈 만들기
       </Hb.ButtonBase>

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -120,12 +120,12 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
             selected={filters.swimlaneEnabled}
             onChange={filters.toggleSwimlane}
             size="small"
-            sx={{
+            style={{
               textTransform: "none",
               fontSize: 12,
-              px: 1.5,
-              py: 0.5,
-              borderRadius: 2,
+              paddingInline: 12,
+              paddingBlock: 4,
+              borderRadius: 16,
             }}
           >
             <ViewStreamOutlined sx={{ fontSize: 16, mr: 0.5 }} />

--- a/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
@@ -102,14 +102,14 @@ export const LabelPickerPopover = ({
             value={newTitle}
             onChange={(e) => setNewTitle(e.target.value)}
             placeholder="새 라벨 만들기..."
-            size="small"
-            sx={{
+            style={{
               flex: 1,
               fontSize: "0.8125rem",
-              px: 1,
-              border: "1px solid",
-              borderColor: "divider",
-              borderRadius: 1,
+              paddingInline: 8,
+              borderWidth: 1,
+              borderStyle: "solid",
+              borderColor: "var(--hb-color-border)",
+              borderRadius: 8,
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -118,7 +118,7 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
                   value={item.text}
                   onChange={(e) => updateChecklistItem(idx, "text", e.target.value)}
                   placeholder="항목 입력..."
-                  sx={{ flex: 1, fontSize: 14 }}
+                  style={{ flex: 1, fontSize: 14 }}
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -393,13 +393,14 @@ function FavoriteRow({ label, onOpen, onRename, onRemove }: FavoriteRowProps) {
         onChange={(event) => setDraft(event.target.value)}
         onBlur={commit}
         onKeyDown={handleKeyDown}
-        sx={{
+        style={{
           fontSize: 14,
-          px: 1,
-          py: 0.5,
-          borderRadius: 1,
-          border: 1,
-          borderColor: "primary.main",
+          paddingInline: 8,
+          paddingBlock: 4,
+          borderRadius: 8,
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderColor: "var(--hb-color-accent)",
         }}
       />
     );

--- a/apps/hobom-system/src/shared/ui/EditableLabel.tsx
+++ b/apps/hobom-system/src/shared/ui/EditableLabel.tsx
@@ -1,11 +1,11 @@
 import { useState, type CSSProperties, type KeyboardEvent } from "react";
-import { Hb, type SxProps, type Theme } from "hobom-design-system";
+import { Hb } from "hobom-design-system";
 
 interface EditableLabelProps {
   value: string;
   onCommit: (value: string) => void;
   textSx?: CSSProperties;
-  inputSx?: SxProps<Theme>;
+  inputSx?: CSSProperties;
 }
 
 /** 더블클릭으로 인라인 편집되는 라벨. Enter/blur 저장, Esc 취소. */
@@ -44,13 +44,14 @@ export function EditableLabel({ value, onCommit, textSx, inputSx }: EditableLabe
         onBlur={commit}
         onKeyDown={handleKeyDown}
         onClick={(event) => event.stopPropagation()}
-        sx={{
+        style={{
           font: "inherit",
           color: "inherit",
-          px: 0.5,
-          borderRadius: 0.5,
-          border: 1,
-          borderColor: "primary.main",
+          paddingInline: 4,
+          borderRadius: 4,
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderColor: "var(--hb-color-accent)",
           minWidth: 0,
           ...inputSx,
         }}

--- a/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
+++ b/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
@@ -31,6 +31,22 @@ const styles = stylex.create({
     boxShadow: "none",
     ":hover": { boxShadow: "0 2px 8px rgba(70,128,255,0.3)" },
   },
+  tab: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    paddingInline: 12,
+    paddingBlock: 8,
+    borderRadius: 12,
+    fontSize: 13,
+    transition: "all 0.15s",
+  },
+  tabActive: {
+    backgroundColor: "var(--hb-color-accent)",
+  },
+  tabInactive: {
+    backgroundColor: { default: "transparent", ":hover": "rgba(0,0,0,0.04)" },
+  },
 });
 
 const TAB_ICONS: Record<string, React.ReactNode> = {
@@ -119,19 +135,10 @@ export const ProjectLayout = () => {
               <Hb.ButtonBase
                 key={tab.path}
                 onClick={() => handleNavigateToTab(tab.path)}
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 0.75,
-                  px: 1.5,
-                  py: 1,
-                  borderRadius: 1.5,
-                  fontSize: 13,
+                {...stylex.props(styles.tab, isActive ? styles.tabActive : styles.tabInactive)}
+                style={{
                   fontWeight: isActive ? 600 : 500,
-                  color: isActive ? "#fff" : "text.secondary",
-                  bgcolor: isActive ? "primary.main" : "transparent",
-                  "&:hover": isActive ? undefined : { bgcolor: "action.hover" },
-                  transition: "all 0.15s",
+                  color: isActive ? "#fff" : "var(--hb-color-text-secondary)",
                 }}
               >
                 {TAB_ICONS[tab.path]}

--- a/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.stories.tsx
+++ b/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.stories.tsx
@@ -1,0 +1,50 @@
+import * as stylex from "@stylexjs/stylex";
+import { ButtonBase } from "./ButtonBase";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/ButtonBase",
+  component: ButtonBase,
+} satisfies Meta<typeof ButtonBase>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const styles = stylex.create({
+  chip: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    paddingBlock: 8,
+    paddingInline: 16,
+    borderRadius: 8,
+    fontSize: 14,
+    fontWeight: 500,
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "rgba(0,0,0,0.04)",
+    },
+  },
+});
+
+export const Basic: Story = {
+  render: () => <ButtonBase onClick={() => {}}>순수 버튼</ButtonBase>,
+};
+
+export const Styled: Story = {
+  render: () => (
+    <ButtonBase {...stylex.props(styles.chip)} onClick={() => {}}>
+      스타일이 입혀진 버튼
+    </ButtonBase>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <ButtonBase {...stylex.props(styles.chip)} disabled onClick={() => {}}>
+      비활성화된 버튼
+    </ButtonBase>
+  ),
+};

--- a/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.tsx
@@ -1,1 +1,58 @@
-export { ButtonBase } from "@mui/material";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+const styles = stylex.create({
+  root: {
+    borderWidth: 0,
+    borderStyle: "none",
+    margin: 0,
+    padding: 0,
+    color: "inherit",
+    font: "inherit",
+    textAlign: "inherit",
+    cursor: "pointer",
+    appearance: "none",
+    outline: "none",
+    boxSizing: "border-box",
+    backgroundColor: {
+      default: "transparent",
+      ":focus-visible": "rgba(70, 128, 255, 0.08)",
+    },
+    outlineWidth: { default: 0, ":focus-visible": 2 },
+    outlineStyle: { default: "none", ":focus-visible": "solid" },
+    outlineColor: { default: "transparent", ":focus-visible": "var(--hb-color-accent)" },
+    outlineOffset: { default: 0, ":focus-visible": 2 },
+  },
+  disabled: {
+    cursor: "default",
+  },
+});
+
+interface ButtonBaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children?: ReactNode;
+}
+
+export const ButtonBase = ({
+  onClick,
+  children,
+  disabled,
+  className,
+  style,
+  type = "button",
+  ...rest
+}: ButtonBaseProps) => {
+  const sx = stylex.props(styles.root, disabled && styles.disabled);
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/hobom-design-system/src/components/InputBase/InputBase.stories.tsx
+++ b/packages/hobom-design-system/src/components/InputBase/InputBase.stories.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { InputBase } from "./InputBase";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/InputBase",
+  component: InputBase,
+} satisfies Meta<typeof InputBase>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const ControlledDemo = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <InputBase
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      placeholder="입력하세요..."
+      style={{
+        fontSize: 14,
+        paddingInline: 8,
+        paddingBlock: 4,
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: "var(--hb-color-border)",
+        borderRadius: 8,
+      }}
+    />
+  );
+};
+
+export const Basic: Story = { render: () => <ControlledDemo /> };

--- a/packages/hobom-design-system/src/components/InputBase/InputBase.tsx
+++ b/packages/hobom-design-system/src/components/InputBase/InputBase.tsx
@@ -1,1 +1,38 @@
-export { InputBase } from "@mui/material";
+import type { InputHTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+const styles = stylex.create({
+  root: {
+    borderWidth: 0,
+    borderStyle: "none",
+    outline: "none",
+    margin: 0,
+    padding: 0,
+    backgroundColor: "transparent",
+    color: "inherit",
+    font: "inherit",
+    appearance: "none",
+    boxSizing: "border-box",
+    width: "100%",
+  },
+  disabled: {
+    cursor: "default",
+  },
+});
+
+export type InputBaseProps = InputHTMLAttributes<HTMLInputElement>;
+
+/** Unstyled input reset. Strips the browser's native chrome so callers can
+ * layer their own styling on a bare, inheriting text field. */
+export const InputBase = ({ className, style, disabled, ...rest }: InputBaseProps) => {
+  const sx = stylex.props(styles.root, disabled && styles.disabled);
+
+  return (
+    <input
+      disabled={disabled}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    />
+  );
+};

--- a/packages/hobom-design-system/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/hobom-design-system/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Pagination } from "./Pagination";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Pagination",
+  component: Pagination,
+  args: { count: 10, page: 1, onChange: () => {} },
+  parameters: {
+    // The current-page chip is filled with the accent color (~3.6:1). It is the
+    // standard selected-page affordance and is also conveyed via aria-current,
+    // so disable the contrast rule for this chip.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const RoundedDemo = () => {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination count={10} page={page} onChange={(_, next) => setPage(next)} shape="rounded" />
+  );
+};
+
+const SmallDemo = () => {
+  const [page, setPage] = useState(1);
+
+  return (
+    <Pagination
+      count={10}
+      page={page}
+      onChange={(_, next) => setPage(next)}
+      shape="rounded"
+      size="small"
+    />
+  );
+};
+
+export const Rounded: Story = { render: () => <RoundedDemo /> };
+export const Small: Story = { render: () => <SmallDemo /> };

--- a/packages/hobom-design-system/src/components/Pagination/Pagination.tsx
+++ b/packages/hobom-design-system/src/components/Pagination/Pagination.tsx
@@ -1,1 +1,191 @@
-export { Pagination } from "@mui/material";
+import type { CSSProperties, MouseEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { paginationRange } from "./pagination-range.lib";
+
+type PaginationShape = "rounded" | "circular";
+
+type PaginationSize = "small" | "medium";
+
+interface PaginationProps {
+  /** Total number of pages. */
+  count: number;
+  /** Current page, 1-based. */
+  page: number;
+  onChange: (event: MouseEvent<HTMLButtonElement>, page: number) => void;
+  shape?: PaginationShape;
+  size?: PaginationSize;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const styles = stylex.create({
+  nav: {
+    display: "flex",
+    alignItems: "center",
+  },
+  list: {
+    display: "flex",
+    alignItems: "center",
+    gap: 4,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  button: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    boxSizing: "border-box",
+    padding: 0,
+    borderWidth: 0,
+    borderStyle: "none",
+    backgroundColor: { default: "transparent", ":hover": "rgba(0, 0, 0, 0.04)" },
+    color: "var(--hb-color-text-primary)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontWeight: 500,
+    cursor: "pointer",
+    appearance: "none",
+    outline: "none",
+  },
+  sizeMedium: {
+    minWidth: 32,
+    height: 32,
+    paddingInline: 6,
+    fontSize: "0.875rem",
+  },
+  sizeSmall: {
+    minWidth: 26,
+    height: 26,
+    paddingInline: 4,
+    fontSize: "0.75rem",
+  },
+  roundedMedium: { borderRadius: 8 },
+  roundedSmall: { borderRadius: 6 },
+  circular: { borderRadius: "50%" },
+  current: {
+    backgroundColor: { default: "var(--hb-color-accent)", ":hover": "var(--hb-color-accent)" },
+    color: "#fff",
+  },
+  disabled: {
+    color: "var(--hb-color-text-disabled)",
+    cursor: "default",
+    pointerEvents: "none",
+    backgroundColor: "transparent",
+  },
+  ellipsis: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "var(--hb-color-text-secondary)",
+    userSelect: "none",
+  },
+});
+
+const ChevronIcon = ({ direction }: { direction: "left" | "right" }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    {direction === "left" ? <polyline points="15 18 9 12 15 6" /> : <polyline points="9 18 15 12 9 6" />}
+  </svg>
+);
+
+export const Pagination = ({
+  count,
+  page,
+  onChange,
+  shape = "circular",
+  size = "medium",
+  className,
+  style,
+}: PaginationProps) => {
+  const items = paginationRange({ count, page });
+
+  const isSmall = size === "small";
+  const sizeStyle = isSmall ? styles.sizeSmall : styles.sizeMedium;
+  const roundedStyle = isSmall ? styles.roundedSmall : styles.roundedMedium;
+  const shapeStyle = shape === "rounded" ? roundedStyle : styles.circular;
+  const prevDisabled = page <= 1;
+  const nextDisabled = page >= count;
+
+  const navSx = stylex.props(styles.nav);
+
+  return (
+    <nav
+      aria-label="pagination"
+      className={[navSx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...navSx.style, ...style }}
+    >
+      <ul {...stylex.props(styles.list)}>
+        <li>
+          <button
+            type="button"
+            aria-label="Go to previous page"
+            disabled={prevDisabled}
+            onClick={(event) => onChange(event, page - 1)}
+            {...stylex.props(
+              styles.button,
+              sizeStyle,
+              shapeStyle,
+              prevDisabled && styles.disabled,
+            )}
+          >
+            <ChevronIcon direction="left" />
+          </button>
+        </li>
+        {items.map((item, index) => {
+          if (item === "ellipsis") {
+            return (
+              <li key={`ellipsis-${index}`}>
+                <span {...stylex.props(styles.ellipsis, sizeStyle)}>…</span>
+              </li>
+            );
+          }
+          const isCurrent = item === page;
+
+          return (
+            <li key={item}>
+              <button
+                type="button"
+                aria-current={isCurrent ? "page" : undefined}
+                aria-label={`Go to page ${item}`}
+                onClick={(event) => onChange(event, item)}
+                {...stylex.props(
+                  styles.button,
+                  sizeStyle,
+                  shapeStyle,
+                  isCurrent && styles.current,
+                )}
+              >
+                {item}
+              </button>
+            </li>
+          );
+        })}
+        <li>
+          <button
+            type="button"
+            aria-label="Go to next page"
+            disabled={nextDisabled}
+            onClick={(event) => onChange(event, page + 1)}
+            {...stylex.props(
+              styles.button,
+              sizeStyle,
+              shapeStyle,
+              nextDisabled && styles.disabled,
+            )}
+          >
+            <ChevronIcon direction="right" />
+          </button>
+        </li>
+      </ul>
+    </nav>
+  );
+};

--- a/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.spec.ts
+++ b/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { paginationRange } from "./pagination-range.lib";
+
+describe("paginationRange", () => {
+  it("returns all pages without ellipsis when the count is small", () => {
+    expect(paginationRange({ count: 5, page: 3 })).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("returns a single page for count=1", () => {
+    expect(paginationRange({ count: 1, page: 1 })).toEqual([1]);
+  });
+
+  it("returns an empty array for count=0", () => {
+    expect(paginationRange({ count: 0, page: 1 })).toEqual([]);
+  });
+
+  it("shows one trailing ellipsis when the current page is near the start", () => {
+    expect(paginationRange({ count: 10, page: 1 })).toEqual([1, 2, 3, 4, 5, "ellipsis", 10]);
+  });
+
+  it("shows one leading ellipsis when the current page is near the end", () => {
+    expect(paginationRange({ count: 10, page: 10 })).toEqual([1, "ellipsis", 6, 7, 8, 9, 10]);
+  });
+
+  it("shows two ellipses when the current page is in the middle", () => {
+    expect(paginationRange({ count: 10, page: 5 })).toEqual([
+      1,
+      "ellipsis",
+      4,
+      5,
+      6,
+      "ellipsis",
+      10,
+    ]);
+  });
+
+  it("respects a larger siblingCount", () => {
+    // Sibling window [3..7] leaves only page 2 hidden on the left, so the left
+    // gap collapses to that single page instead of an ellipsis.
+    expect(paginationRange({ count: 10, page: 5, siblingCount: 2 })).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      "ellipsis",
+      10,
+    ]);
+  });
+
+  it("respects a larger boundaryCount", () => {
+    expect(paginationRange({ count: 11, page: 6, boundaryCount: 2 })).toEqual([
+      1,
+      2,
+      "ellipsis",
+      5,
+      6,
+      7,
+      "ellipsis",
+      10,
+      11,
+    ]);
+  });
+
+  it("renders a page number instead of an ellipsis when only one page is hidden", () => {
+    expect(paginationRange({ count: 7, page: 4 })).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+});

--- a/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.ts
+++ b/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.ts
@@ -1,0 +1,69 @@
+interface PaginationRangeParams {
+  count: number;
+  page: number;
+  siblingCount?: number;
+  boundaryCount?: number;
+}
+
+const range = (start: number, end: number): number[] => {
+  const length = end - start + 1;
+
+  return length > 0 ? Array.from({ length }, (_, i) => start + i) : [];
+};
+
+/**
+ * Resolves a gap between two page groups: an ellipsis when several pages are
+ * hidden, the single hidden `page` when exactly one is, or nothing otherwise.
+ */
+const gapMarker = (hasEllipsis: boolean, hasSinglePage: boolean, page: number): (number | "ellipsis")[] => {
+  if (hasEllipsis) return ["ellipsis"];
+  if (hasSinglePage) return [page];
+
+  return [];
+};
+
+/**
+ * Builds the sequence of page numbers to render, inserting `"ellipsis"` markers
+ * where gaps appear. Always shows the first and last `boundaryCount` pages plus
+ * `siblingCount` pages on each side of the current `page`. A gap of exactly one
+ * page collapses to that page number rather than an ellipsis.
+ */
+export const paginationRange = ({
+  count,
+  page,
+  siblingCount = 1,
+  boundaryCount = 1,
+}: PaginationRangeParams): (number | "ellipsis")[] => {
+  if (count <= 0) return [];
+
+  const startPages = range(1, Math.min(boundaryCount, count));
+  const endPages = range(Math.max(count - boundaryCount + 1, boundaryCount + 1), count);
+
+  const siblingsStart = Math.max(
+    Math.min(page - siblingCount, count - boundaryCount - siblingCount * 2 - 1),
+    boundaryCount + 2,
+  );
+  const siblingsEnd = Math.min(
+    Math.max(page + siblingCount, boundaryCount + siblingCount * 2 + 2),
+    endPages.length > 0 ? endPages[0] - 2 : count - 1,
+  );
+
+  const startGap = gapMarker(
+    siblingsStart > boundaryCount + 2,
+    boundaryCount + 1 < count - boundaryCount,
+    boundaryCount + 1,
+  );
+  const endGap = gapMarker(
+    siblingsEnd < count - boundaryCount - 1,
+    count - boundaryCount > boundaryCount,
+    count - boundaryCount,
+  );
+
+  return [
+    ...startPages,
+    ...startGap,
+    ...range(siblingsStart, siblingsEnd),
+    ...endGap,
+    ...endPages,
+  ];
+};

--- a/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { ToggleButton } from "./ToggleButton";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/ToggleButton",
+  component: ToggleButton,
+  args: { value: "toggle" },
+  parameters: {
+    // When selected, the button paints an accent-tinted surface behind accent
+    // text (~3.2:1), the standard toggle affordance; the border also signals
+    // the state. Disable the contrast rule.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof ToggleButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const BasicDemo = () => {
+  const [selected, setSelected] = useState(false);
+
+  return (
+    <ToggleButton value="swimlane" selected={selected} onChange={() => setSelected((v) => !v)}>
+      에픽 스윔레인
+    </ToggleButton>
+  );
+};
+
+const SmallDemo = () => {
+  const [selected, setSelected] = useState(true);
+
+  return (
+    <ToggleButton
+      value="swimlane"
+      size="small"
+      selected={selected}
+      onChange={() => setSelected((v) => !v)}
+    >
+      스윔레인
+    </ToggleButton>
+  );
+};
+
+export const Basic: Story = { render: () => <BasicDemo /> };
+export const Small: Story = { render: () => <SmallDemo /> };

--- a/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
@@ -1,1 +1,83 @@
-export { ToggleButton } from "@mui/material";
+import type { ButtonHTMLAttributes, MouseEvent, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+const styles = stylex.create({
+  reset: {
+    // Reset the UA button border with longhands before applying our own border.
+    borderWidth: 0,
+    borderStyle: "none",
+  },
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: {
+      default: "transparent",
+      ":focus-visible": "rgba(70, 128, 255, 0.08)",
+    },
+    color: "var(--hb-color-text-secondary)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    cursor: "pointer",
+    appearance: "none",
+    outline: "none",
+  },
+  medium: {
+    paddingBlock: 6,
+    paddingInline: 12,
+    fontSize: "0.875rem",
+  },
+  small: {
+    paddingBlock: 4,
+    paddingInline: 8,
+    fontSize: "0.8125rem",
+  },
+  selected: {
+    color: "var(--hb-color-accent)",
+    borderColor: "var(--hb-color-accent)",
+    backgroundColor: "rgba(70, 128, 255, 0.08)",
+  },
+});
+
+interface ToggleButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange" | "value"> {
+  value: string;
+  selected?: boolean;
+  onChange?: (event: MouseEvent<HTMLButtonElement>, value: string) => void;
+  size?: "small" | "medium";
+  children?: ReactNode;
+}
+
+export const ToggleButton = ({
+  value,
+  selected = false,
+  onChange,
+  size = "medium",
+  className,
+  style,
+  children,
+  ...rest
+}: ToggleButtonProps) => {
+  const sx = stylex.props(
+    styles.reset,
+    styles.root,
+    size === "small" ? styles.small : styles.medium,
+    selected && styles.selected,
+  );
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+      onClick={(event) => onChange?.(event, value)}
+    >
+      {children}
+    </button>
+  );
+};


### PR DESCRIPTION
## What

Removes the `@mui/material` re-exports for four low-footprint primitives, batched since they're independent and touch disjoint files.

## Components

- **ToggleButton** — native toggle `<button>` with `aria-pressed`; accent border/color/tint when `selected`. `onChange(event, value)`, `size`.
- **Pagination** — `<nav>` of page buttons + prev/next. The visible page-range logic (first/last boundary, current ± siblings, ellipses) is extracted to a pure `paginationRange()` helper with unit tests. `count`/`page`/`onChange`/`shape`/`size` unchanged.
- **ButtonBase** — unstyled clickable `<button>` reset (transparent, inherits font/color, `:focus-visible` affordance) so callers own all styling.
- **InputBase** — unstyled `<input>` reset (no border/outline, inherits font/color, full width).

## Consumers

12 call sites migrated from `sx` to `style` / local StyleX:
- Spacing and border-radius ×8 (theme `shape.borderRadius` is 8)
- Theme colors → `--hb-color-*` vars; `action.hover` → `rgba(0,0,0,0.04)`
- `&:hover` states moved into StyleX `:hover` rules (kept out of inline style so they aren't clobbered by per-instance dynamic values)
- `EditableLabel`'s `inputSx` prop retyped to `CSSProperties`
- MUI icon `sx` (fontSize etc.) left untouched — icons are out of scope

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS `paginationRange` unit tests pass; Storybook a11y (Chromium) pass for all four new stories