### PR TITLE
Neutralize leftover accent tints

### DIFF
--- a/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
+++ b/apps/hobom-system/src/entities/notification/ui/NotificationItem.tsx
@@ -26,8 +26,8 @@ const styles = stylex.create({
   },
   unread: {
     backgroundColor: {
-      default: "rgba(70, 128, 255, 0.04)",
-      ":hover": "rgba(70, 128, 255, 0.07)",
+      default: "color-mix(in srgb, var(--hb-color-accent) 4%, transparent)",
+      ":hover": "color-mix(in srgb, var(--hb-color-accent) 7%, transparent)",
     },
   },
 });

--- a/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/SprintSection.tsx
@@ -32,7 +32,7 @@ const styles = stylex.create({
     paddingLeft: 12,
     paddingRight: 12,
     fontWeight: 600,
-    ":hover": { boxShadow: "0 2px 8px rgba(70,128,255,0.3)" },
+    ":hover": { boxShadow: "0 2px 8px rgba(0,0,0,0.18)" },
   },
 });
 
@@ -48,7 +48,7 @@ export const SprintSection = ({ sprint, issues }: { sprint: SprintType; issues: 
       style={{
         borderRadius: 20,
         overflow: "hidden",
-        borderColor: sprint.status === "ACTIVE" ? "#4680ff40" : "var(--hb-color-border)",
+        borderColor: sprint.status === "ACTIVE" ? "color-mix(in srgb, var(--hb-color-accent) 25%, transparent)" : "var(--hb-color-border)",
       }}
     >
       <Hb.Box

--- a/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
@@ -83,7 +83,7 @@ export const HeaderCell = ({
           transition: "background-color 0.15s",
         }}
         onPointerEnter={(e) => {
-          (e.currentTarget as HTMLDivElement).style.backgroundColor = "#4680ff";
+          (e.currentTarget as HTMLDivElement).style.backgroundColor = "var(--hb-color-accent)";
         }}
         onPointerLeave={(e) => {
           (e.currentTarget as HTMLDivElement).style.backgroundColor = "transparent";

--- a/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/ProjectSettings.tsx
@@ -43,7 +43,7 @@ export const ProjectSettings = ({ projectId }: ProjectSettingsProps) => {
           style={{
             width: 48,
             height: 48,
-            backgroundColor: "#4680ff",
+            backgroundColor: "var(--hb-color-accent)",
             fontSize: 20,
             fontWeight: 700,
           }}

--- a/apps/hobom-system/src/features/send-future-message/config/future-message-grid.config.ts
+++ b/apps/hobom-system/src/features/send-future-message/config/future-message-grid.config.ts
@@ -23,7 +23,7 @@ export const COLORS = {
   subtitleText: "#a0aec0",
   dateText: "#374151",
   rowNum: "#c9d3e0",
-  resizeHandle: "#4680ff",
+  resizeHandle: "#262626",
   headerBorder: "#e9ecef",
   pendingBg: "#fff3e0",
   pendingText: "#e65100",

--- a/apps/hobom-system/src/shared/model/useToast.ts
+++ b/apps/hobom-system/src/shared/model/useToast.ts
@@ -38,9 +38,9 @@ export const useToast = () => {
                   closeToast?.();
                 },
                 style: {
-                  background: "rgba(70,128,255,0.15)",
+                  background: "rgba(255,255,255,0.15)",
                   border: "none",
-                  color: "#6ea8fe",
+                  color: "#ffffff",
                   fontWeight: 600,
                   fontSize: 13,
                   cursor: "pointer",

--- a/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
+++ b/apps/hobom-system/src/widgets/project-layout/ui/ProjectLayout.tsx
@@ -29,7 +29,7 @@ const styles = stylex.create({
     fontWeight: 600,
     fontSize: 12,
     boxShadow: "none",
-    ":hover": { boxShadow: "0 2px 8px rgba(70,128,255,0.3)" },
+    ":hover": { boxShadow: "0 2px 8px rgba(0,0,0,0.18)" },
   },
   tab: {
     display: "flex",

--- a/apps/hobom-system/src/widgets/project-list-workspace/ui/ProjectListWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/project-list-workspace/ui/ProjectListWorkspace.tsx
@@ -10,7 +10,7 @@ const styles = stylex.create({
     textTransform: "none",
     fontWeight: 600,
     boxShadow: "none",
-    ":hover": { boxShadow: "0 2px 8px rgba(70,128,255,0.3)" },
+    ":hover": { boxShadow: "0 2px 8px rgba(0,0,0,0.18)" },
   },
 });
 

--- a/apps/hobom-system/src/widgets/wiki-space-list-workspace/ui/WikiSpaceListWorkspace.tsx
+++ b/apps/hobom-system/src/widgets/wiki-space-list-workspace/ui/WikiSpaceListWorkspace.tsx
@@ -18,7 +18,7 @@ const styles = stylex.create({
     textTransform: "none",
     fontWeight: 600,
     boxShadow: "none",
-    ":hover": { boxShadow: "0 2px 8px rgba(70,128,255,0.3)" },
+    ":hover": { boxShadow: "0 2px 8px rgba(0,0,0,0.18)" },
   },
 });
 

--- a/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.tsx
+++ b/packages/hobom-design-system/src/components/ButtonBase/ButtonBase.tsx
@@ -16,7 +16,7 @@ const styles = stylex.create({
     boxSizing: "border-box",
     backgroundColor: {
       default: "transparent",
-      ":focus-visible": "rgba(70, 128, 255, 0.08)",
+      ":focus-visible": "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
     },
     outlineWidth: { default: 0, ":focus-visible": 2 },
     outlineStyle: { default: "none", ":focus-visible": "solid" },

--- a/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
@@ -17,7 +17,7 @@ const styles = stylex.create({
     borderColor: "var(--hb-color-border)",
     backgroundColor: {
       default: "transparent",
-      ":focus-visible": "rgba(70, 128, 255, 0.08)",
+      ":focus-visible": "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
     },
     color: "var(--hb-color-text-secondary)",
     fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
@@ -38,7 +38,7 @@ const styles = stylex.create({
   selected: {
     color: "var(--hb-color-accent)",
     borderColor: "var(--hb-color-accent)",
-    backgroundColor: "rgba(70, 128, 255, 0.08)",
+    backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
   },
 });
 


### PR DESCRIPTION
## What

Replaces the remaining hardcoded blue (`#4680ff` / `rgba(70,128,255,…)`) accent affordances with the neutral accent token, so they follow the Astryx palette and flip with the color scheme.

## Neutralized (chrome / accent affordances)

- **ButtonBase / ToggleButton** — `:focus-visible` and `selected` tints → `color-mix(… var(--hb-color-accent) …)`
- **Card hover glows** — SprintSection, ProjectListWorkspace, ProjectLayout, WikiSpaceListWorkspace → neutral shadow
- **Active-sprint border** → accent tint
- **Unread-notification highlight** → accent tint
- **Column-resize handle** (issue table) → `var(--hb-color-accent)`
- **Project avatar** default background → `var(--hb-color-accent)`
- **Toast undo button** → neutral translucent white
- **Future-message grid resize handle** (config literal) → neutral

## Kept intentionally (categorical / data-viz)

Chart series colors, status/category color maps (`board.model`, `notification-category`, `backlog-constants`, `IssueRegistry`), and the avatar / label / project palettes keep their hues — these are data encodings, not chrome.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium) pass