### PR TITLE
Replace Menu with in-house component; decouple Select options

### DIFF
--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
@@ -111,9 +111,9 @@ const AddTodoDialog = ({
           onChange={(e) => setValue("cycle", e.target.value as CycleType)}
         >
           {CYCLE_OPTIONS.map((key) => (
-            <Hb.Menu.Item key={key} value={key}>
+            <Hb.Form.Option key={key} value={key}>
               {CYCLE_LABELS[key]}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.TextField>
       </Hb.Dialog.Content>

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
@@ -50,9 +50,9 @@ export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
           onChange={(e) => setEditCategory(e.target.value)}
         >
           {(categoriesData?.items ?? []).map((cat) => (
-            <Hb.Menu.Item key={cat.id} value={cat.id}>
+            <Hb.Form.Option key={cat.id} value={cat.id}>
               {cat.title}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.TextField>
       </Hb.Dialog.Content>

--- a/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
@@ -72,7 +72,7 @@ export const ParentIssueAutocomplete = ({
       const config = ISSUE_KIND_REGISTRY[option.type];
 
       return (
-        <Hb.Menu.Item
+        <Hb.Form.Option
           key={key}
           {...props}
           sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75 }}
@@ -100,7 +100,7 @@ export const ParentIssueAutocomplete = ({
           >
             {option.title}
           </Hb.Text>
-        </Hb.Menu.Item>
+        </Hb.Form.Option>
       );
     }}
     renderInput={(params) => <Hb.TextField {...params} label={label} placeholder={placeholder} />}

--- a/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
@@ -216,9 +216,7 @@ export const IssueRow = ({
         anchorEl={menuEl}
         open={Boolean(menuEl)}
         onClose={() => setMenuEl(null)}
-        slotProps={{
-          paper: { sx: { minWidth: 180, borderRadius: 2, boxShadow: 3 } },
-        }}
+        style={{ minWidth: 180, borderRadius: 16 }}
       >
         {canAddChild && (
           <Hb.Menu.Item
@@ -226,7 +224,7 @@ export const IssueRow = ({
               onCreateChildIssue(issue.id);
               setMenuEl(null);
             }}
-            sx={{ fontSize: 13, py: 0.8 }}
+            style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
             <Hb.List.ItemIcon sx={{ minWidth: 28 }}>
               <AddOutlined sx={{ fontSize: 16 }} />
@@ -239,7 +237,7 @@ export const IssueRow = ({
         )}
         {canAddChild && moveTargets.length > 0 && <Hb.Divider />}
         {moveTargets.length > 0 && (
-          <Hb.Menu.Item disabled sx={{ fontSize: 11, py: 0.5, minHeight: 0 }}>
+          <Hb.Menu.Item disabled style={{ fontSize: 11, paddingBlock: 4, minHeight: 0 }}>
             이동
           </Hb.Menu.Item>
         )}
@@ -247,7 +245,7 @@ export const IssueRow = ({
           <Hb.Menu.Item
             key={t.id ?? "backlog"}
             onClick={() => handleMove(t.id)}
-            sx={{ fontSize: 13, py: 0.8 }}
+            style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
             <Hb.List.ItemIcon sx={{ minWidth: 28 }}>
               {t.id ? (

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -75,9 +75,9 @@ export const CreateIssueDialog = ({
               onChange={(e) => fields.setKind(e.target.value as IssueKind)}
             >
               {Object.entries(ISSUE_KIND_LABEL).map(([k, label]) => (
-                <Hb.Menu.Item key={k} value={k}>
+                <Hb.Form.Option key={k} value={k}>
                   {label}
-                </Hb.Menu.Item>
+                </Hb.Form.Option>
               ))}
             </Hb.Form.Select>
           </Hb.Form.Control>
@@ -89,9 +89,9 @@ export const CreateIssueDialog = ({
               onChange={(e) => fields.setPriority(e.target.value as IssuePriority)}
             >
               {Object.entries(ISSUE_PRIORITY_LABEL).map(([k, label]) => (
-                <Hb.Menu.Item key={k} value={k}>
+                <Hb.Form.Option key={k} value={k}>
                   {label}
-                </Hb.Menu.Item>
+                </Hb.Form.Option>
               ))}
             </Hb.Form.Select>
           </Hb.Form.Control>
@@ -111,11 +111,11 @@ export const CreateIssueDialog = ({
                 displayEmpty
                 onChange={(e) => fields.setSprint(e.target.value)}
               >
-                <Hb.Menu.Item value="">없음</Hb.Menu.Item>
+                <Hb.Form.Option value="">없음</Hb.Form.Option>
                 {activeSprints.map((s: SprintType) => (
-                  <Hb.Menu.Item key={s.id} value={s.id}>
+                  <Hb.Form.Option key={s.id} value={s.id}>
                     {s.name}
-                  </Hb.Menu.Item>
+                  </Hb.Form.Option>
                 ))}
               </Hb.Form.Select>
             </Hb.Form.Control>

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
@@ -87,9 +87,9 @@ export const LogSearchSection = () => {
               onChange={(e) => handleFilterChange("serviceType", e.target.value)}
             >
               {SERVICE_OPTIONS.map((opt) => (
-                <Hb.Menu.Item key={opt.value} value={opt.value}>
+                <Hb.Form.Option key={opt.value} value={opt.value}>
                   {opt.label}
-                </Hb.Menu.Item>
+                </Hb.Form.Option>
               ))}
             </Hb.Form.Select>
           </Hb.Form.Control>
@@ -102,9 +102,9 @@ export const LogSearchSection = () => {
               onChange={(e) => handleFilterChange("httpMethod", e.target.value)}
             >
               {METHOD_OPTIONS.map((opt) => (
-                <Hb.Menu.Item key={opt.value} value={opt.value}>
+                <Hb.Form.Option key={opt.value} value={opt.value}>
                   {opt.label}
-                </Hb.Menu.Item>
+                </Hb.Form.Option>
               ))}
             </Hb.Form.Select>
           </Hb.Form.Control>

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
@@ -65,9 +65,9 @@ export const ErrorEventFilter = ({
           onChange={(e) => onFilterChange("errorType", e.target.value)}
         >
           {TYPE_OPTIONS.map((opt) => (
-            <Hb.Menu.Item key={opt.value} value={opt.value}>
+            <Hb.Form.Option key={opt.value} value={opt.value}>
               {opt.label}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.Form.Select>
       </Hb.Form.Control>

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -140,15 +140,13 @@ export const IssueDetailDialog = ({
         open={Boolean(actions.statusMenu.anchor)}
         onClose={actions.statusMenu.close}
         aria-label="상태 변경"
-        slotProps={{
-          paper: { sx: { minWidth: 140, borderRadius: 2, boxShadow: 3 } },
-        }}
+        style={{ minWidth: 140, borderRadius: 16 }}
       >
         {actions.statusMenu.anchor?.transitions.map((t) => (
           <Hb.Menu.Item
             key={t.to}
             onClick={() => actions.statusMenu.handleTransition(t)}
-            sx={{ fontSize: 13, py: 0.8 }}
+            style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
             <Hb.Box
               style={{
@@ -170,16 +168,14 @@ export const IssueDetailDialog = ({
         open={Boolean(actions.priorityMenu.anchor)}
         onClose={actions.priorityMenu.close}
         aria-label="우선순위 변경"
-        slotProps={{
-          paper: { sx: { minWidth: 140, borderRadius: 2, boxShadow: 3 } },
-        }}
+        style={{ minWidth: 140, borderRadius: 16 }}
       >
         {(Object.entries(ISSUE_PRIORITY_LABEL) as [IssuePriority, string][]).map(([key, label]) => (
           <Hb.Menu.Item
             key={key}
             selected={issue?.priority === key}
             onClick={() => actions.priorityMenu.handleChange(key)}
-            sx={{ fontSize: 13, py: 0.8 }}
+            style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
             <Hb.Box
               style={{
@@ -202,16 +198,14 @@ export const IssueDetailDialog = ({
         onClose={actions.assigneeMenu.close}
         aria-label="담당자 변경"
         role="listbox"
-        slotProps={{
-          paper: { sx: { minWidth: 160, borderRadius: 2, boxShadow: 3 } },
-        }}
+        style={{ minWidth: 160, borderRadius: 16 }}
       >
         <Hb.Menu.Item
           role="option"
           aria-selected={!issue?.assignee}
           selected={!issue?.assignee}
           onClick={() => actions.assigneeMenu.handleAssign(undefined)}
-          sx={{ fontSize: 13, py: 0.8 }}
+          style={{ fontSize: 13, paddingBlock: 6.4 }}
         >
           <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
             <PersonOffOutlined aria-hidden sx={{ fontSize: 18, color: "text.disabled" }} />
@@ -228,7 +222,7 @@ export const IssueDetailDialog = ({
               aria-selected={isSelected}
               selected={isSelected}
               onClick={() => actions.assigneeMenu.handleAssign(member.userId)}
-              sx={{ fontSize: 13, py: 0.8 }}
+              style={{ fontSize: 13, paddingBlock: 6.4 }}
             >
               <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
                 <Hb.Avatar

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
@@ -288,7 +288,7 @@ export const IssueMetaSection = () => {
             onChange={(e) => updateField({ sprint: e.target.value || undefined })}
             sx={{ fontSize: 13, "& .MuiSelect-select": { py: 0.75 } }}
           >
-            <Hb.Menu.Item value="" sx={{ fontSize: 13 }}>
+            <Hb.Form.Option value="" sx={{ fontSize: 13 }}>
               <Hb.Text
                 variant="body2"
                 style={{
@@ -298,11 +298,11 @@ export const IssueMetaSection = () => {
               >
                 없음
               </Hb.Text>
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
             {activeSprints.map((s) => (
-              <Hb.Menu.Item key={s.id} value={s.id} sx={{ fontSize: 13 }}>
+              <Hb.Form.Option key={s.id} value={s.id} sx={{ fontSize: 13 }}>
                 {s.name}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>

--- a/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
@@ -96,11 +96,11 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             displayEmpty
             onChange={(e) => setStatusFilter(e.target.value)}
           >
-            <Hb.Menu.Item value="">전체</Hb.Menu.Item>
+            <Hb.Form.Option value="">전체</Hb.Form.Option>
             {statuses.map((s) => (
-              <Hb.Menu.Item key={s.id} value={s.id}>
+              <Hb.Form.Option key={s.id} value={s.id}>
                 {s.name}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
@@ -112,11 +112,11 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             displayEmpty
             onChange={(e) => setPriorityFilter(e.target.value as IssuePriority | "")}
           >
-            <Hb.Menu.Item value="">전체</Hb.Menu.Item>
+            <Hb.Form.Option value="">전체</Hb.Form.Option>
             {Object.entries(ISSUE_PRIORITY_LABEL).map(([k, label]) => (
-              <Hb.Menu.Item key={k} value={k}>
+              <Hb.Form.Option key={k} value={k}>
                 {label}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
@@ -128,11 +128,11 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             displayEmpty
             onChange={(e) => setTypeFilter(e.target.value as IssueKind | "")}
           >
-            <Hb.Menu.Item value="">전체</Hb.Menu.Item>
+            <Hb.Form.Option value="">전체</Hb.Form.Option>
             {Object.entries(ISSUE_KIND_LABEL).map(([k, label]) => (
-              <Hb.Menu.Item key={k} value={k}>
+              <Hb.Form.Option key={k} value={k}>
                 {label}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
@@ -171,17 +171,13 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
         anchorEl={menuAnchor?.el}
         open={Boolean(menuAnchor)}
         onClose={closeMenu}
-        slotProps={{
-          paper: {
-            sx: { minWidth: 140, borderRadius: 2, boxShadow: 3 },
-          },
-        }}
+        style={{ minWidth: 140, borderRadius: 16 }}
       >
         {menuAnchor?.transitions.map((t) => (
           <Hb.Menu.Item
             key={t.to}
             onClick={() => handleTransition(t)}
-            sx={{ fontSize: 13, py: 0.8 }}
+            style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
             <Hb.Box
               style={{

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -106,11 +106,11 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
                 displayEmpty
                 onChange={(e) => filters.setEpicFilter(e.target.value || null)}
               >
-                <Hb.Menu.Item value="">전체</Hb.Menu.Item>
+                <Hb.Form.Option value="">전체</Hb.Form.Option>
                 {filters.epics.map((epic) => (
-                  <Hb.Menu.Item key={epic.id} value={epic.id}>
+                  <Hb.Form.Option key={epic.id} value={epic.id}>
                     {epic.issueKey} {epic.title}
-                  </Hb.Menu.Item>
+                  </Hb.Form.Option>
                 ))}
               </Hb.Form.Select>
             </Hb.Form.Control>

--- a/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
@@ -57,9 +57,9 @@ export const ReminderPickerPopover = ({ anchorEl, onClose, onSet }: ReminderPick
           sx={{ mt: 1 }}
         >
           {RECURRENCE_OPTIONS.map((opt) => (
-            <Hb.Menu.Item key={opt.value} value={opt.value}>
+            <Hb.Form.Option key={opt.value} value={opt.value}>
               {opt.label}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.Form.Select>
         <Hb.Box

--- a/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
@@ -52,9 +52,9 @@ export const ProjectDashboardContent = () => {
             onChange={(e) => setSelectedSprintId(e.target.value)}
           >
             {sprints.map((s) => (
-              <Hb.Menu.Item key={s.id} value={s.id}>
+              <Hb.Form.Option key={s.id} value={s.id}>
                 {s.name}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>

--- a/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
@@ -84,9 +84,9 @@ export const AddMemberDialog = ({
           <Hb.Form.Label>역할</Hb.Form.Label>
           <Hb.Form.Select value={role} label="역할" onChange={(e) => setRole(e.target.value)}>
             {Object.entries(ROLE_LABEL).map(([k, label]) => (
-              <Hb.Menu.Item key={k} value={k}>
+              <Hb.Form.Option key={k} value={k}>
                 {label}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
@@ -85,9 +85,9 @@ export const MenuRecommendationSpeedDial = () => {
             {...register("menuKind")}
           >
             {Bom.values(MenuKindModel).map((item) => (
-              <Hb.Menu.Item key={item} value={item}>
+              <Hb.Form.Option key={item} value={item}>
                 {MENU_KIND_LABEL[item] ?? item}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
           <Hb.Form.Select
@@ -97,9 +97,9 @@ export const MenuRecommendationSpeedDial = () => {
             {...register("timeOfMeal")}
           >
             {Bom.values(TimeOfMealModel).map((item) => (
-              <Hb.Menu.Item key={item} value={item}>
+              <Hb.Form.Option key={item} value={item}>
                 {TIME_LABEL[item] ?? item}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
           <Hb.Form.Select
@@ -109,9 +109,9 @@ export const MenuRecommendationSpeedDial = () => {
             {...register("foodType")}
           >
             {Bom.values(FoodTypeModel).map((item) => (
-              <Hb.Menu.Item key={item} value={item}>
+              <Hb.Form.Option key={item} value={item}>
                 {FOOD_TYPE_LABEL[item] ?? item}
-              </Hb.Menu.Item>
+              </Hb.Form.Option>
             ))}
           </Hb.Form.Select>
         </Hb.Box>

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
@@ -57,9 +57,9 @@ const Inner = ({ onNextStep }: Props) => {
           }}
         >
           {users.items.map((user) => (
-            <Hb.Menu.Item key={user.id} value={user.id}>
+            <Hb.Form.Option key={user.id} value={user.id}>
               {user.nickname}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.Form.Select>
         <Hb.Form.Helper>목록에서 선택해 주세요.</Hb.Form.Helper>

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryMenu.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryMenu.tsx
@@ -37,10 +37,10 @@ export const CategoryMenu = ({ categoryId, categoryTitle }: Props) => {
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={closeMenu}
-        slotProps={{ paper: { sx: { minWidth: 100 } } }}
+        style={{ minWidth: 100 }}
       >
         <Hb.Menu.Item onClick={openEdit}>수정</Hb.Menu.Item>
-        <Hb.Menu.Item sx={{ color: "error.main" }} onClick={handleDelete}>
+        <Hb.Menu.Item style={{ color: "var(--hb-color-danger)" }} onClick={handleDelete}>
           삭제
         </Hb.Menu.Item>
       </Hb.Menu.Root>

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -78,7 +78,7 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
           }}
         >
           {availableLabels.map((label) => (
-            <Hb.Menu.Item key={label.id} value={label.id}>
+            <Hb.Form.Option key={label.id} value={label.id}>
               <Hb.Box
                 style={{
                   width: 10,
@@ -89,7 +89,7 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
                 }}
               />
               {label.name}
-            </Hb.Menu.Item>
+            </Hb.Form.Option>
           ))}
         </Hb.TextField>
       )}

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/PageSelect.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/PageSelect.tsx
@@ -31,11 +31,11 @@ export const PageSelect = ({
       value={selectedPageId ?? "__root__"}
       onChange={(e) => onSelect(e.target.value === "__root__" ? null : e.target.value)}
     >
-      <Hb.Menu.Item value="__root__">최상위 (루트)</Hb.Menu.Item>
+      <Hb.Form.Option value="__root__">최상위 (루트)</Hb.Form.Option>
       {flatList.map((item) => (
-        <Hb.Menu.Item key={item.id} value={item.id}>
+        <Hb.Form.Option key={item.id} value={item.id}>
           {"─".repeat(item.depth)} {item.title}
-        </Hb.Menu.Item>
+        </Hb.Form.Option>
       ))}
     </Hb.TextField>
   );

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/SpaceSelect.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/SpaceSelect.tsx
@@ -20,9 +20,9 @@ export const SpaceSelect = ({ selectedSpaceKey, onSelect }: SpaceSelectProps) =>
       onChange={(e) => onSelect(e.target.value)}
     >
       {spaces.map((space) => (
-        <Hb.Menu.Item key={space.key} value={space.key}>
+        <Hb.Form.Option key={space.key} value={space.key}>
           {space.name}
-        </Hb.Menu.Item>
+        </Hb.Form.Option>
       ))}
     </Hb.TextField>
   );

--- a/packages/hobom-design-system/src/components/Form/Form.tsx
+++ b/packages/hobom-design-system/src/components/Form/Form.tsx
@@ -3,6 +3,7 @@ import {
   FormControlLabel as MuiFormControlLabel,
   FormHelperText as MuiFormHelperText,
   InputLabel as MuiInputLabel,
+  MenuItem as MuiMenuItem,
   Select as MuiSelect,
 } from "@mui/material";
 
@@ -11,5 +12,8 @@ const ControlLabel = MuiFormControlLabel;
 const Helper = MuiFormHelperText;
 const Label = MuiInputLabel;
 const Select = MuiSelect;
+// Option for `Select` — the underlying control clones these to read `value`
+// and drive selection, so it stays MUI until Select itself is in-house.
+const Option = MuiMenuItem;
 
-export const Form = { Control, ControlLabel, Helper, Label, Select };
+export const Form = { Control, ControlLabel, Helper, Label, Select, Option };

--- a/packages/hobom-design-system/src/components/Menu/Menu.stories.tsx
+++ b/packages/hobom-design-system/src/components/Menu/Menu.stories.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Menu } from "./Menu";
+import { Button } from "../Button/Button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Menu",
+  component: Menu.Root,
+  args: { open: false, anchorEl: null },
+  parameters: {
+    // The demo trigger is a filled accent button (~3.6:1), a known
+    // below-threshold pattern unrelated to Menu itself.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Menu.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Demo = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const close = () => setAnchorEl(null);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={(event) => setAnchorEl(event.currentTarget)}>Open menu</Button>
+      <Menu.Root open={!!anchorEl} anchorEl={anchorEl} onClose={close}>
+        <Menu.Item onClick={() => {}}>Edit</Menu.Item>
+        <Menu.Item onClick={() => {}}>Duplicate</Menu.Item>
+        <Menu.Item disabled onClick={() => {}}>
+          Archive
+        </Menu.Item>
+        <Menu.Item onClick={() => {}} style={{ color: "var(--hb-color-danger)" }}>
+          Delete
+        </Menu.Item>
+      </Menu.Root>
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/components/Menu/Menu.tsx
+++ b/packages/hobom-design-system/src/components/Menu/Menu.tsx
@@ -1,6 +1,187 @@
-import { Menu as MuiMenu, MenuItem as MuiMenuItem } from "@mui/material";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Popover } from "../Popover/Popover";
+import type { PopoverOrigin } from "../Popover/popover-position.lib";
 
-const Root = MuiMenu;
-const Item = MuiMenuItem;
+interface MenuContextValue {
+  onClose?: () => void;
+}
+
+const MenuContext = createContext<MenuContextValue | null>(null);
+
+const enabledItems = (list: HTMLUListElement | null): HTMLElement[] =>
+  list
+    ? Array.from(
+        list.querySelectorAll<HTMLElement>('[role="menuitem"]:not([aria-disabled="true"])'),
+      )
+    : [];
+
+const styles = stylex.create({
+  list: {
+    listStyle: "none",
+    margin: 0,
+    padding: "4px 0",
+    minWidth: 112,
+    outline: "none",
+  },
+  item: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    paddingBlock: 8,
+    paddingInline: 16,
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    lineHeight: 1.5,
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+    userSelect: "none",
+    whiteSpace: "nowrap",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "rgba(0, 0, 0, 0.04)",
+      ":focus-visible": "rgba(0, 0, 0, 0.04)",
+    },
+    outline: "none",
+  },
+  selected: {
+    backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
+  },
+  disabled: {
+    color: "var(--hb-color-text-disabled)",
+    cursor: "default",
+    pointerEvents: "none",
+  },
+});
+
+interface RootProps extends Omit<HTMLAttributes<HTMLUListElement>, "onChange"> {
+  open: boolean;
+  anchorEl: HTMLElement | null | undefined;
+  onClose?: () => void;
+  anchorOrigin?: PopoverOrigin;
+  transformOrigin?: PopoverOrigin;
+  children?: ReactNode;
+}
+
+const Root = ({
+  open,
+  anchorEl,
+  onClose,
+  anchorOrigin,
+  transformOrigin,
+  className,
+  style,
+  children,
+  ...rest
+}: RootProps) => {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Move focus to the first item once the menu is open (after the popover has
+  // mounted and focused its paper).
+  useEffect(() => {
+    if (!open) return;
+
+    enabledItems(listRef.current)[0]?.focus();
+  }, [open]);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    const items = enabledItems(listRef.current);
+
+    if (items.length === 0) return;
+    const current = items.indexOf(document.activeElement as HTMLElement);
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        items[(current + 1) % items.length]?.focus();
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        items[(current - 1 + items.length) % items.length]?.focus();
+        break;
+      case "Home":
+        event.preventDefault();
+        items[0]?.focus();
+        break;
+      case "End":
+        event.preventDefault();
+        items[items.length - 1]?.focus();
+        break;
+    }
+  };
+
+  return (
+    <MenuContext.Provider value={{ onClose }}>
+      <Popover
+        open={open}
+        anchorEl={anchorEl ?? null}
+        onClose={onClose}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+        className={className}
+        style={style}
+      >
+        <ul ref={listRef} role="menu" onKeyDown={onKeyDown} {...rest} {...stylex.props(styles.list)}>
+          {children}
+        </ul>
+      </Popover>
+    </MenuContext.Provider>
+  );
+};
+
+interface ItemProps extends Omit<HTMLAttributes<HTMLLIElement>, "onClick"> {
+  onClick?: (event: MouseEvent<HTMLLIElement>) => void;
+  disabled?: boolean;
+  selected?: boolean;
+  children?: ReactNode;
+}
+
+const Item = ({
+  onClick,
+  disabled = false,
+  selected = false,
+  className,
+  style,
+  children,
+  ...rest
+}: ItemProps) => {
+  const ctx = useContext(MenuContext);
+
+  const sx = stylex.props(styles.item, selected && styles.selected, disabled && styles.disabled);
+
+  return (
+    <li
+      role="menuitem"
+      tabIndex={-1}
+      aria-disabled={disabled || undefined}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+      onClick={(event) => {
+        if (disabled) return;
+        onClick?.(event);
+        ctx?.onClose?.();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          // Fire a real click so the onClick handler runs with a MouseEvent.
+          event.currentTarget.click();
+        }
+      }}
+    >
+      {children}
+    </li>
+  );
+};
 
 export const Menu = { Root, Item };


### PR DESCRIPTION
## What

`Hb.Menu.Item` was doing double duty — both as dropdown-menu items **and** as MUI `Select` options (MUI `Select` clones its children to read `value` and drive selection). An in-house `Menu.Item` would break inside `Select`, so this splits the two concerns and replaces the standalone menu with a native implementation built on the in-house Popover.

## How

- **`Form.Option`** (still MUI `MenuItem`, temporary until `Select` itself is in-house) is added for `Select`/`Autocomplete` options. The 16 option-only call sites are pointed at it.
- **In-house `Menu.Root` + `Menu.Item`** on top of the in-house Popover:
  - `role="menu"` list with Arrow/Home/End keyboard navigation, Enter/Space activation, first-item focus on open, and click / Escape / backdrop dismissal (items auto-close via context).
  - `Menu.Root` forwards `style` to the popover paper and passes through `aria-*` / `role` so a listbox-style menu (assignee picker) can override the menu defaults.
- The 5 standalone-menu call sites are migrated from `sx` / `slotProps` to `style` (spacing/radius ×8, theme colors → `--hb-color-*`).

## Not included

`Select` stays MUI for now (it needs MUI `MenuItem` options via `Form.Option`); it gets migrated with the rest of Form later.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS unit + Storybook a11y (Chromium): 108 pass