### PR TITLE
Replace Dialog with in-house component

### DIFF
--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
@@ -81,7 +81,9 @@ const AddTodoDialog = ({
 
   return (
     <Hb.Dialog.Root open={isOpen} onClose={handleClose} size="xs">
-      <Hb.Dialog.Title sx={{ pb: 1 }}>
+      <Hb.Dialog.Title style={{
+        paddingBottom: 8
+      }}>
         할 일 추가
         <Hb.Text
           variant="body2"
@@ -93,7 +95,7 @@ const AddTodoDialog = ({
           {item.categoryTitle}
         </Hb.Text>
       </Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ pt: "12px !important" }}>
+      <Hb.Dialog.Content style={{ paddingTop: 12 }}>
         <Hb.TextField
           fullWidth
           autoFocus
@@ -117,7 +119,12 @@ const AddTodoDialog = ({
           ))}
         </Hb.TextField>
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2, gap: 1 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16,
+        gap: 8
+      }}>
         <Hb.Button fullWidth variant="secondary" onClick={handleClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
@@ -31,8 +31,10 @@ export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
 
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="xs">
-      <Hb.Dialog.Title sx={{ pb: 1 }}>할 일 수정</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ pt: "12px !important" }}>
+      <Hb.Dialog.Title style={{
+        paddingBottom: 8
+      }}>할 일 수정</Hb.Dialog.Title>
+      <Hb.Dialog.Content style={{ paddingTop: 12 }}>
         <Hb.TextField
           fullWidth
           autoFocus
@@ -56,7 +58,12 @@ export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
           ))}
         </Hb.TextField>
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2, gap: 1 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16,
+        gap: 8
+      }}>
         <Hb.Button fullWidth variant="ghost" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
@@ -34,7 +34,11 @@ export const CreateSprintDialog = ({ open, onClose, projectId }: CreateSprintDia
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>스프린트 만들기</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Hb.Dialog.Content style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16
+      }}>
         <Hb.TextField
           label="스프린트 이름"
           value={name}
@@ -71,7 +75,11 @@ export const CreateSprintDialog = ({ open, onClose, projectId }: CreateSprintDia
           />
         </Hb.Box>
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16
+      }}>
         <Hb.Button variant="secondary" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -43,7 +43,11 @@ export const CreateIssueDialog = ({
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>{defaultParentId ? "하위 이슈 만들기" : "이슈 만들기"}</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Hb.Dialog.Content style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16
+      }}>
         <Hb.TextField
           label="제목"
           value={fields.title}
@@ -204,7 +208,11 @@ export const CreateIssueDialog = ({
           onChange={fields.setParentIssue}
         />
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16
+      }}>
         <Hb.Button variant="secondary" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqDetailDialog.tsx
@@ -106,10 +106,10 @@ export const DlqDetailDialog = ({
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="md">
       <Hb.Dialog.Title
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
+          justifyContent: "space-between"
         }}
       >
         <Hb.Text

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventDetailDialog.tsx
@@ -46,10 +46,10 @@ export const ErrorEventDetailDialog = ({ event, open, onClose }: ErrorEventDetai
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="md">
       <Hb.Dialog.Title
-        sx={{
+        style={{
           display: "flex",
           alignItems: "center",
-          justifyContent: "space-between",
+          justifyContent: "space-between"
         }}
       >
         <Hb.Box

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -44,7 +44,12 @@ export const IssueDetailDialog = ({
       <Hb.Dialog.Root open={open && !!issue} onClose={onClose} size="sm">
         {issue && contextValue && (
           <IssueDetailContext.Provider value={contextValue}>
-            <Hb.Dialog.Title sx={{ display: "flex", alignItems: "center", gap: 1, pr: 6 }}>
+            <Hb.Dialog.Title style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              paddingRight: 48
+            }}>
               <Hb.Chip
                 label={ISSUE_KIND_LABEL[issue.type]}
                 size="small"
@@ -78,7 +83,9 @@ export const IssueDetailDialog = ({
                 <CloseOutlined sx={{ fontSize: 18 }} />
               </Hb.Button.Icon>
             </Hb.Dialog.Title>
-            <Hb.Dialog.Content sx={{ pt: 0 }}>
+            <Hb.Dialog.Content style={{
+              paddingTop: 0
+            }}>
               <ErrorBoundary inline resetKey={issueId ?? ""}>
                 <Hb.Text
                   variant="h6"

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -65,15 +65,15 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
       open={open}
       onClose={handleSave}
       size="sm"
-      PaperProps={{
-        sx: {
-          backgroundColor:
-            form.color === NOTE_COLORS.DEFAULT ? "var(--hb-color-surface)" : form.color,
-          borderRadius: 2,
-        },
+      style={{
+        backgroundColor:
+          form.color === NOTE_COLORS.DEFAULT ? "var(--hb-color-surface)" : form.color,
+        borderRadius: 16,
       }}
     >
-      <Hb.Dialog.Content sx={{ pb: 1 }}>
+      <Hb.Dialog.Content style={{
+        paddingBottom: 8
+      }}>
         <Hb.TextField
           placeholder="제목"
           fullWidth
@@ -181,7 +181,12 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
           />
         )}
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 2, pb: 1.5, justifyContent: "space-between" }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 16,
+        paddingRight: 16,
+        paddingBottom: 12,
+        justifyContent: "space-between"
+      }}>
         <Hb.Box
           style={{
             display: "flex",

--- a/apps/hobom-system/src/features/project-list/ui/CreateProjectDialog.tsx
+++ b/apps/hobom-system/src/features/project-list/ui/CreateProjectDialog.tsx
@@ -35,7 +35,11 @@ export const CreateProjectDialog = ({ open, onClose }: CreateProjectDialogProps)
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
       <Hb.Dialog.Title>프로젝트 만들기</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Hb.Dialog.Content style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16
+      }}>
         <Hb.TextField
           label="프로젝트 키"
           placeholder="PROJ"
@@ -63,7 +67,11 @@ export const CreateProjectDialog = ({ open, onClose }: CreateProjectDialogProps)
           size="small"
         />
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16
+      }}>
         <Hb.Button variant="secondary" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
@@ -91,7 +91,11 @@ export const AddMemberDialog = ({
           </Hb.Form.Select>
         </Hb.Form.Control>
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16
+      }}>
         <Hb.Button variant="secondary" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/project-settings/ui/RemoveMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/RemoveMemberDialog.tsx
@@ -22,7 +22,11 @@ export const RemoveMemberDialog = ({
         <strong>"{memberName}"</strong> 님을 프로젝트에서 제거하시겠어요?
       </Hb.Text>
     </Hb.Dialog.Content>
-    <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+    <Hb.Dialog.Actions style={{
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingBottom: 16
+    }}>
       <Hb.Button variant="secondary" onClick={onClose}>
         취소
       </Hb.Button>

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageEditDialog.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageEditDialog.tsx
@@ -23,8 +23,10 @@ export const FutureMessageEditDialog = ({ message, open, onClose }: Props) => {
 
   return (
     <Hb.Dialog.Root open={open} onClose={onClose} size="sm">
-      <Hb.Dialog.Title sx={{ pb: 1 }}>메시지 수정</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ pt: "12px !important" }}>
+      <Hb.Dialog.Title style={{
+        paddingBottom: 8
+      }}>메시지 수정</Hb.Dialog.Title>
+      <Hb.Dialog.Content style={{ paddingTop: 12 }}>
         <Hb.TextField
           fullWidth
           autoFocus
@@ -44,7 +46,12 @@ export const FutureMessageEditDialog = ({ message, open, onClose }: Props) => {
           onChange={(e) => setContent(e.target.value)}
         />
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2, gap: 1 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16,
+        gap: 8
+      }}>
         <Hb.Button fullWidth variant="secondary" onClick={onClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryCreateDialog.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryCreateDialog.tsx
@@ -26,8 +26,10 @@ export const CategoryCreateDialog = ({ open, onClose }: Props) => {
 
   return (
     <Hb.Dialog.Root open={open} onClose={handleClose} size="xs">
-      <Hb.Dialog.Title sx={{ pb: 1 }}>카테고리 추가</Hb.Dialog.Title>
-      <Hb.Dialog.Content sx={{ pt: "12px !important" }}>
+      <Hb.Dialog.Title style={{
+        paddingBottom: 8
+      }}>카테고리 추가</Hb.Dialog.Title>
+      <Hb.Dialog.Content style={{ paddingTop: 12 }}>
         <Hb.TextField
           fullWidth
           autoFocus
@@ -43,7 +45,12 @@ export const CategoryCreateDialog = ({ open, onClose }: Props) => {
           }}
         />
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2, gap: 1 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16,
+        gap: 8
+      }}>
         <Hb.Button fullWidth variant="secondary" onClick={handleClose}>
           취소
         </Hb.Button>

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryMenu.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/CategoryMenu.tsx
@@ -45,8 +45,10 @@ export const CategoryMenu = ({ categoryId, categoryTitle }: Props) => {
         </Hb.Menu.Item>
       </Hb.Menu.Root>
       <Hb.Dialog.Root open={editOpen} onClose={() => setEditOpen(false)} size="xs">
-        <Hb.Dialog.Title sx={{ pb: 1 }}>카테고리 수정</Hb.Dialog.Title>
-        <Hb.Dialog.Content sx={{ pt: "12px !important" }}>
+        <Hb.Dialog.Title style={{
+          paddingBottom: 8
+        }}>카테고리 수정</Hb.Dialog.Title>
+        <Hb.Dialog.Content style={{ paddingTop: 12 }}>
           <Hb.TextField
             fullWidth
             autoFocus
@@ -62,7 +64,12 @@ export const CategoryMenu = ({ categoryId, categoryTitle }: Props) => {
             }}
           />
         </Hb.Dialog.Content>
-        <Hb.Dialog.Actions sx={{ px: 3, pb: 2, gap: 1 }}>
+        <Hb.Dialog.Actions style={{
+          paddingLeft: 24,
+          paddingRight: 24,
+          paddingBottom: 16,
+          gap: 8
+        }}>
           <Hb.Button fullWidth variant="secondary" onClick={() => setEditOpen(false)}>
             취소
           </Hb.Button>

--- a/apps/hobom-system/src/features/wiki-space-list/ui/DeleteSpaceDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-space-list/ui/DeleteSpaceDialog.tsx
@@ -57,7 +57,11 @@ export const DeleteSpaceDialog = ({
           autoFocus
         />
       </Hb.Dialog.Content>
-      <Hb.Dialog.Actions sx={{ px: 3, pb: 2 }}>
+      <Hb.Dialog.Actions style={{
+        paddingLeft: 24,
+        paddingRight: 24,
+        paddingBottom: 16
+      }}>
         <Hb.Button variant="secondary" onClick={handleClose}>
           취소
         </Hb.Button>

--- a/packages/hobom-design-system/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/hobom-design-system/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { Dialog } from "./Dialog";
+import { Button } from "../Button/Button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Dialog",
+  component: Dialog.Root,
+  args: { open: false },
+  parameters: {
+    // The demo triggers/actions are filled accent buttons (~3.6:1), a known
+    // below-threshold pattern unrelated to Dialog itself.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Dialog.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Dialog.Root open={open} onClose={() => setOpen(false)} size="xs">
+        <Dialog.Title>Delete item?</Dialog.Title>
+        <Dialog.Content>
+          <Dialog.ContentText>
+            This action cannot be undone. The item will be permanently removed.
+          </Dialog.ContentText>
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => setOpen(false)}>
+            Delete
+          </Button>
+        </Dialog.Actions>
+      </Dialog.Root>
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/hobom-design-system/src/components/Dialog/Dialog.tsx
@@ -1,25 +1,237 @@
 import {
-  Dialog as MuiDialog,
-  type DialogProps as MuiDialogProps,
-  DialogTitle as MuiDialogTitle,
-  DialogContent as MuiDialogContent,
-  DialogActions as MuiDialogActions,
-  DialogContentText as MuiDialogContentText,
-} from "@mui/material";
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import * as stylex from "@stylexjs/stylex";
 
 type DialogSize = "xs" | "sm" | "md" | "lg";
 
-interface DialogRootProps extends Omit<MuiDialogProps, "maxWidth" | "fullWidth"> {
+const MAX_WIDTH: Record<DialogSize, number> = { xs: 444, sm: 600, md: 900, lg: 1200 };
+
+const FOCUSABLE =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+const focusable = (root: HTMLElement | null): HTMLElement[] =>
+  root ? Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE)) : [];
+
+const fadeIn = stylex.keyframes({ from: { opacity: 0 }, to: { opacity: 1 } });
+const popIn = stylex.keyframes({
+  from: { opacity: 0, transform: "translateY(8px) scale(0.98)" },
+  to: { opacity: 1, transform: "translateY(0) scale(1)" },
+});
+
+const styles = stylex.create({
+  backdrop: {
+    position: "fixed",
+    inset: 0,
+    zIndex: 1300,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 32,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    animationName: fadeIn,
+    animationDuration: "0.2s",
+    animationTimingFunction: "ease",
+  },
+  paper: {
+    display: "flex",
+    flexDirection: "column",
+    boxSizing: "border-box",
+    width: "100%",
+    maxHeight: "100%",
+    overflow: "hidden",
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    borderRadius: 12,
+    boxShadow: "0 8px 32px rgba(0, 0, 0, 0.24)",
+    outline: "none",
+    animationName: popIn,
+    animationDuration: "0.2s",
+    animationTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+  },
+  title: {
+    margin: 0,
+    padding: "16px 24px",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "1.25rem",
+    fontWeight: 600,
+    lineHeight: 1.4,
+    flexShrink: 0,
+  },
+  content: {
+    padding: "12px 24px 20px",
+    overflowY: "auto",
+    flex: 1,
+  },
+  dividers: {
+    paddingBlock: 16,
+    borderTopWidth: 1,
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-color-border)",
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+  },
+  contentText: {
+    margin: 0,
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.875rem",
+    lineHeight: 1.5,
+  },
+  actions: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    gap: 8,
+    padding: "8px 16px",
+    flexShrink: 0,
+  },
+});
+
+interface RootProps {
+  open: boolean;
+  onClose?: () => void;
+  /** Caps the paper width. Defaults to `"sm"`. */
   size?: DialogSize;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
 }
 
-const Root = ({ size = "sm", ...props }: DialogRootProps) => (
-  <MuiDialog maxWidth={size} fullWidth {...props} />
-);
+const Root = ({ open, onClose, size = "sm", className, style, children }: RootProps) => {
+  const paperRef = useRef<HTMLDivElement>(null);
 
-const Title = MuiDialogTitle;
-const Content = MuiDialogContent;
-const Actions = MuiDialogActions;
-const ContentText = MuiDialogContentText;
+  useEffect(() => {
+    if (!open) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    (focusable(paperRef.current)[0] ?? paperRef.current)?.focus();
+
+    return () => previouslyFocused?.focus?.();
+  }, [open]);
+
+  if (!open) return null;
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      onClose?.();
+
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+    const items = focusable(paperRef.current);
+
+    if (items.length === 0) {
+      event.preventDefault();
+
+      return;
+    }
+
+    const first = items[0];
+    const last = items[items.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const sx = stylex.props(styles.paper);
+
+  return createPortal(
+    <div {...stylex.props(styles.backdrop)} onMouseDown={onClose}>
+      <div
+        ref={paperRef}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        onKeyDown={onKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+        className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+        style={{ ...sx.style, maxWidth: MAX_WIDTH[size], ...style }}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+const Title = ({ className, style, children, ...rest }: HTMLAttributes<HTMLHeadingElement>) => {
+  const sx = stylex.props(styles.title);
+
+  return (
+    <h2
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </h2>
+  );
+};
+
+interface ContentProps extends HTMLAttributes<HTMLDivElement> {
+  /** Add top and bottom rules to separate the content from title/actions. */
+  dividers?: boolean;
+}
+
+const Content = ({ dividers = false, className, style, children, ...rest }: ContentProps) => {
+  const sx = stylex.props(styles.content, dividers && styles.dividers);
+
+  return (
+    <div
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const ContentText = ({
+  className,
+  style,
+  children,
+  ...rest
+}: HTMLAttributes<HTMLParagraphElement>) => {
+  const sx = stylex.props(styles.contentText);
+
+  return (
+    <p
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </p>
+  );
+};
+
+const Actions = ({ className, style, children, ...rest }: HTMLAttributes<HTMLDivElement>) => {
+  const sx = stylex.props(styles.actions);
+
+  return (
+    <div
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </div>
+  );
+};
 
 export const Dialog = { Root, Title, Content, Actions, ContentText };


### PR DESCRIPTION
## What

Removes the `@mui/material` re-export for the `Dialog` compound and replaces it with a native modal.

## How

- **`Dialog.Root`** — portal to `document.body`, dimmed backdrop, **focus trap** (Tab/Shift+Tab cycle within the paper), Escape / backdrop-click dismissal, focus-restore on close. The paper is a scheme-aware surface capped by `size` (`xs` 444 / `sm` 600 / `md` 900 / `lg` 1200) and pops in via a StyleX keyframe. `role="dialog"` + `aria-modal`.
- **`Title` / `Content` / `Actions` / `ContentText`** — plain styled elements matching MUI's default paddings. `Content` gains a `dividers` prop (top/bottom rules).

## Consumers

24 files. The `open` / `onClose` / `size` API is unchanged; `sx` on `Title` / `Content` / `Actions` is codemodded to `style` (spacing/radius ×8, and the `pt: "12px !important"` MUI-adjacency workaround collapses to a plain `paddingTop`). One `PaperProps={{ sx }}` moved to `style`.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 111 pass