### PR TITLE
Replace List with in-house component

### DIFF
--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -145,14 +145,16 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
           </Hb.Stack>
         }
       >
+        <style href="hb-todo-reveal" precedence="medium">
+          {".hb-todo-reveal:hover .reaction-trigger{opacity:1}"}
+        </style>
         <Hb.List.ItemButton
-          sx={{
-            px: 2.5,
-            py: 0.75,
-            "&:hover .reaction-trigger": { opacity: 1 },
-          }}
+          className="hb-todo-reveal"
+          style={{ paddingInline: 20, paddingBlock: 6 }}
         >
-          <Hb.List.ItemIcon sx={{ minWidth: 36 }}>
+          <Hb.List.ItemIcon style={{
+            minWidth: 36
+          }}>
             <Hb.Checkbox
               edge="start"
               size="small"
@@ -186,15 +188,13 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                 )}
               </Hb.Box>
             }
-            slotProps={{
-              primary: {
-                sx: {
-                  fontSize: "0.925rem",
-                  textDecoration: isCompleteStatus(item.progress) ? "line-through" : "none",
-                  color: isCompleteStatus(item.progress) ? "text.disabled" : "text.primary",
-                  transition: "color 0.2s ease, text-decoration-color 0.2s ease",
-                },
-              },
+            primaryStyle={{
+              fontSize: "0.925rem",
+              textDecoration: isCompleteStatus(item.progress) ? "line-through" : "none",
+              color: isCompleteStatus(item.progress)
+                ? "var(--hb-color-text-disabled)"
+                : "var(--hb-color-text-primary)",
+              transition: "color 0.2s ease, text-decoration-color 0.2s ease",
             }}
           />
           {!item.reaction && (

--- a/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
@@ -45,14 +45,19 @@ export const MenuRecommendationListItem = memo(function MenuRecommendationListIt
 }) {
   return (
     <>
-      <Hb.List.Item secondaryAction={rightAddon} sx={{ py: 1.5, px: 2.5 }}>
+      <Hb.List.Item secondaryAction={rightAddon} style={{
+        paddingTop: 12,
+        paddingBottom: 12,
+        paddingLeft: 20,
+        paddingRight: 20
+      }}>
         <Hb.List.ItemText
           primary={item.name}
-          primaryTypographyProps={{
+          primaryStyle={{
             fontWeight: 600,
             fontSize: 14,
-            color: "text.primary",
-            mb: 0.75,
+            color: "var(--hb-color-text-primary)",
+            marginBottom: 6,
           }}
           secondary={
             <Hb.Box

--- a/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
+++ b/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
@@ -79,10 +79,18 @@ export const ProjectLabelPicker = ({
       >
         라벨
       </Hb.Text>
-      <Hb.List.Root dense disablePadding sx={{ maxHeight: 240, overflow: "auto" }}>
+      <Hb.List.Root dense disablePadding style={{
+        maxHeight: 240,
+        overflow: "auto"
+      }}>
         {labels.map((label) => (
-          <Hb.List.ItemButton key={label.id} onClick={() => onToggle(label.id)} sx={{ py: 0.5 }}>
-            <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
+          <Hb.List.ItemButton key={label.id} onClick={() => onToggle(label.id)} style={{
+            paddingTop: 4,
+            paddingBottom: 4
+          }}>
+            <Hb.List.ItemIcon style={{
+              minWidth: 32
+            }}>
               <Hb.Checkbox
                 size="small"
                 checked={selectedIds.has(label.id)}
@@ -102,10 +110,9 @@ export const ProjectLabelPicker = ({
             />
             <Hb.List.ItemText
               primary={label.name}
-              slotProps={{
-                primary: {
-                  sx: { fontSize: "0.8125rem", color: "text.primary" },
-                },
+              primaryStyle={{
+                fontSize: "0.8125rem",
+                color: "var(--hb-color-text-primary)",
               }}
             />
           </Hb.List.ItemButton>
@@ -215,7 +222,11 @@ export const ProjectLabelPicker = ({
           </Hb.Box>
         </Hb.Box>
       ) : (
-        <Hb.List.ItemButton onClick={() => setCreating(true)} sx={{ py: 1, gap: 1 }}>
+        <Hb.List.ItemButton onClick={() => setCreating(true)} style={{
+          paddingTop: 8,
+          paddingBottom: 8,
+          gap: 8
+        }}>
           <AddOutlined sx={{ fontSize: 16, color: "text.secondary" }} />
           <Hb.Text
             variant="body2"

--- a/apps/hobom-system/src/entities/wiki-space/ui/SpaceCard.tsx
+++ b/apps/hobom-system/src/entities/wiki-space/ui/SpaceCard.tsx
@@ -161,7 +161,9 @@ export const SpaceCard = ({ space, onClick, onEdit, onDelete }: SpaceCardProps) 
                   <Hb.List.ItemIcon>
                     <DeleteOutlined fontSize="small" color="error" />
                   </Hb.List.ItemIcon>
-                  <Hb.List.ItemText sx={{ color: "error.main" }}>삭제</Hb.List.ItemText>
+                  <Hb.List.ItemText style={{
+                    color: "var(--hb-color-danger)"
+                  }}>삭제</Hb.List.ItemText>
                 </Hb.Menu.Item>
               )}
             </Hb.Menu.Root>

--- a/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/IssueRow.tsx
@@ -226,12 +226,14 @@ export const IssueRow = ({
             }}
             style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
-            <Hb.List.ItemIcon sx={{ minWidth: 28 }}>
+            <Hb.List.ItemIcon style={{
+              minWidth: 28
+            }}>
               <AddOutlined sx={{ fontSize: 16 }} />
             </Hb.List.ItemIcon>
             <Hb.List.ItemText
               primary="하위 이슈 추가"
-              slotProps={{ primary: { sx: { fontSize: 13 } } }}
+              primaryStyle={{ fontSize: 13 }}
             />
           </Hb.Menu.Item>
         )}
@@ -247,14 +249,16 @@ export const IssueRow = ({
             onClick={() => handleMove(t.id)}
             style={{ fontSize: 13, paddingBlock: 6.4 }}
           >
-            <Hb.List.ItemIcon sx={{ minWidth: 28 }}>
+            <Hb.List.ItemIcon style={{
+              minWidth: 28
+            }}>
               {t.id ? (
                 <DriveFileMoveOutlined sx={{ fontSize: 16 }} />
               ) : (
                 <InboxOutlined sx={{ fontSize: 16 }} />
               )}
             </Hb.List.ItemIcon>
-            <Hb.List.ItemText primary={t.label} slotProps={{ primary: { sx: { fontSize: 13 } } }} />
+            <Hb.List.ItemText primary={t.label} primaryStyle={{ fontSize: 13 }} />
           </Hb.Menu.Item>
         ))}
       </Hb.Menu.Root>

--- a/apps/hobom-system/src/features/dashboard-message/ui/UpcomingMessageTimeline.tsx
+++ b/apps/hobom-system/src/features/dashboard-message/ui/UpcomingMessageTimeline.tsx
@@ -1,5 +1,16 @@
+import * as stylex from "@stylexjs/stylex";
 import { Schedule } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  item: {
+    paddingInline: 0,
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+    ":last-child": { borderBottomStyle: "none" },
+  },
+});
 
 interface UpcomingMessage {
   id: string;
@@ -48,21 +59,13 @@ export const UpcomingMessageTimeline = ({ data }: UpcomingMessageTimelineProps) 
             const dDay = getDDay(msg.scheduledAt);
 
             return (
-              <Hb.List.Item
-                key={msg.id}
-                sx={{
-                  px: 0,
-                  borderBottom: "1px solid",
-                  borderColor: "divider",
-                  "&:last-child": { borderBottom: "none" },
-                }}
-              >
+              <Hb.List.Item key={msg.id} {...stylex.props(styles.item)}>
                 <Schedule sx={{ color: "text.secondary", mr: 1.5, fontSize: 20 }} />
                 <Hb.List.ItemText
                   primary={msg.title}
                   secondary={msg.scheduledAt.slice(0, 10)}
-                  primaryTypographyProps={{ variant: "body2" }}
-                  secondaryTypographyProps={{ variant: "caption" }}
+                  primaryStyle={{ fontSize: "0.875rem" }}
+                  secondaryStyle={{ fontSize: "0.75rem" }}
                 />
                 <Hb.Chip
                   label={dDay === 0 ? "D-Day" : `D-${dDay}`}

--- a/apps/hobom-system/src/features/dashboard-notification/ui/UnreadAlertList.tsx
+++ b/apps/hobom-system/src/features/dashboard-notification/ui/UnreadAlertList.tsx
@@ -1,5 +1,16 @@
+import * as stylex from "@stylexjs/stylex";
 import { NotificationsActive } from "hobom-design-system/icons";
 import { Hb } from "@/shared/ui";
+
+const styles = stylex.create({
+  item: {
+    paddingInline: 0,
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+    ":last-child": { borderBottomStyle: "none" },
+  },
+});
 
 interface UnreadItem {
   id: string;
@@ -39,21 +50,13 @@ export const UnreadAlertList = ({ data }: UnreadAlertListProps) => {
       ) : (
         <Hb.List.Root disablePadding>
           {data.slice(0, 5).map((item) => (
-            <Hb.List.Item
-              key={item.id}
-              sx={{
-                px: 0,
-                borderBottom: "1px solid",
-                borderColor: "divider",
-                "&:last-child": { borderBottom: "none" },
-              }}
-            >
+            <Hb.List.Item key={item.id} {...stylex.props(styles.item)}>
               <NotificationsActive sx={{ color: "warning.main", mr: 1.5, fontSize: 20 }} />
               <Hb.List.ItemText
                 primary={item.title}
                 secondary={item.createdAt.slice(0, 10)}
-                primaryTypographyProps={{ variant: "body2" }}
-                secondaryTypographyProps={{ variant: "caption" }}
+                primaryStyle={{ fontSize: "0.875rem" }}
+                secondaryStyle={{ fontSize: "0.75rem" }}
               />
               <Hb.Chip label={item.category} size="small" variant="outlined" />
             </Hb.List.Item>

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueDetailDialog.tsx
@@ -214,10 +214,12 @@ export const IssueDetailDialog = ({
           onClick={() => actions.assigneeMenu.handleAssign(undefined)}
           style={{ fontSize: 13, paddingBlock: 6.4 }}
         >
-          <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
+          <Hb.List.ItemIcon style={{
+            minWidth: 32
+          }}>
             <PersonOffOutlined aria-hidden sx={{ fontSize: 18, color: "text.disabled" }} />
           </Hb.List.ItemIcon>
-          <Hb.List.ItemText primary="미할당" slotProps={{ primary: { sx: { fontSize: 13 } } }} />
+          <Hb.List.ItemText primary="미할당" primaryStyle={{ fontSize: 13 }} />
         </Hb.Menu.Item>
         {state.projectMembers.map((member) => {
           const isSelected = issue?.assignee === member.userId;
@@ -231,7 +233,9 @@ export const IssueDetailDialog = ({
               onClick={() => actions.assigneeMenu.handleAssign(member.userId)}
               style={{ fontSize: 13, paddingBlock: 6.4 }}
             >
-              <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
+              <Hb.List.ItemIcon style={{
+                minWidth: 32
+              }}>
                 <Hb.Avatar
                   alt={member.nickname}
                   style={{
@@ -248,7 +252,7 @@ export const IssueDetailDialog = ({
               </Hb.List.ItemIcon>
               <Hb.List.ItemText
                 primary={member.nickname}
-                slotProps={{ primary: { sx: { fontSize: 13 } } }}
+                primaryStyle={{ fontSize: 13 }}
               />
             </Hb.Menu.Item>
           );

--- a/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/LabelPickerPopover.tsx
@@ -56,11 +56,19 @@ export const LabelPickerPopover = ({
         </Hb.Text>
 
         {labels.length > 0 && (
-          <Hb.List.Root dense disablePadding sx={{ maxHeight: 200, overflow: "auto" }}>
+          <Hb.List.Root dense disablePadding style={{
+            maxHeight: 200,
+            overflow: "auto"
+          }}>
             {labels.map((label) => (
               <Hb.List.Item key={label.id} disablePadding>
-                <Hb.List.ItemButton onClick={() => onToggle(label.id)} dense sx={{ py: 0.25 }}>
-                  <Hb.List.ItemIcon sx={{ minWidth: 32 }}>
+                <Hb.List.ItemButton onClick={() => onToggle(label.id)} dense style={{
+                  paddingTop: 2,
+                  paddingBottom: 2
+                }}>
+                  <Hb.List.ItemIcon style={{
+                    minWidth: 32
+                  }}>
                     <Hb.Checkbox
                       size="small"
                       checked={selectedIds.has(label.id)}
@@ -72,12 +80,10 @@ export const LabelPickerPopover = ({
                   </Hb.List.ItemIcon>
                   <Hb.List.ItemText
                     primary={label.title}
-                    slotProps={{
-                      primary: {
-                        title: label.title,
-                        fontSize: "0.8125rem",
-                        color: "secondary",
-                      },
+                    title={label.title}
+                    primaryStyle={{
+                      fontSize: "0.8125rem",
+                      color: "var(--hb-color-text-secondary)",
                     }}
                   />
                 </Hb.List.ItemButton>

--- a/apps/hobom-system/src/features/note/ui/MemberPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/MemberPickerPopover.tsx
@@ -50,7 +50,10 @@ export const MemberPickerPopover = ({
         </Hb.Text>
 
         {members.length > 0 ? (
-          <Hb.List.Root dense disablePadding sx={{ maxHeight: 200, overflow: "auto" }}>
+          <Hb.List.Root dense disablePadding style={{
+            maxHeight: 200,
+            overflow: "auto"
+          }}>
             {members.map((user) => (
               <Hb.List.Item
                 key={user.id}
@@ -66,9 +69,14 @@ export const MemberPickerPopover = ({
                     </Hb.Button.Icon>
                   ) : null
                 }
-                sx={{ py: 0.5 }}
+                style={{
+                  paddingTop: 4,
+                  paddingBottom: 4
+                }}
               >
-                <Hb.List.ItemAvatar sx={{ minWidth: 36 }}>
+                <Hb.List.ItemAvatar style={{
+                  minWidth: 36
+                }}>
                   <Hb.Avatar
                     style={{
                       width: 28,
@@ -84,9 +92,7 @@ export const MemberPickerPopover = ({
                 </Hb.List.ItemAvatar>
                 <Hb.List.ItemText
                   primary={user.nickname}
-                  slotProps={{
-                    primary: { fontSize: "0.8125rem", fontWeight: 500 },
-                  }}
+                  primaryStyle={{ fontSize: "0.8125rem", fontWeight: 500 }}
                 />
               </Hb.List.Item>
             ))}

--- a/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/StudyMaterialContent.tsx
@@ -51,7 +51,9 @@ export const StudyMaterialContent = ({ materialId }: Props) => {
       <Hb.List.Root disablePadding>
         {material.keyPoints.map((point, i) => (
           <Hb.List.Item key={i} disableGutters>
-            <Hb.List.ItemIcon sx={{ minWidth: 36 }}>
+            <Hb.List.ItemIcon style={{
+              minWidth: 36
+            }}>
               <Hb.Chip label={i + 1} size="small" color="primary" />
             </Hb.List.ItemIcon>
             <Hb.List.ItemText>

--- a/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
+++ b/apps/hobom-system/src/features/view-todos-by-category/ui/DailyTodoListContentSection.tsx
@@ -75,24 +75,29 @@ export const DailyTodoListContentSection = ({ groupedTodos, renderItem }: Props)
             <Hb.List.Root
               key={item.categoryId}
               disablePadding
-              sx={{ width: "100%", mb: 1 }}
+              style={{
+                width: "100%",
+                marginBottom: 8
+              }}
               subheader={
                 <Hb.List.Subheader
                   disableSticky
                   disableGutters
                   component="div"
-                  sx={{
-                    px: 2.5,
-                    py: 1,
+                  style={{
+                    paddingLeft: 20,
+                    paddingRight: 20,
+                    paddingTop: 8,
+                    paddingBottom: 8,
                     display: "flex",
                     alignItems: "center",
-                    gap: 1,
+                    gap: 8,
                     fontSize: "0.8rem",
                     fontWeight: 600,
-                    color: "text.secondary",
-                    bgcolor: "transparent",
+                    color: "var(--hb-color-text-secondary)",
+                    backgroundColor: "transparent",
                     borderBottom: "1px solid",
-                    borderColor: "divider",
+                    borderColor: "var(--hb-color-border)"
                   }}
                 >
                   {item.categoryTitle}

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/LabelList.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/LabelList.tsx
@@ -53,7 +53,10 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
           {labels.map((label) => (
             <Hb.List.Item
               key={label.id}
-              sx={{ px: 2 }}
+              style={{
+                paddingLeft: 16,
+                paddingRight: 16
+              }}
               secondaryAction={
                 <Hb.Box
                   style={{
@@ -95,9 +98,7 @@ export const LabelList = ({ spaceKey }: LabelListProps) => {
               />
               <Hb.List.ItemText
                 primary={label.name}
-                slotProps={{
-                  primary: { sx: { fontSize: "0.875rem", fontWeight: 500 } },
-                }}
+                primaryStyle={{ fontSize: "0.875rem", fontWeight: 500 }}
               />
             </Hb.List.Item>
           ))}

--- a/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-trash/ui/TrashPageList.tsx
@@ -44,10 +44,11 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
         {pages.map((page) => (
           <Hb.List.Item
             key={page.id}
-            sx={{
-              px: 2,
+            style={{
+              paddingLeft: 16,
+              paddingRight: 16,
               borderBottom: "1px solid",
-              borderColor: "divider",
+              borderColor: "var(--hb-color-border)"
             }}
             secondaryAction={
               <Hb.Box
@@ -89,10 +90,14 @@ export const TrashPageList = ({ spaceKey }: TrashPageListProps) => {
                   ? `삭제: ${new Date(page.deletedAt).toLocaleString("ko-KR")}`
                   : undefined
               }
-              slotProps={{
-                primary: { noWrap: true, sx: { fontSize: "0.875rem", fontWeight: 500 } },
-                secondary: { sx: { fontSize: "0.75rem" } },
+              primaryStyle={{
+                fontSize: "0.875rem",
+                fontWeight: 500,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
               }}
+              secondaryStyle={{ fontSize: "0.75rem" }}
             />
           </Hb.List.Item>
         ))}

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/PageTreeNode.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/PageTreeNode.tsx
@@ -28,28 +28,20 @@ export const PageTreeNode = ({
 
   return (
     <Fragment>
+      <style href="hb-tree-node" precedence="medium">
+        {".hb-tree-node:hover .tree-node-add{opacity:1}"}
+      </style>
       <Hb.List.ItemButton
-        selected={isActive}
+        className="hb-tree-node"
         onClick={() => onSelect(node.id)}
-        sx={{
-          pl: 1 + depth * 2,
-          py: 0.75,
-          borderRadius: 1,
-          mb: 0.25,
+        style={{
+          paddingLeft: (1 + depth * 2) * 8,
+          paddingBlock: 6,
+          marginBottom: 2,
           minHeight: 36,
-          color: "text.primary",
-          "&:hover": {
-            bgcolor: "action.hover",
-            color: "text.primary",
-            "& .tree-node-add": { opacity: 1 },
-          },
-          "&.Mui-selected": {
-            bgcolor: "primary.main",
-            color: "#fff",
-            "& .MuiListItemIcon-root": { color: "#fff" },
-            "& .tree-node-add": { color: "rgba(255,255,255,0.7)" },
-            "&:hover": { bgcolor: "primary.dark", color: "#fff" },
-          },
+          ...(isActive
+            ? { backgroundColor: "var(--hb-color-accent)", color: "#fff" }
+            : { color: "var(--hb-color-text-primary)" }),
         }}
       >
         {hasChildren ? (
@@ -80,19 +72,21 @@ export const PageTreeNode = ({
             }}
           />
         )}
-        <Hb.List.ItemIcon sx={{ minWidth: 24, color: "inherit" }}>
+        <Hb.List.ItemIcon style={{
+          minWidth: 24,
+          color: isActive ? "#fff" : "inherit"
+        }}>
           <ArticleOutlined sx={{ fontSize: 16 }} />
         </Hb.List.ItemIcon>
         <Hb.List.ItemText
           primary={node.title}
-          slotProps={{
-            primary: {
-              noWrap: true,
-              sx: {
-                fontSize: "0.8125rem",
-                fontWeight: isActive ? 600 : 400,
-              },
-            },
+          primaryStyle={{
+            fontSize: "0.8125rem",
+            fontWeight: isActive ? 600 : 400,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            color: isActive ? "#fff" : undefined,
           }}
         />
         <Hb.Tooltip title="하위 페이지 추가">
@@ -108,7 +102,7 @@ export const PageTreeNode = ({
               padding: 2,
               opacity: 0,
               transition: "opacity 0.15s ease",
-              color: "var(--hb-color-text-disabled)",
+              color: isActive ? "rgba(255,255,255,0.7)" : "var(--hb-color-text-disabled)",
             }}
           >
             <AddOutlined sx={{ fontSize: 15 }} />

--- a/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
+++ b/apps/hobom-system/src/features/wiki-page-versions/ui/VersionList.tsx
@@ -54,7 +54,10 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
           버전 목록 ({totalCount})
         </Hb.Text>
       </Hb.Box>
-      <Hb.List.Root dense disablePadding sx={{ maxHeight: "40vh", overflow: "auto" }}>
+      <Hb.List.Root dense disablePadding style={{
+        maxHeight: "40vh",
+        overflow: "auto"
+      }}>
         {versions.map((version) => {
           const isSelected = selectedVersion?.id === version.id;
           const author = version.editedBy ?? "익명";
@@ -62,36 +65,26 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
           return (
             <Hb.List.ItemButton
               key={version.id}
-              selected={isSelected}
               onClick={() => setSelectedVersion(version)}
-              sx={{
-                mx: 1,
-                borderRadius: 1,
-                mb: 0.5,
-                color: "text.primary",
-                "&.Mui-selected": {
-                  bgcolor: "primary.main",
-                  color: "#fff",
-                  "& .MuiListItemAvatar-root .MuiAvatar-root": {
-                    bgcolor: "rgba(255,255,255,0.2)",
-                  },
-                  "& .MuiListItemText-secondary": {
-                    color: "rgba(255,255,255,0.7)",
-                  },
-                  "&:hover": { bgcolor: "primary.dark" },
-                },
-                "&:hover:not(.Mui-selected)": { bgcolor: "action.hover" },
+              style={{
+                marginInline: 8,
+                marginBottom: 4,
+                ...(isSelected
+                  ? { backgroundColor: "var(--hb-color-accent)", color: "#fff" }
+                  : { color: "var(--hb-color-text-primary)" }),
               }}
             >
-              <Hb.List.ItemAvatar sx={{ minWidth: 40 }}>
+              <Hb.List.ItemAvatar style={{
+                minWidth: 40
+              }}>
                 <Hb.Avatar
                   style={{
                     width: 28,
                     height: 28,
                     fontSize: "0.7rem",
                     fontWeight: 700,
-                    backgroundColor: isSelected ? "rgba(255,255,255,0.2)" : "grey.200",
-                    color: isSelected ? "#fff" : "text.secondary",
+                    backgroundColor: isSelected ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.06)",
+                    color: isSelected ? "#fff" : "var(--hb-color-text-secondary)",
                   }}
                 >
                   v{version.version}
@@ -100,14 +93,17 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
               <Hb.List.ItemText
                 primary={version.title}
                 secondary={`${author} · ${new Date(version.createdAt).toLocaleString("ko-KR")}`}
-                slotProps={{
-                  primary: {
-                    noWrap: true,
-                    sx: { fontSize: "0.8125rem", fontWeight: 500 },
-                  },
-                  secondary: {
-                    sx: { fontSize: "0.6875rem" },
-                  },
+                primaryStyle={{
+                  fontSize: "0.8125rem",
+                  fontWeight: 500,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  color: isSelected ? "#fff" : undefined,
+                }}
+                secondaryStyle={{
+                  fontSize: "0.6875rem",
+                  color: isSelected ? "rgba(255,255,255,0.7)" : undefined,
                 }}
               />
               <Hb.Tooltip title="이 버전으로 복원">
@@ -120,7 +116,7 @@ export const VersionList = ({ spaceKey, pageId, onClose }: VersionListProps) => 
                   }}
                   disabled={isRestoring}
                   style={{
-                    color: isSelected ? "rgba(255,255,255,0.8)" : "text.secondary",
+                    color: isSelected ? "rgba(255,255,255,0.8)" : "var(--hb-color-text-secondary)",
                     marginLeft: 4,
                   }}
                 >

--- a/packages/hobom-design-system/src/components/List/List.stories.tsx
+++ b/packages/hobom-design-system/src/components/List/List.stories.tsx
@@ -1,0 +1,55 @@
+import { List } from "./List";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/List",
+  component: List.Root,
+  parameters: {
+    // Secondary text uses Astryx neutral #737373, which sits just under the
+    // 4.5:1 line on the tinted canvas — a known, intentional pattern.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof List.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <div style={{ width: 280 }}>
+      <List.Root>
+        <List.Item>
+          <List.ItemText primary="Inbox" secondary="12 unread" />
+        </List.Item>
+        <List.Item>
+          <List.ItemText primary="Drafts" />
+        </List.Item>
+      </List.Root>
+    </div>
+  ),
+};
+
+export const Buttons: Story = {
+  render: () => (
+    <div style={{ width: 280 }}>
+      <List.Root>
+        <List.Item disablePadding>
+          <List.ItemButton onClick={() => {}}>
+            <List.ItemText primary="Profile" />
+          </List.ItemButton>
+        </List.Item>
+        <List.Item disablePadding>
+          <List.ItemButton selected onClick={() => {}}>
+            <List.ItemText primary="Settings" />
+          </List.ItemButton>
+        </List.Item>
+        <List.Item disablePadding>
+          <List.ItemButton disabled onClick={() => {}}>
+            <List.ItemText primary="Disabled" />
+          </List.ItemButton>
+        </List.Item>
+      </List.Root>
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/List/List.tsx
+++ b/packages/hobom-design-system/src/components/List/List.tsx
@@ -1,27 +1,297 @@
 import {
-  List as MuiList,
-  ListItem as MuiListItem,
-  ListItemText as MuiListItemText,
-  ListItemIcon as MuiListItemIcon,
-  ListItemButton as MuiListItemButton,
-  ListItemAvatar as MuiListItemAvatar,
-  ListSubheader as MuiListSubheader,
-} from "@mui/material";
+  createContext,
+  useContext,
+  type CSSProperties,
+  type HTMLAttributes,
+  type LiHTMLAttributes,
+  type ReactNode,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
 
-const Root = MuiList;
-const Item = MuiListItem;
-const ItemText = MuiListItemText;
-const ItemIcon = MuiListItemIcon;
-const ItemButton = MuiListItemButton;
-const ItemAvatar = MuiListItemAvatar;
-const Subheader = MuiListSubheader;
+const DenseContext = createContext(false);
 
-export const List = {
-  Root,
-  Item,
-  ItemText,
-  ItemIcon,
-  ItemButton,
-  ItemAvatar,
-  Subheader,
+const styles = stylex.create({
+  root: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    position: "relative",
+  },
+  rootPadding: { paddingBlock: 8 },
+  item: {
+    display: "flex",
+    alignItems: "center",
+    position: "relative",
+    boxSizing: "border-box",
+    paddingBlock: 8,
+    paddingInline: 16,
+    width: "100%",
+  },
+  itemAlignStart: { alignItems: "flex-start" },
+  itemNoGutters: { paddingInline: 0 },
+  itemNoPadding: { padding: 0 },
+  secondaryAction: {
+    marginLeft: "auto",
+    display: "inline-flex",
+    alignItems: "center",
+  },
+  button: {
+    display: "flex",
+    alignItems: "center",
+    boxSizing: "border-box",
+    width: "100%",
+    marginBottom: 4,
+    paddingBlock: 10,
+    paddingInline: 16,
+    borderWidth: 0,
+    borderStyle: "none",
+    borderRadius: 8,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "rgba(0, 0, 0, 0.04)",
+    },
+    color: "var(--hb-color-text-secondary)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    textAlign: "left",
+    cursor: "pointer",
+    appearance: "none",
+    outline: "none",
+    transition: "background-color 0.15s",
+  },
+  buttonDense: { paddingBlock: 6 },
+  buttonSelected: {
+    backgroundColor: {
+      default: "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
+      ":hover": "color-mix(in srgb, var(--hb-color-accent) 12%, transparent)",
+    },
+    color: "var(--hb-color-text-primary)",
+  },
+  buttonDisabled: { opacity: 0.5, pointerEvents: "none", cursor: "default" },
+  text: { flex: 1, minWidth: 0 },
+  primary: { fontSize: "1rem", lineHeight: 1.5, color: "var(--hb-color-text-primary)" },
+  primaryDense: { fontSize: "0.875rem" },
+  secondary: {
+    fontSize: "0.875rem",
+    lineHeight: 1.43,
+    color: "var(--hb-color-text-secondary)",
+  },
+  icon: {
+    display: "inline-flex",
+    alignItems: "center",
+    minWidth: 36,
+    color: "inherit",
+    flexShrink: 0,
+  },
+  avatar: {
+    display: "inline-flex",
+    alignItems: "center",
+    minWidth: 56,
+    flexShrink: 0,
+  },
+  subheader: {
+    display: "block",
+    boxSizing: "border-box",
+    margin: 0,
+    paddingBlock: 8,
+    paddingInline: 16,
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    fontWeight: 500,
+    lineHeight: 2.5,
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  subheaderNoGutters: { paddingInline: 0 },
+});
+
+const cx = (a: string | undefined, b: string | undefined): string | undefined =>
+  [a, b].filter(Boolean).join(" ") || undefined;
+
+interface RootProps extends HTMLAttributes<HTMLUListElement> {
+  dense?: boolean;
+  disablePadding?: boolean;
+  /** Rendered before the list items (e.g. a `List.Subheader`). */
+  subheader?: ReactNode;
+}
+
+const Root = ({
+  dense = false,
+  disablePadding = false,
+  subheader,
+  className,
+  style,
+  children,
+  ...rest
+}: RootProps) => {
+  const sx = stylex.props(styles.root, !disablePadding && styles.rootPadding);
+
+  return (
+    <DenseContext.Provider value={dense}>
+      <ul {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+        {subheader}
+        {children}
+      </ul>
+    </DenseContext.Provider>
+  );
 };
+
+interface ItemProps extends LiHTMLAttributes<HTMLLIElement> {
+  disablePadding?: boolean;
+  disableGutters?: boolean;
+  alignItems?: "center" | "flex-start";
+  secondaryAction?: ReactNode;
+}
+
+const Item = ({
+  disablePadding = false,
+  disableGutters = false,
+  alignItems = "center",
+  secondaryAction,
+  className,
+  style,
+  children,
+  ...rest
+}: ItemProps) => {
+  const sx = stylex.props(
+    styles.item,
+    alignItems === "flex-start" && styles.itemAlignStart,
+    disableGutters && styles.itemNoGutters,
+    disablePadding && styles.itemNoPadding,
+  );
+
+  return (
+    <li {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {children}
+      {secondaryAction && <span {...stylex.props(styles.secondaryAction)}>{secondaryAction}</span>}
+    </li>
+  );
+};
+
+interface ItemButtonProps extends HTMLAttributes<HTMLDivElement> {
+  selected?: boolean;
+  disabled?: boolean;
+  dense?: boolean;
+}
+
+const ItemButton = ({
+  selected = false,
+  disabled = false,
+  dense,
+  className,
+  style,
+  children,
+  ...rest
+}: ItemButtonProps) => {
+  const denseCtx = useContext(DenseContext);
+  const isDense = dense ?? denseCtx;
+  const sx = stylex.props(
+    styles.button,
+    isDense && styles.buttonDense,
+    selected && styles.buttonSelected,
+    disabled && styles.buttonDisabled,
+  );
+
+  return (
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      {...rest}
+      className={cx(sx.className, className)}
+      style={{ ...sx.style, ...style }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          event.currentTarget.click();
+        }
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+interface ItemTextProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  primary?: ReactNode;
+  secondary?: ReactNode;
+  primaryStyle?: CSSProperties;
+  secondaryStyle?: CSSProperties;
+  children?: ReactNode;
+}
+
+const ItemText = ({
+  primary,
+  secondary,
+  primaryStyle,
+  secondaryStyle,
+  className,
+  style,
+  children,
+  ...rest
+}: ItemTextProps) => {
+  const dense = useContext(DenseContext);
+  const sx = stylex.props(styles.text);
+  const primarySx = stylex.props(styles.primary, dense && styles.primaryDense);
+  const secondarySx = stylex.props(styles.secondary);
+
+  return (
+    <div {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      <div className={primarySx.className} style={{ ...primarySx.style, ...primaryStyle }}>
+        {primary ?? children}
+      </div>
+      {secondary != null && (
+        <div className={secondarySx.className} style={{ ...secondarySx.style, ...secondaryStyle }}>
+          {secondary}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ItemIcon = ({ className, style, children, ...rest }: HTMLAttributes<HTMLSpanElement>) => {
+  const sx = stylex.props(styles.icon);
+
+  return (
+    <span {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {children}
+    </span>
+  );
+};
+
+const ItemAvatar = ({ className, style, children, ...rest }: HTMLAttributes<HTMLDivElement>) => {
+  const sx = stylex.props(styles.avatar);
+
+  return (
+    <div {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {children}
+    </div>
+  );
+};
+
+interface SubheaderProps extends HTMLAttributes<HTMLElement> {
+  component?: "li" | "div";
+  /** No-op kept for API compatibility. */
+  disableSticky?: boolean;
+  disableGutters?: boolean;
+}
+
+const Subheader = ({
+  component: Component = "li",
+  disableSticky: _disableSticky,
+  disableGutters = false,
+  className,
+  style,
+  children,
+  ...rest
+}: SubheaderProps) => {
+  const sx = stylex.props(styles.subheader, disableGutters && styles.subheaderNoGutters);
+
+  return (
+    <Component {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {children}
+    </Component>
+  );
+};
+
+export const List = { Root, Item, ItemText, ItemIcon, ItemButton, ItemAvatar, Subheader };


### PR DESCRIPTION
## What

Removes the `@mui/material` re-exports for the `List` compound (`Root` / `Item` / `ItemText` / `ItemIcon` / `ItemButton` / `ItemAvatar` / `Subheader`) and replaces them with native StyleX elements.

## Components

- **`Root`** — `<ul>` with a `dense` context and optional padding; supports a `subheader` slot.
- **`Item`** — `<li>` row with `disablePadding` / `disableGutters` / `alignItems` / `secondaryAction`.
- **`ItemButton`** — keyboard-activatable row (`role="button"`, Enter/Space), default hover tint, `selected` / `disabled`, dense-aware.
- **`ItemText`** — renders `primary` / `secondary` with **`primaryStyle` / `secondaryStyle`** slots (replacing MUI `slotProps` / `primaryTypographyProps` / `secondaryTypographyProps`).
- **`ItemIcon` / `ItemAvatar` / `Subheader`** — styled wrappers; `Subheader` supports `component` / `disableGutters`.

## Consumers (19 files)

- Codemodded `sx` → `style` on all list parts.
- Migrated `ItemText` text props to `primaryStyle` / `secondaryStyle` (incl. `variant` → font-size, `noWrap` → ellipsis CSS).
- The two selected-row lists (page tree, version history) used `&.Mui-selected` with descendant selectors into MUI child classes (now gone) — reworked to pass **conditional inline styles** to children plus a scoped `<style>` hover-reveal for the custom `.tree-node-add` affordance.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 113 pass