### PR TITLE
Replace Table with in-house component

### DIFF
--- a/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogEntryTable.tsx
@@ -1,15 +1,16 @@
+import type { CSSProperties } from "react";
 import type { LogEntry } from "@/entities/log";
 import { Hb } from "@/shared/ui";
 import { SERVICE_LABEL_MAP } from "../lib/log-dashboard.lib";
 import { METHOD_CHIP_COLOR as METHOD_COLOR } from "./endpoint-error-constants";
 
-const HEADER_SX = {
+const HEADER_STYLE: CSSProperties = {
   fontWeight: 600,
   fontSize: 11,
   textTransform: "uppercase",
   letterSpacing: "0.04em",
-  color: "text.secondary",
-} as const;
+  color: "var(--hb-color-text-secondary)",
+};
 
 const LEVEL_COLOR: Record<string, { bg: string; text: string }> = {
   DEBUG: { bg: "#22d3ee18", text: "#22d3ee" },
@@ -52,29 +53,31 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
   }
 
   return (
-    <Hb.Table.Container sx={{ maxHeight: 520 }}>
+    <Hb.Table.Container style={{
+      maxHeight: 520
+    }}>
       <Hb.Table.Root size="small" stickyHeader>
         <Hb.Table.Head>
           <Hb.Table.Row>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Level
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Service
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Method
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Path
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Message
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" align="center" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" align="center" style={HEADER_STYLE}>
               Status
             </Hb.Table.Cell>
-            <Hb.Table.Cell scope="col" sx={HEADER_SX}>
+            <Hb.Table.Cell scope="col" style={HEADER_STYLE}>
               Time
             </Hb.Table.Cell>
           </Hb.Table.Row>
@@ -125,7 +128,9 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                     }}
                   />
                 </Hb.Table.Cell>
-                <Hb.Table.Cell sx={{ maxWidth: 200 }}>
+                <Hb.Table.Cell style={{
+                  maxWidth: 200
+                }}>
                   <Hb.Tooltip title={`${row.httpMethod} ${row.path}`} enterDelay={200}>
                     <Hb.Text
                       variant="body2"
@@ -139,7 +144,9 @@ export const LogEntryTable = ({ data }: LogEntryTableProps) => {
                     </Hb.Text>
                   </Hb.Tooltip>
                 </Hb.Table.Cell>
-                <Hb.Table.Cell sx={{ maxWidth: 220 }}>
+                <Hb.Table.Cell style={{
+                  maxWidth: 220
+                }}>
                   <Hb.Tooltip title={row.message} enterDelay={200}>
                     <Hb.Text
                       variant="body2"

--- a/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
+++ b/apps/hobom-system/src/features/dlq-management/ui/DlqManagementContent.tsx
@@ -49,21 +49,26 @@ export const DlqManagementContent = () => {
     }
 
     return (
-      <Hb.Table.Container sx={{ maxHeight: "calc(100vh - 280px)", overflow: "auto" }}>
+      <Hb.Table.Container style={{
+        maxHeight: "calc(100vh - 280px)",
+        overflow: "auto"
+      }}>
         <Hb.Table.Root stickyHeader size="small">
           <Hb.Table.Head>
             <Hb.Table.Row>
               <Hb.Table.Cell
-                sx={{
+                style={{
                   fontWeight: 600,
                   fontSize: 11,
                   textTransform: "uppercase",
-                  letterSpacing: "0.04em",
+                  letterSpacing: "0.04em"
                 }}
               >
                 Key
               </Hb.Table.Cell>
-              <Hb.Table.Cell sx={{ width: 100 }} align="center">
+              <Hb.Table.Cell style={{
+                width: 100
+              }} align="center">
                 액션
               </Hb.Table.Cell>
             </Hb.Table.Row>
@@ -73,14 +78,16 @@ export const DlqManagementContent = () => {
               <Hb.Table.Row
                 key={key}
                 hover
-                sx={{ cursor: "pointer" }}
+                style={{
+                  cursor: "pointer"
+                }}
                 onClick={() => setSelectedKey(key)}
               >
                 <Hb.Table.Cell
-                  sx={{
+                  style={{
                     fontFamily: "'JetBrains Mono', monospace",
                     fontSize: 12,
-                    wordBreak: "break-all",
+                    wordBreak: "break-all"
                   }}
                 >
                   {key}

--- a/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
+++ b/apps/hobom-system/src/features/manage-pending-users/ui/PendingUsersTable.tsx
@@ -92,20 +92,25 @@ export const PendingUsersTable = () => {
         </Hb.Paper>
       ) : (
         <Hb.Table.Container component={Hb.Paper} variant="outlined">
+          <style href="hb-pending-row" precedence="medium">
+            {".hb-pending-row:last-child td{border-bottom:0}"}
+          </style>
           <Hb.Table.Root>
             <Hb.Table.Head>
               <Hb.Table.Row>
                 <Hb.Table.Cell scope="col">사용자</Hb.Table.Cell>
                 <Hb.Table.Cell scope="col">닉네임</Hb.Table.Cell>
                 <Hb.Table.Cell scope="col">이메일</Hb.Table.Cell>
-                <Hb.Table.Cell scope="col" align="right" sx={{ width: 200 }}>
+                <Hb.Table.Cell scope="col" align="right" style={{
+                  width: 200
+                }}>
                   액션
                 </Hb.Table.Cell>
               </Hb.Table.Row>
             </Hb.Table.Head>
             <Hb.Table.Body>
               {users.map((user) => (
-                <Hb.Table.Row key={user.id} sx={{ "&:last-child td": { borderBottom: 0 } }}>
+                <Hb.Table.Row key={user.id} className="hb-pending-row">
                   <Hb.Table.Cell>
                     <Hb.Stack
                       direction="row"

--- a/packages/hobom-design-system/src/components/Table/Table.stories.tsx
+++ b/packages/hobom-design-system/src/components/Table/Table.stories.tsx
@@ -1,0 +1,49 @@
+import { Table } from "./Table";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Table",
+  component: Table.Root,
+  parameters: {
+    // Header cells use Astryx neutral secondary text (#737373), which sits just
+    // under the 4.5:1 line on the tinted canvas — a known, intentional pattern.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Table.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const rows = [
+  { name: "Alpha", status: "Active", count: 12 },
+  { name: "Beta", status: "Pending", count: 3 },
+  { name: "Gamma", status: "Archived", count: 0 },
+];
+
+export const Basic: Story = {
+  render: () => (
+    <Table.Container>
+      <Table.Root>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell scope="col">Name</Table.Cell>
+            <Table.Cell scope="col">Status</Table.Cell>
+            <Table.Cell scope="col" align="right">
+              Count
+            </Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {rows.map((row) => (
+            <Table.Row key={row.name} hover>
+              <Table.Cell>{row.name}</Table.Cell>
+              <Table.Cell>{row.status}</Table.Cell>
+              <Table.Cell align="right">{row.count}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Table.Container>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Table/Table.tsx
+++ b/packages/hobom-design-system/src/components/Table/Table.tsx
@@ -1,17 +1,173 @@
 import {
-  Table as MuiTable,
-  TableBody as MuiTableBody,
-  TableCell as MuiTableCell,
-  TableContainer as MuiTableContainer,
-  TableHead as MuiTableHead,
-  TableRow as MuiTableRow,
-} from "@mui/material";
+  createContext,
+  createElement,
+  useContext,
+  type CSSProperties,
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+  type TdHTMLAttributes,
+  type ThHTMLAttributes,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
 
-const Root = MuiTable;
-const Container = MuiTableContainer;
-const Head = MuiTableHead;
-const Body = MuiTableBody;
-const Row = MuiTableRow;
-const Cell = MuiTableCell;
+type TableSize = "small" | "medium";
+
+interface TableContextValue {
+  size: TableSize;
+  stickyHeader: boolean;
+}
+
+const TableContext = createContext<TableContextValue>({ size: "medium", stickyHeader: false });
+const HeadContext = createContext(false);
+
+const styles = stylex.create({
+  container: { width: "100%", overflowX: "auto" },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    borderSpacing: 0,
+  },
+  cell: {
+    paddingBlock: 16,
+    paddingInline: 16,
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    lineHeight: 1.43,
+    color: "var(--hb-color-text-primary)",
+    textAlign: "left",
+    verticalAlign: "inherit",
+  },
+  cellSmall: { paddingBlock: 6, paddingInline: 16 },
+  headCell: {
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+    whiteSpace: "nowrap",
+  },
+  headCellSticky: {
+    position: "sticky",
+    top: 0,
+    zIndex: 2,
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  rowHover: {
+    backgroundColor: { default: "transparent", ":hover": "rgba(0, 0, 0, 0.04)" },
+  },
+});
+
+const cx = (a: string | undefined, b: string | undefined): string | undefined =>
+  [a, b].filter(Boolean).join(" ") || undefined;
+
+interface ContainerProps extends HTMLAttributes<HTMLElement> {
+  component?: ElementType;
+  /** Forwarded to `component` (e.g. Paper's `variant`). */
+  variant?: string;
+  children?: ReactNode;
+}
+
+const Container = ({ component, className, style, children, ...rest }: ContainerProps) => {
+  const sx = stylex.props(styles.container);
+  const props = {
+    ...rest,
+    className: cx(sx.className, className),
+    style: { ...sx.style, ...style },
+  };
+
+  return component ? createElement(component, props, children) : <div {...props}>{children}</div>;
+};
+
+interface RootProps extends HTMLAttributes<HTMLTableElement> {
+  size?: TableSize;
+  stickyHeader?: boolean;
+}
+
+const Root = ({
+  size = "medium",
+  stickyHeader = false,
+  className,
+  style,
+  children,
+  ...rest
+}: RootProps) => {
+  const sx = stylex.props(styles.table);
+
+  return (
+    <TableContext.Provider value={{ size, stickyHeader }}>
+      <table {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+        {children}
+      </table>
+    </TableContext.Provider>
+  );
+};
+
+const Head = ({ children, ...rest }: HTMLAttributes<HTMLTableSectionElement>) => (
+  <HeadContext.Provider value={true}>
+    <thead {...rest}>{children}</thead>
+  </HeadContext.Provider>
+);
+
+const Body = ({ children, ...rest }: HTMLAttributes<HTMLTableSectionElement>) => (
+  <tbody {...rest}>{children}</tbody>
+);
+
+interface RowProps extends HTMLAttributes<HTMLTableRowElement> {
+  hover?: boolean;
+  selected?: boolean;
+}
+
+const Row = ({ hover = false, selected = false, className, style, children, ...rest }: RowProps) => {
+  const sx = stylex.props(hover && styles.rowHover);
+
+  return (
+    <tr
+      {...rest}
+      aria-selected={selected || undefined}
+      className={cx(sx.className, className)}
+      style={style}
+    >
+      {children}
+    </tr>
+  );
+};
+
+interface CellProps extends Omit<TdHTMLAttributes<HTMLTableCellElement>, "align"> {
+  align?: "left" | "center" | "right";
+  /** `th` scope, forwarded when the cell renders inside a `Table.Head`. */
+  scope?: ThHTMLAttributes<HTMLTableCellElement>["scope"];
+  width?: number | string;
+}
+
+const Cell = ({ align, scope, width, className, style, children, ...rest }: CellProps) => {
+  const { size, stickyHeader } = useContext(TableContext);
+  const isHead = useContext(HeadContext);
+  const sx = stylex.props(
+    styles.cell,
+    size === "small" && styles.cellSmall,
+    isHead && styles.headCell,
+    isHead && stickyHeader && styles.headCellSticky,
+  );
+
+  const dynamic: CSSProperties = { ...sx.style };
+
+  if (align) dynamic.textAlign = align;
+  if (width != null) dynamic.width = width;
+
+  const props = {
+    ...rest,
+    className: cx(sx.className, className),
+    style: { ...dynamic, ...style },
+  };
+
+  return isHead ? (
+    <th scope={scope} {...props}>
+      {children}
+    </th>
+  ) : (
+    <td {...props}>{children}</td>
+  );
+};
 
 export const Table = { Root, Container, Head, Body, Row, Cell };


### PR DESCRIPTION
## What

Removes the `@mui/material` re-exports for the `Table` compound (`Root` / `Container` / `Head` / `Body` / `Row` / `Cell`) and replaces them with native table elements.

## Components

- **`Container`** — scroll wrapper (`<div>`, or a polymorphic `component` such as `Paper`).
- **`Root`** — `<table>` providing `size` (small/medium → cell padding) and `stickyHeader` context.
- **`Head` / `Body`** — `<thead>` / `<tbody>`; `Head` flags its cells to render as `<th>`.
- **`Row`** — `<tr>` with `hover` / `selected`.
- **`Cell`** — renders `<th scope=…>` inside a `Head`, `<td>` otherwise; honors `align` / `width` and the size/sticky context.

## Consumers (4 files)

- Codemodded `sx` → `style` on all table parts.
- A shared header `sx` object became a plain `style` object (`text.secondary` → var).
- The last-row-borderless rule (`&:last-child td`) — a descendant selector StyleX can't express — moved to a scoped, deduplicated `<style>`.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 114 pass