### PR TITLE
Replace TextField with in-house component

### DIFF
--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
@@ -101,23 +101,25 @@ const AddTodoDialog = ({
           autoFocus
           label="제목"
           size="small"
-          sx={{ mb: 2 }}
+          style={{
+            marginBottom: 16
+          }}
           {...register("title")}
         />
-        <Hb.TextField
-          fullWidth
-          select
-          label="반복 주기"
-          size="small"
-          value={cycle}
-          onChange={(e) => setValue("cycle", e.target.value as CycleType)}
-        >
-          {CYCLE_OPTIONS.map((key) => (
-            <Hb.Form.Option key={key} value={key}>
-              {CYCLE_LABELS[key]}
-            </Hb.Form.Option>
-          ))}
-        </Hb.TextField>
+        <Hb.Form.Control fullWidth size="small">
+          <Hb.Form.Label>반복 주기</Hb.Form.Label>
+          <Hb.Form.Select
+            label="반복 주기"
+            value={cycle}
+            onChange={(e) => setValue("cycle", e.target.value as CycleType)}
+          >
+            {CYCLE_OPTIONS.map((key) => (
+              <Hb.Form.Option key={key} value={key}>
+                {CYCLE_LABELS[key]}
+              </Hb.Form.Option>
+            ))}
+          </Hb.Form.Select>
+        </Hb.Form.Control>
       </Hb.Dialog.Content>
       <Hb.Dialog.Actions style={{
         paddingLeft: 24,

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
@@ -40,23 +40,25 @@ export const DailyTodoEditDialog = ({ item, open, onClose }: Props) => {
           autoFocus
           label="제목"
           size="small"
-          sx={{ mb: 2 }}
+          style={{
+            marginBottom: 16
+          }}
           {...register("title")}
         />
-        <Hb.TextField
-          fullWidth
-          select
-          label="카테고리"
-          size="small"
-          value={editCategory}
-          onChange={(e) => setEditCategory(e.target.value)}
-        >
-          {(categoriesData?.items ?? []).map((cat) => (
-            <Hb.Form.Option key={cat.id} value={cat.id}>
-              {cat.title}
-            </Hb.Form.Option>
-          ))}
-        </Hb.TextField>
+        <Hb.Form.Control fullWidth size="small">
+          <Hb.Form.Label>카테고리</Hb.Form.Label>
+          <Hb.Form.Select
+            label="카테고리"
+            value={editCategory}
+            onChange={(e) => setEditCategory(e.target.value)}
+          >
+            {(categoriesData?.items ?? []).map((cat) => (
+              <Hb.Form.Option key={cat.id} value={cat.id}>
+                {cat.title}
+              </Hb.Form.Option>
+            ))}
+          </Hb.Form.Select>
+        </Hb.Form.Control>
       </Hb.Dialog.Content>
       <Hb.Dialog.Actions style={{
         paddingLeft: 24,

--- a/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
+++ b/apps/hobom-system/src/features/backlog-board/ui/CreateSprintDialog.tsx
@@ -45,7 +45,9 @@ export const CreateSprintDialog = ({ open, onClose, projectId }: CreateSprintDia
           onChange={(e) => setName(e.target.value)}
           fullWidth
           size="small"
-          sx={{ mt: 1 }}
+          style={{
+            marginTop: 8
+          }}
         />
         <Hb.Box
           style={{

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -54,7 +54,9 @@ export const CreateIssueDialog = ({
           onChange={(e) => fields.setTitle(e.target.value)}
           fullWidth
           size="small"
-          sx={{ mt: 1 }}
+          style={{
+            marginTop: 8
+          }}
         />
         <Hb.TextField
           label="설명"
@@ -131,7 +133,9 @@ export const CreateIssueDialog = ({
             onChange={(e) => fields.setStoryPoints(e.target.value)}
             size="small"
             slotProps={{ htmlInput: { min: 0, step: 1 } }}
-            sx={{ width: 140 }}
+            style={{
+              width: 140
+            }}
           />
         </Hb.Box>
         <Hb.Box>

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
@@ -115,7 +115,9 @@ export const LogSearchSection = () => {
             type="number"
             value={filter.statusCode}
             onChange={(e) => handleFilterChange("statusCode", e.target.value)}
-            sx={{ width: 130 }}
+            style={{
+              width: 130
+            }}
             slotProps={{ htmlInput: { min: 100, max: 599 } }}
           />
 

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
@@ -77,7 +77,9 @@ export const ErrorEventFilter = ({
         label="화면 (path)"
         value={filter.screen}
         onChange={(e) => onFilterChange("screen", e.target.value)}
-        sx={{ width: 200 }}
+        style={{
+          width: 200
+        }}
       />
 
       <Hb.Button

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
@@ -108,11 +108,8 @@ const StoryPointsInput = ({
           setEditing(false);
         }
       }}
-      slotProps={{ htmlInput: { min: 0, step: 1 } }}
-      sx={{
-        width: 80,
-        "& .MuiInputBase-input": { fontSize: 13, py: 0.5 },
-      }}
+      slotProps={{ htmlInput: { min: 0, step: 1, style: { fontSize: 13 } } }}
+      style={{ width: 80 }}
     />
   );
 };

--- a/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/CreateIssueInlineForm.tsx
@@ -76,11 +76,9 @@ export const CreateIssueInlineForm = ({ onSubmit }: CreateIssueInlineFormProps) 
         fullWidth
         placeholder="이슈 제목을 입력하세요"
         data-no-dnd
-        sx={{
-          "& .MuiOutlinedInput-root": {
-            borderRadius: 2,
-            fontSize: 13,
-          },
+        slotProps={{
+          input: { style: { borderRadius: 16 } },
+          htmlInput: { style: { fontSize: 13 } },
         }}
       />
     </Hb.Box>

--- a/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
+++ b/apps/hobom-system/src/features/note/ui/NoteEditDialog.tsx
@@ -79,8 +79,10 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
           fullWidth
           value={form.title}
           onChange={(e) => setField("title", e.target.value)}
-          InputProps={{ disableUnderline: true, sx: { fontWeight: 600 } }}
-          sx={{ mb: 1 }}
+          slotProps={{ htmlInput: { style: { fontWeight: 600 } } }}
+          style={{
+            marginBottom: 8
+          }}
         />
 
         {form.type === "TEXT" && (
@@ -91,7 +93,6 @@ export const NoteEditDialog = ({ open, onClose, note }: NoteEditDialogProps) => 
             minRows={3}
             value={form.content}
             onChange={(e) => setField("content", e.target.value)}
-            InputProps={{ disableUnderline: true }}
           />
         )}
 

--- a/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
@@ -47,7 +47,9 @@ export const ReminderPickerPopover = ({ anchorEl, onClose, onSet }: ReminderPick
           size="small"
           value={date}
           onChange={(e) => setDate(e.target.value)}
-          sx={{ mt: 1 }}
+          style={{
+            marginTop: 8
+          }}
         />
         <Hb.Form.Select
           value={recurrence}

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawArticleViewer.tsx
@@ -114,7 +114,10 @@ export const LawArticleViewer = ({ versionId }: Props) => {
             ),
           },
         }}
-        sx={{ mb: 2, width: 320 }}
+        style={{
+          marginBottom: 16,
+          width: 320
+        }}
       />
       <Hb.Stack spacing={0.5}>
         {filtered.map((article) => (

--- a/apps/hobom-system/src/features/project-list/ui/CreateProjectDialog.tsx
+++ b/apps/hobom-system/src/features/project-list/ui/CreateProjectDialog.tsx
@@ -47,7 +47,9 @@ export const CreateProjectDialog = ({ open, onClose }: CreateProjectDialogProps)
           onChange={(e) => setKey(e.target.value)}
           fullWidth
           size="small"
-          sx={{ mt: 1 }}
+          style={{
+            marginTop: 8
+          }}
           helperText="영문 대문자로 입력하세요 (예: PROJ)"
         />
         <Hb.TextField

--- a/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
@@ -75,7 +75,9 @@ export const AddMemberDialog = ({
               label="사용자 검색"
               size="small"
               placeholder="이름 또는 아이디로 검색"
-              sx={{ mt: 1 }}
+              style={{
+                marginTop: 8
+              }}
             />
           )}
           noOptionsText="검색 결과가 없어요"

--- a/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardItem.tsx
@@ -79,7 +79,10 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
             onBlur={handleSaveName}
             autoFocus
             disabled={isUpdating}
-            sx={{ flex: 1, mr: 1 }}
+            style={{
+              flex: 1,
+              marginRight: 8
+            }}
           />
         ) : (
           <Hb.Box
@@ -241,10 +244,8 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
           value={newStatusId}
           onChange={(e) => setNewStatusId(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleAddColumn()}
-          sx={{
-            flex: 1,
-            "& .MuiInputBase-input": { fontSize: 13, py: 0.75 },
-          }}
+          style={{ flex: 1 }}
+          slotProps={{ htmlInput: { style: { fontSize: 13 } } }}
         />
         <Hb.TextField
           size="small"
@@ -252,10 +253,8 @@ export const BoardItem = ({ board, projectId, onDelete }: BoardItemProps) => {
           value={newStatusName}
           onChange={(e) => setNewStatusName(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && handleAddColumn()}
-          sx={{
-            flex: 1,
-            "& .MuiInputBase-input": { fontSize: 13, py: 0.75 },
-          }}
+          style={{ flex: 1 }}
+          slotProps={{ htmlInput: { style: { fontSize: 13 } } }}
         />
         <Hb.Button.Icon
           size="small"

--- a/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/BoardSettingsSection.tsx
@@ -108,7 +108,9 @@ export const BoardSettingsSection = ({ projectId }: BoardSettingsSectionProps) =
             value={newBoardName}
             onChange={(e) => setNewBoardName(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleCreate()}
-            sx={{ flex: 1 }}
+            style={{
+              flex: 1
+            }}
           />
           <Hb.Button
             variant="primary"

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageEditDialog.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageEditDialog.tsx
@@ -34,7 +34,9 @@ export const FutureMessageEditDialog = ({ message, open, onClose }: Props) => {
           size="small"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          sx={{ mb: 2 }}
+          style={{
+            marginBottom: 16
+          }}
         />
         <Hb.TextField
           fullWidth

--- a/apps/hobom-system/src/features/submit-auth-login/ui/NicknameField.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/NicknameField.tsx
@@ -18,22 +18,10 @@ export const NicknameField = () => {
       }}
       render={({ field, fieldState }) => (
         <Hb.TextField
-          sx={{
-            fontSize: 14,
-            "& input::placeholder": {
-              fontSize: 14,
-            },
-          }}
           label="닉네임"
           size="small"
           placeholder="닉네임을 입력해주세요."
           fullWidth
-          slotProps={{
-            inputLabel: {
-              size: "small",
-              shrink: true,
-            },
-          }}
           error={Boolean(fieldState.error)}
           helperText={fieldState.error?.message}
           value={field.value}

--- a/apps/hobom-system/src/features/submit-auth-login/ui/PasswordField.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/PasswordField.tsx
@@ -14,23 +14,11 @@ export const PasswordField = () => {
       }}
       render={({ field, fieldState }) => (
         <Hb.TextField
-          sx={{
-            fontSize: 14,
-            "& input::placeholder": {
-              fontSize: 14,
-            },
-          }}
           label="비밀번호"
           placeholder="비밀번호를 입력해 주세요."
           size="small"
           type="password"
           fullWidth
-          slotProps={{
-            inputLabel: {
-              size: "small",
-              shrink: true,
-            },
-          }}
           error={Boolean(fieldState.error)}
           helperText={fieldState.error?.message}
           value={field.value}

--- a/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
@@ -43,15 +43,6 @@ export const AuthSignUpForm = () => {
     openWarnToast({ message: "입력 정보를 확인해 주세요." });
   };
 
-  const fieldSx = {
-    fontSize: 14,
-    "& input::placeholder": { fontSize: 14 },
-  };
-
-  const inputLabelProps = {
-    inputLabel: { size: "small" as const, shrink: true },
-  };
-
   return (
     <FormProvider {...formMethods}>
       <Hb.Box
@@ -84,12 +75,10 @@ export const AuthSignUpForm = () => {
           }}
           render={({ field, fieldState }) => (
             <Hb.TextField
-              sx={fieldSx}
               label="이름"
               size="small"
               placeholder="이름을 입력해 주세요."
               fullWidth
-              slotProps={inputLabelProps}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
               value={field.value}
@@ -107,12 +96,10 @@ export const AuthSignUpForm = () => {
           }}
           render={({ field, fieldState }) => (
             <Hb.TextField
-              sx={fieldSx}
               label="닉네임"
               size="small"
               placeholder="로그인 시 사용할 닉네임이에요."
               fullWidth
-              slotProps={inputLabelProps}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
               value={field.value}
@@ -133,12 +120,10 @@ export const AuthSignUpForm = () => {
           }}
           render={({ field, fieldState }) => (
             <Hb.TextField
-              sx={fieldSx}
               label="이메일"
               size="small"
               placeholder="이메일을 입력해 주세요."
               fullWidth
-              slotProps={inputLabelProps}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
               value={field.value}
@@ -156,13 +141,11 @@ export const AuthSignUpForm = () => {
           }}
           render={({ field, fieldState }) => (
             <Hb.TextField
-              sx={fieldSx}
               label="비밀번호"
               size="small"
               type="password"
               placeholder="비밀번호를 입력해 주세요."
               fullWidth
-              slotProps={inputLabelProps}
               error={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
               value={field.value}

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
@@ -80,7 +80,10 @@ export const CreateLabelDialog = ({
             if (e.key === "Enter") handleSubmit();
           }}
           disabled={loading}
-          sx={{ mt: 1, mb: 2 }}
+          style={{
+            marginTop: 8,
+            marginBottom: 16
+          }}
         />
         <Hb.Text
           variant="caption"

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -53,45 +53,45 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
         />
       ))}
       {availableLabels.length > 0 && (
-        <Hb.TextField
-          select
+        <Hb.Form.Control
           size="small"
-          value=""
-          onChange={(e) => {
-            if (e.target.value) {
-              addLabel.mutate(
-                { spaceKey, pageId, labelId: e.target.value },
-                { onSuccess: invalidatePageDetail },
-              );
-            }
-          }}
-          sx={{ minWidth: 100 }}
-          slotProps={{
-            select: {
-              displayEmpty: true,
-              renderValue: () => (
-                <Hb.Text variant="caption" color="text.disabled">
-                  + 라벨
-                </Hb.Text>
-              ),
-            },
+          style={{
+            minWidth: 100
           }}
         >
-          {availableLabels.map((label) => (
-            <Hb.Form.Option key={label.id} value={label.id}>
-              <Hb.Box
-                style={{
-                  width: 10,
-                  height: 10,
-                  borderRadius: "50%",
-                  backgroundColor: label.color,
-                  marginRight: 8,
-                }}
-              />
-              {label.name}
-            </Hb.Form.Option>
-          ))}
-        </Hb.TextField>
+          <Hb.Form.Select
+            value=""
+            onChange={(e) => {
+              if (e.target.value) {
+                addLabel.mutate(
+                  { spaceKey, pageId, labelId: e.target.value },
+                  { onSuccess: invalidatePageDetail },
+                );
+              }
+            }}
+            displayEmpty
+            renderValue={() => (
+              <Hb.Text variant="caption" color="text.disabled">
+                + 라벨
+              </Hb.Text>
+            )}
+          >
+            {availableLabels.map((label) => (
+              <Hb.Form.Option key={label.id} value={label.id}>
+                <Hb.Box
+                  style={{
+                    width: 10,
+                    height: 10,
+                    borderRadius: "50%",
+                    backgroundColor: label.color,
+                    marginRight: 8,
+                  }}
+                />
+                {label.name}
+              </Hb.Form.Option>
+            ))}
+          </Hb.Form.Select>
+        </Hb.Form.Control>
       )}
     </Hb.Box>
   );

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorContent.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorContent.tsx
@@ -131,12 +131,11 @@ export const PageEditorContent = ({
           error={titleError}
           helperText={titleError ? "제목을 입력하세요" : undefined}
           slotProps={{
-            input: {
-              sx: { fontSize: "1.5rem", fontWeight: 600 },
-              disableUnderline: !titleError,
-            },
+            htmlInput: { style: { fontSize: "1.5rem", fontWeight: 600 } },
           }}
-          sx={{ flex: 1 }}
+          style={{
+            flex: 1
+          }}
         />
         <Hb.Button variant="primary" onClick={handleSave} loading={saving} size="small">
           저장

--- a/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
+++ b/apps/hobom-system/src/features/wiki-page-editor/ui/PageEditorToolbar.tsx
@@ -239,7 +239,9 @@ export const PageEditorToolbar = ({ editor }: PageEditorToolbarProps) => {
             onKeyDown={(e) => {
               if (e.key === "Enter") handleLinkSubmit();
             }}
-            sx={{ mt: 1 }}
+            style={{
+              marginTop: 8
+            }}
           />
         </Hb.Dialog.Content>
         <Hb.Dialog.Actions>

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/CreatePageDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/CreatePageDialog.tsx
@@ -51,7 +51,9 @@ export const CreatePageDialog = ({
             if (e.key === "Enter") handleSubmit();
           }}
           disabled={loading}
-          sx={{ mt: 1 }}
+          style={{
+            marginTop: 8
+          }}
         />
       </Hb.Dialog.Content>
       <Hb.Dialog.Actions>

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/PageSelect.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/PageSelect.tsx
@@ -24,19 +24,20 @@ export const PageSelect = ({
   );
 
   return (
-    <Hb.TextField
-      select
-      fullWidth
-      label="부모 페이지"
-      value={selectedPageId ?? "__root__"}
-      onChange={(e) => onSelect(e.target.value === "__root__" ? null : e.target.value)}
-    >
-      <Hb.Form.Option value="__root__">최상위 (루트)</Hb.Form.Option>
-      {flatList.map((item) => (
-        <Hb.Form.Option key={item.id} value={item.id}>
-          {"─".repeat(item.depth)} {item.title}
-        </Hb.Form.Option>
-      ))}
-    </Hb.TextField>
+    <Hb.Form.Control fullWidth>
+      <Hb.Form.Label>부모 페이지</Hb.Form.Label>
+      <Hb.Form.Select
+        label="부모 페이지"
+        value={selectedPageId ?? "__root__"}
+        onChange={(e) => onSelect(e.target.value === "__root__" ? null : e.target.value)}
+      >
+        <Hb.Form.Option value="__root__">최상위 (루트)</Hb.Form.Option>
+        {flatList.map((item) => (
+          <Hb.Form.Option key={item.id} value={item.id}>
+            {"─".repeat(item.depth)} {item.title}
+          </Hb.Form.Option>
+        ))}
+      </Hb.Form.Select>
+    </Hb.Form.Control>
   );
 };

--- a/apps/hobom-system/src/features/wiki-page-tree/ui/SpaceSelect.tsx
+++ b/apps/hobom-system/src/features/wiki-page-tree/ui/SpaceSelect.tsx
@@ -12,18 +12,19 @@ export const SpaceSelect = ({ selectedSpaceKey, onSelect }: SpaceSelectProps) =>
   const spaces = data.items.items;
 
   return (
-    <Hb.TextField
-      select
-      fullWidth
-      label="대상 스페이스"
-      value={selectedSpaceKey}
-      onChange={(e) => onSelect(e.target.value)}
-    >
-      {spaces.map((space) => (
-        <Hb.Form.Option key={space.key} value={space.key}>
-          {space.name}
-        </Hb.Form.Option>
-      ))}
-    </Hb.TextField>
+    <Hb.Form.Control fullWidth>
+      <Hb.Form.Label>대상 스페이스</Hb.Form.Label>
+      <Hb.Form.Select
+        label="대상 스페이스"
+        value={selectedSpaceKey}
+        onChange={(e) => onSelect(e.target.value)}
+      >
+        {spaces.map((space) => (
+          <Hb.Form.Option key={space.key} value={space.key}>
+            {space.name}
+          </Hb.Form.Option>
+        ))}
+      </Hb.Form.Select>
+    </Hb.Form.Control>
   );
 };

--- a/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
+++ b/apps/hobom-system/src/widgets/inspector/ui/Inspector.tsx
@@ -163,7 +163,8 @@ function SizeField({ label, value, onChange }: SizeFieldProps) {
         onChange={(event) =>
           onChange(event.target.value === "" ? undefined : Number(event.target.value))
         }
-        sx={{ ...inputSx, width: 72 }}
+        slotProps={inputSlotProps}
+        style={{ width: 72 }}
       />
     </Hb.Stack>
   );
@@ -177,7 +178,7 @@ interface PropFieldProps {
 }
 
 const labelStyle = { fontSize: 11, color: "var(--hb-color-text-secondary)" } as const;
-const inputSx = { "& .MuiInputBase-input": { fontSize: 12, py: 0.75 } } as const;
+const inputSlotProps = { htmlInput: { style: { fontSize: 12 } } } as const;
 
 const styles = stylex.create({
   segment: {
@@ -241,7 +242,7 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
           size="small"
           value={value === undefined ? "" : String(value)}
           onChange={(event) => onChange(name, event.target.value)}
-          sx={inputSx}
+          slotProps={inputSlotProps}
         />
       </Hb.Stack>
     );
@@ -263,7 +264,8 @@ function PropField({ name, spec, value, onChange }: PropFieldProps) {
           type="number"
           value={value === undefined ? "" : String(value)}
           onChange={(event) => onChange(name, Number(event.target.value))}
-          sx={{ ...inputSx, width: 72 }}
+          slotProps={inputSlotProps}
+          style={{ width: 72 }}
         />
       </Hb.Stack>
     );

--- a/packages/hobom-design-system/src/components/TextField/TextField.stories.tsx
+++ b/packages/hobom-design-system/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { TextField } from "./TextField";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/TextField",
+  component: TextField,
+  parameters: {
+    // Helper text uses Astryx neutral secondary (#737373), just under the
+    // 4.5:1 line on the tinted canvas — a known, intentional muted pattern.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Demo = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16, width: 280 }}>
+      <TextField
+        label="Name"
+        placeholder="Enter your name"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        fullWidth
+      />
+      <TextField label="Email" type="email" helperText="We'll never share it." fullWidth />
+      <TextField label="Code" error helperText="Invalid code" defaultValue="abc" fullWidth />
+      <TextField label="Notes" multiline minRows={3} maxRows={6} fullWidth />
+      <TextField label="Small" size="small" placeholder="Compact" fullWidth />
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/components/TextField/TextField.tsx
+++ b/packages/hobom-design-system/src/components/TextField/TextField.tsx
@@ -1,5 +1,212 @@
-import { TextField as MuiTextField, type TextFieldProps as MuiTextFieldProps } from "@mui/material";
+import {
+  useId,
+  type CSSProperties,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type Ref,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
 
-type TextFieldProps = Omit<MuiTextFieldProps, "variant">;
+type TextFieldSize = "small" | "medium";
 
-export const TextField = (props: TextFieldProps) => <MuiTextField variant="outlined" {...props} />;
+/** Slot props for the bordered input container (adornments, ref, className). */
+interface InputSlotProps {
+  ref?: Ref<HTMLDivElement>;
+  className?: string;
+  style?: CSSProperties;
+  startAdornment?: ReactNode;
+  endAdornment?: ReactNode;
+  /** Accept (and ignore) other MUI input-slot props such as `disableUnderline`. */
+  [key: string]: unknown;
+}
+
+interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "ref"> {
+  label?: ReactNode;
+  helperText?: ReactNode;
+  error?: boolean;
+  size?: TextFieldSize;
+  fullWidth?: boolean;
+  multiline?: boolean;
+  rows?: number;
+  minRows?: number;
+  maxRows?: number;
+  /** Newer slot API. */
+  slotProps?: {
+    htmlInput?: InputHTMLAttributes<HTMLInputElement>;
+    input?: InputSlotProps;
+    inputLabel?: Record<string, unknown>;
+  };
+  /** Legacy props supplied by the Autocomplete `renderInput` params. */
+  InputProps?: InputSlotProps;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+  InputLabelProps?: Record<string, unknown>;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const styles = stylex.create({
+  root: {
+    display: "inline-flex",
+    flexDirection: "column",
+    gap: 4,
+    minWidth: 0,
+  },
+  fullWidth: { display: "flex", width: "100%" },
+  label: {
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.8125rem",
+    fontWeight: 500,
+    lineHeight: 1.4,
+    color: "var(--hb-color-text-primary)",
+  },
+  labelError: { color: "var(--hb-color-danger)" },
+  container: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    boxSizing: "border-box",
+    width: "100%",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: {
+      default: "var(--hb-color-border)",
+      ":focus-within": "var(--hb-color-accent)",
+    },
+    borderRadius: 8,
+    backgroundColor: "var(--hb-color-surface)",
+    transition: "border-color 0.15s",
+  },
+  containerError: { borderColor: "var(--hb-color-danger)" },
+  medium: { paddingBlock: 8, paddingInline: 12 },
+  small: { paddingBlock: 5, paddingInline: 10 },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    borderWidth: 0,
+    borderStyle: "none",
+    outline: "none",
+    padding: 0,
+    margin: 0,
+    backgroundColor: "transparent",
+    color: "var(--hb-color-text-primary)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    lineHeight: 1.5,
+    appearance: "none",
+    "::placeholder": { color: "var(--hb-color-text-disabled)" },
+  },
+  textarea: {
+    resize: "none",
+    fieldSizing: "content",
+  },
+  helper: {
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.75rem",
+    lineHeight: 1.4,
+    color: "var(--hb-color-text-secondary)",
+  },
+  helperError: { color: "var(--hb-color-danger)" },
+});
+
+const cx = (...names: (string | undefined)[]): string | undefined =>
+  names.filter(Boolean).join(" ") || undefined;
+
+export const TextField = ({
+  label,
+  helperText,
+  error = false,
+  size = "medium",
+  fullWidth = false,
+  multiline = false,
+  rows,
+  minRows,
+  maxRows,
+  slotProps,
+  InputProps,
+  inputProps,
+  // Consumed (kept out of the input props); the top label has no shrink state.
+  InputLabelProps: _InputLabelProps,
+  id,
+  required,
+  disabled,
+  className,
+  style,
+  // `input`/`textarea` are void-ish; never forward children onto them.
+  children: _children,
+  ...rest
+}: TextFieldProps) => {
+  const reactId = useId();
+  const inputId = id ?? reactId;
+
+  const container = { ...InputProps, ...slotProps?.input };
+  const startAdornment = container.startAdornment;
+  const endAdornment = container.endAdornment;
+
+  const rootSx = stylex.props(styles.root, fullWidth && styles.fullWidth);
+  const containerSx = stylex.props(
+    styles.container,
+    size === "small" ? styles.small : styles.medium,
+    error && styles.containerError,
+  );
+  const inputSx = stylex.props(styles.input, multiline && styles.textarea);
+  const labelSx = stylex.props(styles.label, error && styles.labelError);
+  const helperSx = stylex.props(styles.helper, error && styles.helperError);
+
+  // Autocomplete supplies value/onChange/ref via inputProps; merge it last.
+  const nativeProps = { ...rest, ...inputProps, ...slotProps?.htmlInput };
+
+  const textareaStyle: CSSProperties | undefined = multiline
+    ? {
+        minHeight: minRows != null ? `${minRows * 1.5}em` : undefined,
+        maxHeight: maxRows != null ? `${maxRows * 1.5}em` : undefined,
+      }
+    : undefined;
+
+  return (
+    <div
+      className={cx(rootSx.className, className)}
+      style={{ ...rootSx.style, ...style }}
+    >
+      {label != null && (
+        <label htmlFor={inputId} className={labelSx.className} style={labelSx.style}>
+          {label}
+          {required ? " *" : ""}
+        </label>
+      )}
+      <div
+        ref={container.ref}
+        className={cx(containerSx.className, container.className)}
+        style={{ ...containerSx.style, ...container.style }}
+        data-disabled={disabled || undefined}
+      >
+        {startAdornment}
+        {multiline ? (
+          <textarea
+            id={inputId}
+            required={required}
+            disabled={disabled}
+            rows={rows ?? minRows}
+            {...(nativeProps as InputHTMLAttributes<HTMLTextAreaElement>)}
+            className={inputSx.className}
+            style={{ ...inputSx.style, ...textareaStyle }}
+          />
+        ) : (
+          <input
+            id={inputId}
+            required={required}
+            disabled={disabled}
+            {...nativeProps}
+            className={inputSx.className}
+            style={inputSx.style}
+          />
+        )}
+        {endAdornment}
+      </div>
+      {helperText != null && (
+        <p className={helperSx.className} style={helperSx.style}>
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## What

Removes the `@mui/material` re-export for `TextField` and replaces it with a native implementation.

## Design

- **Top-aligned label** (Astryx style, text-primary for readability) — not MUI's floating notched label.
- **Bordered container** that turns accent on `:focus-within` and danger on `error`; scheme-aware surface.
- **helperText** below (error → danger), **start/end adornment** slots, **multiline** via a `field-sizing: content` textarea with `minRows`/`maxRows`.
- Accepts both the newer **slotProps** (`htmlInput` / `input` / `inputLabel`) and the legacy **InputProps / inputProps / InputLabelProps** that MUI Autocomplete's `renderInput` supplies — so the four autocomplete inputs keep working without the app importing MUI directly.

## Consumers (52 files, 71 uses)

- Codemodded `sx` → `style`; inner-input styling (`& .MuiInputBase-input`, `InputProps.sx`) → `slotProps.htmlInput.style`.
- The five **`select`-mode** TextFields → `Form.Control` + `Form.Label` + `Form.Select` (still MUI, via the earlier `Form.Option` decouple).
- Redundant overrides that matched the new defaults (14px font, label shrink) were dropped.

## ⚠️ Needs a visual pass

This is the widest input component. Worth eyeballing in the running app — especially the **4 Autocomplete inputs** (member pickers, wiki search, parent-issue) and the note/page-title inputs — since Autocomplete's input contract can't be fully exercised by unit tests.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 115 pass