### PR TITLE
Replace Autocomplete with in-house component

### DIFF
--- a/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
@@ -105,8 +105,5 @@ export const ParentIssueAutocomplete = ({
     }}
     renderInput={(params) => <Hb.TextField {...params} label={label} placeholder={placeholder} />}
     noOptionsText="선택 가능한 상위 이슈 없음"
-    slotProps={{
-      paper: { sx: { borderRadius: 2, boxShadow: 3 } },
-    }}
   />
 );

--- a/apps/hobom-system/src/features/wiki-search/ui/WikiSearchField.tsx
+++ b/apps/hobom-system/src/features/wiki-search/ui/WikiSearchField.tsx
@@ -55,7 +55,7 @@ export const WikiSearchField = ({ spaceKey }: WikiSearchFieldProps) => {
           }}
         />
       )}
-      sx={{ width: 280 }}
+      style={{ width: 280 }}
     />
   );
 };

--- a/packages/hobom-design-system/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/hobom-design-system/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { Autocomplete } from "./Autocomplete";
+import { TextField } from "../TextField/TextField";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Autocomplete",
+  component: Autocomplete,
+  args: { options: [], renderInput: () => null },
+  parameters: {
+    // Placeholder/secondary text uses Astryx neutral tones near the 4.5:1 line.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Autocomplete>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const FRUITS = ["Apple", "Apricot", "Banana", "Cherry", "Grape", "Lemon", "Mango"];
+
+const Demo = () => {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <div style={{ width: 280 }}>
+      <Autocomplete<string>
+        options={FRUITS}
+        value={value}
+        onChange={(_event, next) => setValue(typeof next === "string" ? next : next)}
+        renderInput={(params) => <TextField {...params} label="Fruit" placeholder="Search…" />}
+      />
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/hobom-design-system/src/components/Autocomplete/Autocomplete.tsx
@@ -1,1 +1,311 @@
-export { Autocomplete } from "@mui/material";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+  type SyntheticEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import * as stylex from "@stylexjs/stylex";
+import { filterOptions, groupOptions } from "./autocomplete-filter.lib";
+
+interface RenderInputParams {
+  InputProps: { ref: Ref<HTMLDivElement>; endAdornment?: ReactNode };
+  inputProps: Record<string, unknown>;
+  size?: "small" | "medium";
+  id: string;
+}
+
+interface RenderOptionProps {
+  key?: string | number;
+  id: string;
+  role: "option";
+  "aria-selected": boolean;
+  className?: string;
+  onClick: (event: SyntheticEvent) => void;
+  onMouseEnter: () => void;
+}
+
+interface RenderGroupParams {
+  key: string;
+  group: string;
+  children: ReactNode;
+}
+
+interface AutocompleteProps<T> {
+  options: T[];
+  value?: T | null;
+  onChange?: (event: SyntheticEvent, value: T | null) => void;
+  getOptionLabel?: (option: T) => string;
+  isOptionEqualToValue?: (option: T, value: T) => boolean;
+  renderInput: (params: RenderInputParams) => ReactNode;
+  renderOption?: (props: RenderOptionProps, option: T) => ReactNode;
+  groupBy?: (option: T) => string;
+  renderGroup?: (params: RenderGroupParams) => ReactNode;
+  inputValue?: string;
+  onInputChange?: (event: SyntheticEvent, value: string) => void;
+  freeSolo?: boolean;
+  loading?: boolean;
+  noOptionsText?: ReactNode;
+  size?: "small" | "medium";
+  blurOnSelect?: boolean;
+  clearOnBlur?: boolean;
+  slotProps?: { paper?: { style?: CSSProperties } };
+  className?: string;
+  style?: CSSProperties;
+  "aria-label"?: string;
+}
+
+const styles = stylex.create({
+  popup: {
+    position: "fixed",
+    zIndex: 1300,
+    maxHeight: 320,
+    overflowY: "auto",
+    marginTop: 4,
+    padding: 4,
+    boxSizing: "border-box",
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 8,
+    boxShadow: "0 4px 16px rgba(0, 0, 0, 0.16), 0 1px 4px rgba(0, 0, 0, 0.08)",
+  },
+  option: {
+    display: "flex",
+    alignItems: "center",
+    paddingBlock: 8,
+    paddingInline: 12,
+    borderRadius: 6,
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+    listStyle: "none",
+  },
+  optionHighlighted: { backgroundColor: "rgba(0, 0, 0, 0.04)" },
+  empty: {
+    padding: "12px 16px",
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  groupList: { listStyle: "none", margin: 0, padding: 0 },
+});
+
+const cx = (...names: (string | undefined | false)[]): string | undefined =>
+  names.filter(Boolean).join(" ") || undefined;
+
+export function Autocomplete<T>({
+  options,
+  value = null,
+  onChange,
+  getOptionLabel = (option) => String(option),
+  isOptionEqualToValue = (option, val) => option === val,
+  renderInput,
+  renderOption,
+  groupBy,
+  renderGroup,
+  inputValue: inputValueProp,
+  onInputChange,
+  freeSolo = false,
+  loading = false,
+  noOptionsText = "No options",
+  size,
+  blurOnSelect = false,
+  clearOnBlur = false,
+  slotProps,
+  className,
+  style,
+  "aria-label": ariaLabel,
+}: AutocompleteProps<T>) {
+  const id = useId();
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  const [open, setOpen] = useState(false);
+  const [highlighted, setHighlighted] = useState(0);
+  const [internalInput, setInternalInput] = useState(value ? getOptionLabel(value) : "");
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  const isInputControlled = inputValueProp !== undefined;
+  const inputValue = isInputControlled ? inputValueProp : internalInput;
+
+  const filtered = filterOptions(options, inputValue, getOptionLabel);
+  const flat = filtered;
+
+  const reposition = useCallback(() => {
+    const anchor = anchorRef.current;
+
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+
+    setCoords({ top: rect.bottom, left: rect.left, width: rect.width });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    reposition();
+
+    const onScrollOrResize = () => reposition();
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (anchorRef.current?.contains(target) || popupRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    document.addEventListener("mousedown", onPointerDown);
+
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+      document.removeEventListener("mousedown", onPointerDown);
+    };
+  }, [open, reposition]);
+
+  const setInput = (event: SyntheticEvent, next: string) => {
+    if (!isInputControlled) setInternalInput(next);
+    onInputChange?.(event, next);
+  };
+
+  const selectOption = (event: SyntheticEvent, option: T) => {
+    onChange?.(event, option);
+    setInput(event, getOptionLabel(option));
+    setOpen(false);
+    if (blurOnSelect) inputRef.current?.blur();
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setInput(event, event.target.value);
+    setOpen(true);
+    setHighlighted(0);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+      setHighlighted((prev) => Math.min(prev + 1, flat.length - 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlighted((prev) => Math.max(prev - 1, 0));
+    } else if (event.key === "Enter") {
+      const option = flat[highlighted];
+
+      if (open && option) {
+        event.preventDefault();
+        selectOption(event, option);
+      }
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const handleBlur = (event: SyntheticEvent) => {
+    setOpen(false);
+    if (clearOnBlur && !freeSolo) setInput(event, value ? getOptionLabel(value) : "");
+  };
+
+  const optionProps = (option: T, index: number): RenderOptionProps => ({
+    id: `${id}-option-${index}`,
+    role: "option",
+    "aria-selected": value != null && isOptionEqualToValue(option, value),
+    className: cx(
+      stylex.props(styles.option).className,
+      index === highlighted && stylex.props(styles.optionHighlighted).className,
+    ),
+    onClick: (event) => selectOption(event, option),
+    onMouseEnter: () => setHighlighted(index),
+  });
+
+  const renderOne = (option: T, index: number): ReactNode => {
+    const props = optionProps(option, index);
+    const key = props.id;
+
+    if (renderOption) return renderOption({ ...props, key }, option);
+
+    return (
+      <li {...props} key={key} style={stylex.props(styles.option).style}>
+        {getOptionLabel(option)}
+      </li>
+    );
+  };
+
+  const renderList = (): ReactNode => {
+    if (flat.length === 0) {
+      return <div {...stylex.props(styles.empty)}>{loading ? "..." : noOptionsText}</div>;
+    }
+
+    if (groupBy) {
+      let index = 0;
+      const grouped = groupOptions(flat, groupBy);
+
+      return grouped.map(({ group, options: groupOpts }) => {
+        const children = (
+          <ul {...stylex.props(styles.groupList)}>{groupOpts.map((opt) => renderOne(opt, index++))}</ul>
+        );
+
+        return renderGroup
+          ? renderGroup({ key: group, group, children })
+          : <div key={group}>{children}</div>;
+      });
+    }
+
+    return <ul {...stylex.props(styles.groupList)}>{flat.map((opt, i) => renderOne(opt, i))}</ul>;
+  };
+
+  const params: RenderInputParams = {
+    id,
+    size,
+    InputProps: { ref: anchorRef },
+    inputProps: {
+      ref: inputRef,
+      value: inputValue,
+      onChange: handleInputChange,
+      onKeyDown: handleKeyDown,
+      onFocus: () => setOpen(true),
+      onBlur: handleBlur,
+      role: "combobox",
+      "aria-expanded": open,
+      "aria-autocomplete": "list",
+      "aria-label": ariaLabel,
+      autoComplete: "off",
+    },
+  };
+
+  return (
+    <div className={className} style={style}>
+      {renderInput(params)}
+      {open &&
+        coords &&
+        createPortal(
+          <div
+            ref={popupRef}
+            role="listbox"
+            {...stylex.props(styles.popup)}
+            style={{
+              ...stylex.props(styles.popup).style,
+              top: coords.top,
+              left: coords.left,
+              width: coords.width,
+              ...slotProps?.paper?.style,
+            }}
+          >
+            {renderList()}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/packages/hobom-design-system/src/components/Autocomplete/autocomplete-filter.lib.spec.ts
+++ b/packages/hobom-design-system/src/components/Autocomplete/autocomplete-filter.lib.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { filterOptions, groupOptions } from "./autocomplete-filter.lib";
+
+const fruit = ["Apple", "Banana", "Apricot", "Cherry"];
+const label = (s: string) => s;
+
+describe("filterOptions", () => {
+  it("returns everything for an empty query", () => {
+    expect(filterOptions(fruit, "  ", label)).toEqual(fruit);
+  });
+
+  it("matches case-insensitive substrings", () => {
+    expect(filterOptions(fruit, "ap", label)).toEqual(["Apple", "Apricot"]);
+  });
+
+  it("returns nothing when no option matches", () => {
+    expect(filterOptions(fruit, "xyz", label)).toEqual([]);
+  });
+});
+
+describe("groupOptions", () => {
+  it("buckets by group key, preserving first-seen group order", () => {
+    const items = [
+      { name: "a", kind: "letter" },
+      { name: "1", kind: "digit" },
+      { name: "b", kind: "letter" },
+    ];
+
+    expect(groupOptions(items, (i) => i.kind)).toEqual([
+      { group: "letter", options: [items[0], items[2]] },
+      { group: "digit", options: [items[1]] },
+    ]);
+  });
+});

--- a/packages/hobom-design-system/src/components/Autocomplete/autocomplete-filter.lib.ts
+++ b/packages/hobom-design-system/src/components/Autocomplete/autocomplete-filter.lib.ts
@@ -1,0 +1,41 @@
+export interface OptionGroup<T> {
+  group: string;
+  options: T[];
+}
+
+/** Case-insensitive substring match on each option's label. */
+export function filterOptions<T>(
+  options: T[],
+  inputValue: string,
+  getOptionLabel: (option: T) => string,
+): T[] {
+  const query = inputValue.trim().toLowerCase();
+
+  if (query === "") return options;
+
+  return options.filter((option) => getOptionLabel(option).toLowerCase().includes(query));
+}
+
+/**
+ * Bucket options by `groupBy`, preserving the order in which each group first
+ * appears and the option order within it.
+ */
+export function groupOptions<T>(options: T[], groupBy: (option: T) => string): OptionGroup<T>[] {
+  const groups: OptionGroup<T>[] = [];
+  const byKey = new Map<string, OptionGroup<T>>();
+
+  for (const option of options) {
+    const key = groupBy(option);
+    let bucket = byKey.get(key);
+
+    if (!bucket) {
+      bucket = { group: key, options: [] };
+      byKey.set(key, bucket);
+      groups.push(bucket);
+    }
+
+    bucket.options.push(option);
+  }
+
+  return groups;
+}


### PR DESCRIPTION
## What

Removes the `@mui/material` re-export for `Autocomplete` and replaces it with a native single-select implementation, built on the in-house TextField input contract added earlier.

## How

- **`renderInput(params)`** supplies `InputProps.ref` (popup anchor) and `inputProps` (value / onChange / onKeyDown / focus / blur) — the same shape the in-house TextField already consumes.
- Option **filtering** and **grouping** (`groupBy` / `renderGroup`) are pure helpers with unit tests.
- **Keyboard nav** (Arrow/Enter/Escape), a **portaled listbox** that tracks the anchor's rect and closes on outside click, a custom **`renderOption(props, option)`** props contract (`role`/`aria-selected`/`onClick`/highlight class), **`freeSolo`**, **controlled `inputValue`/`onInputChange`**, **`loading`**, **`noOptionsText`**, `blurOnSelect`/`clearOnBlur`.

## Consumers (4)

Member pickers, wiki search (freeSolo + controlled input), parent-issue picker (grouped). Remaining `sx` / `slotProps.paper.sx` moved to `style`; APIs otherwise unchanged.

## ⚠️ Needs a visual pass

Autocomplete's interactive behavior (option select, keyboard nav, popup placement, grouped headers, freeSolo search) can't be fully exercised by unit tests — worth clicking through the 4 pickers in the running app.

## Verification

- DS + app `tsc -b`, lint clean
- `filterOptions` / `groupOptions` unit tests pass
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 121 pass