### PR TITLE
Replace Form and Radio with in-house components

### DIFF
--- a/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
+++ b/apps/hobom-system/src/entities/issue/ui/ParentIssueAutocomplete.tsx
@@ -72,10 +72,10 @@ export const ParentIssueAutocomplete = ({
       const config = ISSUE_KIND_REGISTRY[option.type];
 
       return (
-        <Hb.Form.Option
+        <li
           key={key}
           {...props}
-          sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.75 }}
+          style={{ display: "flex", alignItems: "center", gap: 12, paddingBlock: 6 }}
         >
           <config.Icon sx={{ fontSize: 16, color: config.color, flexShrink: 0 }} />
           <Hb.Text
@@ -100,7 +100,7 @@ export const ParentIssueAutocomplete = ({
           >
             {option.title}
           </Hb.Text>
-        </Hb.Form.Option>
+        </li>
       );
     }}
     renderInput={(params) => <Hb.TextField {...params} label={label} placeholder={placeholder} />}

--- a/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
+++ b/apps/hobom-system/src/features/create-issue/ui/CreateIssueDialog.tsx
@@ -73,7 +73,9 @@ export const CreateIssueDialog = ({
             gap: 16,
           }}
         >
-          <Hb.Form.Control size="small" sx={{ flex: 1 }}>
+          <Hb.Form.Control size="small" style={{
+            flex: 1
+          }}>
             <Hb.Form.Label>유형</Hb.Form.Label>
             <Hb.Form.Select
               value={fields.kind}
@@ -87,7 +89,9 @@ export const CreateIssueDialog = ({
               ))}
             </Hb.Form.Select>
           </Hb.Form.Control>
-          <Hb.Form.Control size="small" sx={{ flex: 1 }}>
+          <Hb.Form.Control size="small" style={{
+            flex: 1
+          }}>
             <Hb.Form.Label>우선순위</Hb.Form.Label>
             <Hb.Form.Select
               value={fields.priority}
@@ -109,7 +113,9 @@ export const CreateIssueDialog = ({
           }}
         >
           {activeSprints.length > 0 && (
-            <Hb.Form.Control size="small" sx={{ flex: 1 }}>
+            <Hb.Form.Control size="small" style={{
+              flex: 1
+            }}>
               <Hb.Form.Label>스프린트 (선택)</Hb.Form.Label>
               <Hb.Form.Select
                 value={fields.sprint}

--- a/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LogSearchSection.tsx
@@ -79,7 +79,9 @@ export const LogSearchSection = () => {
             flexWrap: "wrap",
           }}
         >
-          <Hb.Form.Control size="small" sx={{ minWidth: 130 }}>
+          <Hb.Form.Control size="small" style={{
+            minWidth: 130
+          }}>
             <Hb.Form.Label>서비스</Hb.Form.Label>
             <Hb.Form.Select
               label="서비스"
@@ -94,7 +96,9 @@ export const LogSearchSection = () => {
             </Hb.Form.Select>
           </Hb.Form.Control>
 
-          <Hb.Form.Control size="small" sx={{ minWidth: 120 }}>
+          <Hb.Form.Control size="small" style={{
+            minWidth: 120
+          }}>
             <Hb.Form.Label>Method</Hb.Form.Label>
             <Hb.Form.Select
               label="Method"

--- a/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
+++ b/apps/hobom-system/src/features/error-monitoring/ui/ErrorEventFilter.tsx
@@ -57,7 +57,9 @@ export const ErrorEventFilter = ({
         marginBottom: 16,
       }}
     >
-      <Hb.Form.Control size="small" sx={{ minWidth: 160 }}>
+      <Hb.Form.Control size="small" style={{
+        minWidth: 160
+      }}>
         <Hb.Form.Label>에러 타입</Hb.Form.Label>
         <Hb.Form.Select
           label="에러 타입"

--- a/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
+++ b/apps/hobom-system/src/features/issue-detail/ui/IssueMetaSection.tsx
@@ -283,21 +283,11 @@ export const IssueMetaSection = () => {
             value={issue.sprint ?? ""}
             displayEmpty
             onChange={(e) => updateField({ sprint: e.target.value || undefined })}
-            sx={{ fontSize: 13, "& .MuiSelect-select": { py: 0.75 } }}
+            style={{ fontSize: 13 }}
           >
-            <Hb.Form.Option value="" sx={{ fontSize: 13 }}>
-              <Hb.Text
-                variant="body2"
-                style={{
-                  fontSize: 13,
-                  color: "var(--hb-color-text-disabled)",
-                }}
-              >
-                없음
-              </Hb.Text>
-            </Hb.Form.Option>
+            <Hb.Form.Option value="">없음</Hb.Form.Option>
             {activeSprints.map((s) => (
-              <Hb.Form.Option key={s.id} value={s.id} sx={{ fontSize: 13 }}>
+              <Hb.Form.Option key={s.id} value={s.id}>
                 {s.name}
               </Hb.Form.Option>
             ))}

--- a/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/IssueListTable.tsx
@@ -88,7 +88,9 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
           alignItems: "center",
         }}
       >
-        <Hb.Form.Control size="small" sx={{ minWidth: 120 }}>
+        <Hb.Form.Control size="small" style={{
+          minWidth: 120
+        }}>
           <Hb.Form.Label shrink>상태</Hb.Form.Label>
           <Hb.Form.Select
             value={statusFilter}
@@ -104,7 +106,9 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
-        <Hb.Form.Control size="small" sx={{ minWidth: 120 }}>
+        <Hb.Form.Control size="small" style={{
+          minWidth: 120
+        }}>
           <Hb.Form.Label shrink>우선순위</Hb.Form.Label>
           <Hb.Form.Select
             value={priorityFilter}
@@ -120,7 +124,9 @@ export const IssueListTable = ({ projectId, onIssueClick }: IssueListTableProps)
             ))}
           </Hb.Form.Select>
         </Hb.Form.Control>
-        <Hb.Form.Control size="small" sx={{ minWidth: 120 }}>
+        <Hb.Form.Control size="small" style={{
+          minWidth: 120
+        }}>
           <Hb.Form.Label shrink>유형</Hb.Form.Label>
           <Hb.Form.Select
             value={typeFilter}

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -92,7 +92,7 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
         <Hb.Box
           style={{
             display: "flex",
-            alignItems: "center",
+            alignItems: "flex-end",
             gap: 12,
             marginBottom: 16,
           }}

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -98,7 +98,9 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
           }}
         >
           {filters.epics.length > 0 && (
-            <Hb.Form.Control size="small" sx={{ minWidth: 200 }}>
+            <Hb.Form.Control size="small" style={{
+              minWidth: 200
+            }}>
               <Hb.Form.Label shrink>에픽 필터</Hb.Form.Label>
               <Hb.Form.Select
                 value={filters.epicFilter ?? ""}

--- a/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
+++ b/apps/hobom-system/src/features/note/ui/ReminderPickerPopover.tsx
@@ -56,7 +56,7 @@ export const ReminderPickerPopover = ({ anchorEl, onClose, onSet }: ReminderPick
           onChange={(e) => setRecurrence(e.target.value as NoteRecurrence)}
           size="small"
           fullWidth
-          sx={{ mt: 1 }}
+          style={{ marginTop: 8 }}
         >
           {RECURRENCE_OPTIONS.map((opt) => (
             <Hb.Form.Option key={opt.value} value={opt.value}>

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamQuestionCard.tsx
@@ -103,19 +103,19 @@ const FillBlankInput = ({
 
 const choiceBorderColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
   if (revealed) {
-    if (isAnswer) return "success.main";
-    if (selected) return "error.main";
+    if (isAnswer) return "var(--hb-color-success)";
+    if (selected) return "var(--hb-color-danger)";
 
-    return "divider";
+    return "var(--hb-color-border)";
   }
 
-  return selected ? "primary.main" : "divider";
+  return selected ? "var(--hb-color-accent)" : "var(--hb-color-border)";
 };
 
 const choiceBgColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
   if (!revealed) return "transparent";
-  if (isAnswer) return "success.50";
-  if (selected) return "error.50";
+  if (isAnswer) return "var(--hb-color-success-subtle)";
+  if (selected) return "color-mix(in srgb, var(--hb-color-danger) 12%, transparent)";
 
   return "transparent";
 };
@@ -176,15 +176,16 @@ const MultipleChoiceInput = ({
               )}
             </Hb.Stack>
           }
-          sx={{
-            mb: 0.5,
-            mx: 0,
-            px: 1.5,
-            py: 0.5,
-            borderRadius: 1,
-            border: 1,
+          style={{
+            marginBottom: 4,
+            marginInline: 0,
+            paddingInline: 12,
+            paddingBlock: 4,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderStyle: "solid",
             borderColor: choiceBorderColor(revealed, isAnswer, selected),
-            bgcolor: choiceBgColor(revealed, isAnswer, selected),
+            backgroundColor: choiceBgColor(revealed, isAnswer, selected),
           }}
         />
       );

--- a/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
+++ b/apps/hobom-system/src/features/privacy-law-study/ui/QuizCard.tsx
@@ -103,19 +103,19 @@ const FillBlankInput = ({
 
 const choiceBorderColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
   if (revealed) {
-    if (isAnswer) return "success.main";
-    if (selected) return "error.main";
+    if (isAnswer) return "var(--hb-color-success)";
+    if (selected) return "var(--hb-color-danger)";
 
-    return "divider";
+    return "var(--hb-color-border)";
   }
 
-  return selected ? "primary.main" : "divider";
+  return selected ? "var(--hb-color-accent)" : "var(--hb-color-border)";
 };
 
 const choiceBgColor = (revealed: boolean, isAnswer: boolean, selected: boolean): string => {
   if (!revealed) return "transparent";
-  if (isAnswer) return "success.50";
-  if (selected) return "error.50";
+  if (isAnswer) return "var(--hb-color-success-subtle)";
+  if (selected) return "color-mix(in srgb, var(--hb-color-danger) 12%, transparent)";
 
   return "transparent";
 };
@@ -176,15 +176,16 @@ const MultipleChoiceInput = ({
               )}
             </Hb.Stack>
           }
-          sx={{
-            mb: 0.5,
-            mx: 0,
-            px: 1.5,
-            py: 0.5,
-            borderRadius: 1,
-            border: 1,
+          style={{
+            marginBottom: 4,
+            marginInline: 0,
+            paddingInline: 12,
+            paddingBlock: 4,
+            borderRadius: 8,
+            borderWidth: 1,
+            borderStyle: "solid",
             borderColor: choiceBorderColor(revealed, isAnswer, selected),
-            bgcolor: choiceBgColor(revealed, isAnswer, selected),
+            backgroundColor: choiceBgColor(revealed, isAnswer, selected),
           }}
         />
       );

--- a/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/ProjectDashboardContent.tsx
@@ -44,7 +44,9 @@ export const ProjectDashboardContent = () => {
         <Hb.Text variant="h6" fontWeight={700}>
           스프린트 대시보드
         </Hb.Text>
-        <Hb.Form.Control size="small" sx={{ minWidth: 200 }}>
+        <Hb.Form.Control size="small" style={{
+          minWidth: 200
+        }}>
           <Hb.Form.Label>스프린트 선택</Hb.Form.Label>
           <Hb.Form.Select
             value={selectedSprintId}

--- a/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/AddMemberDialog.tsx
@@ -82,7 +82,9 @@ export const AddMemberDialog = ({
           )}
           noOptionsText="검색 결과가 없어요"
         />
-        <Hb.Form.Control size="small" fullWidth sx={{ mt: 2 }}>
+        <Hb.Form.Control size="small" fullWidth style={{
+          marginTop: 16
+        }}>
           <Hb.Form.Label>역할</Hb.Form.Label>
           <Hb.Form.Select value={role} label="역할" onChange={(e) => setRole(e.target.value)}>
             {Object.entries(ROLE_LABEL).map(([k, label]) => (

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationSpeedDial.tsx
@@ -1,4 +1,4 @@
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import { Add } from "hobom-design-system/icons";
 import { Bom } from "hobom-utils";
 import {
@@ -39,7 +39,7 @@ export const MenuRecommendationSpeedDial = () => {
   const menuRecommendationHandler = useAddMenuRecommendation();
   const { onOpen, onClose } = useBottomSheetCTA();
   const { openWarnToast } = useToast();
-  const { register, getValues, reset } = useForm<AddMenuRecommendationInput>({
+  const { register, control, getValues, reset } = useForm<AddMenuRecommendationInput>({
     mode: "onChange",
     defaultValues: {
       name: "",
@@ -78,42 +78,60 @@ export const MenuRecommendationSpeedDial = () => {
             placeholder="예: 김치찌개"
             {...register("name")}
           />
-          <Hb.Form.Select
-            fullWidth
-            size="small"
-            defaultValue={MenuKindModel.KOREAN}
-            {...register("menuKind")}
-          >
-            {Bom.values(MenuKindModel).map((item) => (
-              <Hb.Form.Option key={item} value={item}>
-                {MENU_KIND_LABEL[item] ?? item}
-              </Hb.Form.Option>
-            ))}
-          </Hb.Form.Select>
-          <Hb.Form.Select
-            fullWidth
-            size="small"
-            defaultValue={TimeOfMealModel.LUNCH}
-            {...register("timeOfMeal")}
-          >
-            {Bom.values(TimeOfMealModel).map((item) => (
-              <Hb.Form.Option key={item} value={item}>
-                {TIME_LABEL[item] ?? item}
-              </Hb.Form.Option>
-            ))}
-          </Hb.Form.Select>
-          <Hb.Form.Select
-            fullWidth
-            size="small"
-            defaultValue={FoodTypeModel.MEAL}
-            {...register("foodType")}
-          >
-            {Bom.values(FoodTypeModel).map((item) => (
-              <Hb.Form.Option key={item} value={item}>
-                {FOOD_TYPE_LABEL[item] ?? item}
-              </Hb.Form.Option>
-            ))}
-          </Hb.Form.Select>
+          <Controller
+            name="menuKind"
+            control={control}
+            render={({ field }) => (
+              <Hb.Form.Select
+                fullWidth
+                size="small"
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              >
+                {Bom.values(MenuKindModel).map((item) => (
+                  <Hb.Form.Option key={item} value={item}>
+                    {MENU_KIND_LABEL[item] ?? item}
+                  </Hb.Form.Option>
+                ))}
+              </Hb.Form.Select>
+            )}
+          />
+          <Controller
+            name="timeOfMeal"
+            control={control}
+            render={({ field }) => (
+              <Hb.Form.Select
+                fullWidth
+                size="small"
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              >
+                {Bom.values(TimeOfMealModel).map((item) => (
+                  <Hb.Form.Option key={item} value={item}>
+                    {TIME_LABEL[item] ?? item}
+                  </Hb.Form.Option>
+                ))}
+              </Hb.Form.Select>
+            )}
+          />
+          <Controller
+            name="foodType"
+            control={control}
+            render={({ field }) => (
+              <Hb.Form.Select
+                fullWidth
+                size="small"
+                value={field.value}
+                onChange={(e) => field.onChange(e.target.value)}
+              >
+                {Bom.values(FoodTypeModel).map((item) => (
+                  <Hb.Form.Option key={item} value={item}>
+                    {FOOD_TYPE_LABEL[item] ?? item}
+                  </Hb.Form.Option>
+                ))}
+              </Hb.Form.Select>
+            )}
+          />
         </Hb.Box>
       ),
       footer: (

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
@@ -6,7 +6,6 @@ import { authQueries } from "@/entities/auth";
 import type { FutureMessageSendSchemaType } from "@/entities/future-message";
 import { RoutesConfig } from "@/shared/config";
 import { Hb } from "@/shared/ui";
-import type { SelectChangeEvent } from "@/shared/ui";
 
 interface Props {
   onNextStep: () => void;
@@ -52,7 +51,7 @@ const Inner = ({ onNextStep }: Props) => {
         <Hb.Form.Select
           label="받는 사람"
           value={watch("recipientId")}
-          onChange={(evt: SelectChangeEvent) => {
+          onChange={(evt) => {
             setValue("recipientId", evt.target.value);
           }}
         >

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useSuspenseQuery, useDataLot } from "hobom-data";
 import { wikiPageQueries } from "@/entities/wiki-page";
 import { wikiLabelQueries, useAddPageLabel, useRemovePageLabel } from "@/entities/wiki-label";
@@ -10,6 +11,7 @@ interface PageLabelChipsProps {
 }
 
 export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsProps) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const dataLot = useDataLot();
   const { data } = useSuspenseQuery(wikiLabelQueries.list(spaceKey));
   const allLabels = data.items;
@@ -53,31 +55,28 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
         />
       ))}
       {availableLabels.length > 0 && (
-        <Hb.Form.Control
-          size="small"
-          style={{
-            minWidth: 100
-          }}
-        >
-          <Hb.Form.Select
-            value=""
-            onChange={(e) => {
-              if (e.target.value) {
-                addLabel.mutate(
-                  { spaceKey, pageId, labelId: e.target.value },
-                  { onSuccess: invalidatePageDetail },
-                );
-              }
-            }}
-            displayEmpty
-            renderValue={() => (
-              <Hb.Text variant="caption" color="text.disabled">
-                + 라벨
-              </Hb.Text>
-            )}
+        <>
+          <Hb.Chip
+            label="+ 라벨"
+            size="small"
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            style={{ fontSize: "0.75rem", cursor: "pointer" }}
+          />
+          <Hb.Menu.Root
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => setAnchorEl(null)}
           >
             {availableLabels.map((label) => (
-              <Hb.Form.Option key={label.id} value={label.id}>
+              <Hb.Menu.Item
+                key={label.id}
+                onClick={() =>
+                  addLabel.mutate(
+                    { spaceKey, pageId, labelId: label.id },
+                    { onSuccess: invalidatePageDetail },
+                  )
+                }
+              >
                 <Hb.Box
                   style={{
                     width: 10,
@@ -88,10 +87,10 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
                   }}
                 />
                 {label.name}
-              </Hb.Form.Option>
+              </Hb.Menu.Item>
             ))}
-          </Hb.Form.Select>
-        </Hb.Form.Control>
+          </Hb.Menu.Root>
+        </>
       )}
     </Hb.Box>
   );

--- a/packages/hobom-design-system/src/components/Form/Form.stories.tsx
+++ b/packages/hobom-design-system/src/components/Form/Form.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { Form } from "./Form";
+import { Radio } from "../Radio/Radio";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Form",
+  component: Form.Control,
+  parameters: {
+    // Helper text uses Astryx neutral secondary (#737373), a known muted pattern.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Form.Control>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const SelectDemo = () => {
+  const [value, setValue] = useState("apple");
+
+  return (
+    <Form.Control fullWidth>
+      <Form.Label>Fruit</Form.Label>
+      <Form.Select value={value} onChange={(e) => setValue(e.target.value)}>
+        <Form.Option value="apple">Apple</Form.Option>
+        <Form.Option value="banana">Banana</Form.Option>
+        <Form.Option value="cherry">Cherry</Form.Option>
+      </Form.Select>
+      <Form.Helper>Pick your favorite.</Form.Helper>
+    </Form.Control>
+  );
+};
+
+const RadioDemo = () => {
+  const [value, setValue] = useState("a");
+
+  return (
+    <Radio.Group value={value} onChange={(_e, v) => setValue(v)}>
+      {["a", "b", "c"].map((v) => (
+        <Form.ControlLabel key={v} value={v} control={<Radio.Root />} label={`Option ${v}`} />
+      ))}
+    </Radio.Group>
+  );
+};
+
+export const Select: Story = { render: () => <div style={{ width: 260 }}><SelectDemo /></div> };
+export const Radios: Story = { render: () => <RadioDemo /> };

--- a/packages/hobom-design-system/src/components/Form/Form.tsx
+++ b/packages/hobom-design-system/src/components/Form/Form.tsx
@@ -1,19 +1,243 @@
 import {
-  FormControl as MuiFormControl,
-  FormControlLabel as MuiFormControlLabel,
-  FormHelperText as MuiFormHelperText,
-  InputLabel as MuiInputLabel,
-  MenuItem as MuiMenuItem,
-  Select as MuiSelect,
-} from "@mui/material";
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+  useId,
+  type ChangeEvent,
+  type CSSProperties,
+  type FocusEvent,
+  type HTMLAttributes,
+  type LabelHTMLAttributes,
+  type OptionHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type SelectHTMLAttributes,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
+import { RadioGroupContext } from "../Radio/Radio";
 
-const Control = MuiFormControl;
-const ControlLabel = MuiFormControlLabel;
-const Helper = MuiFormHelperText;
-const Label = MuiInputLabel;
-const Select = MuiSelect;
-// Option for `Select` — the underlying control clones these to read `value`
-// and drive selection, so it stays MUI until Select itself is in-house.
-const Option = MuiMenuItem;
+type FieldSize = "small" | "medium";
 
-export const Form = { Control, ControlLabel, Helper, Label, Select, Option };
+interface FormControlContextValue {
+  size: FieldSize;
+  id: string;
+}
+
+const FormControlContext = createContext<FormControlContextValue>({ size: "medium", id: "" });
+
+const styles = stylex.create({
+  control: { display: "inline-flex", flexDirection: "column", gap: 4, minWidth: 0 },
+  fullWidth: { display: "flex", width: "100%" },
+  label: {
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.8125rem",
+    fontWeight: 500,
+    lineHeight: 1.4,
+    color: "var(--hb-color-text-primary)",
+  },
+  helper: {
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.75rem",
+    lineHeight: 1.4,
+    color: "var(--hb-color-text-secondary)",
+    margin: 0,
+  },
+  selectWrap: { position: "relative", display: "inline-flex", width: "100%" },
+  select: {
+    boxSizing: "border-box",
+    width: "100%",
+    appearance: "none",
+    paddingBlock: 8,
+    paddingLeft: 12,
+    paddingRight: 32,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: { default: "var(--hb-color-border)", ":focus": "var(--hb-color-accent)" },
+    borderRadius: 8,
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
+    fontSize: "0.875rem",
+    lineHeight: 1.5,
+    cursor: "pointer",
+    outline: "none",
+  },
+  selectSmall: { paddingBlock: 5, fontSize: "0.8125rem" },
+  chevron: {
+    position: "absolute",
+    right: 10,
+    top: "50%",
+    transform: "translateY(-50%)",
+    pointerEvents: "none",
+    color: "var(--hb-color-text-secondary)",
+    display: "inline-flex",
+  },
+  controlLabel: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    cursor: "pointer",
+    boxSizing: "border-box",
+  },
+  controlLabelDisabled: { cursor: "default", opacity: 0.6 },
+});
+
+const cx = (a: string | undefined, b: string | undefined): string | undefined =>
+  [a, b].filter(Boolean).join(" ") || undefined;
+
+interface ControlProps extends HTMLAttributes<HTMLDivElement> {
+  size?: FieldSize;
+  fullWidth?: boolean;
+  /** No-op kept for API compatibility. */
+  error?: boolean;
+}
+
+const Control = ({
+  size = "medium",
+  fullWidth = false,
+  error: _error,
+  className,
+  style,
+  children,
+  ...rest
+}: ControlProps) => {
+  const id = useId();
+  const sx = stylex.props(styles.control, fullWidth && styles.fullWidth);
+
+  return (
+    <FormControlContext.Provider value={{ size, id }}>
+      <div {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+        {children}
+      </div>
+    </FormControlContext.Provider>
+  );
+};
+
+interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  /** No-op kept for API compatibility (the label is always shown above). */
+  shrink?: boolean;
+}
+
+const Label = ({ shrink: _shrink, htmlFor, className, style, children, ...rest }: LabelProps) => {
+  const { id } = useContext(FormControlContext);
+  const sx = stylex.props(styles.label);
+
+  return (
+    <label
+      htmlFor={(htmlFor ?? id) || undefined}
+      {...rest}
+      className={cx(sx.className, className)}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </label>
+  );
+};
+
+const Helper = ({ className, style, children, ...rest }: HTMLAttributes<HTMLParagraphElement>) => {
+  const sx = stylex.props(styles.helper);
+
+  return (
+    <p {...rest} className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {children}
+    </p>
+  );
+};
+
+interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "size" | "onChange" | "onBlur"> {
+  /** No-op kept for API compatibility (the label sits above via `Form.Label`). */
+  label?: ReactNode;
+  /** No-op kept for API compatibility. */
+  displayEmpty?: boolean;
+  /** No-op kept for API compatibility (the select fills its control). */
+  fullWidth?: boolean;
+  size?: FieldSize;
+  /** Forwarded to the native `<select>` (e.g. a react-hook-form ref). */
+  ref?: Ref<HTMLSelectElement>;
+  // Loosened so a react-hook-form handler (which returns a Promise) is accepted.
+  onChange?: (event: ChangeEvent<HTMLSelectElement>) => unknown;
+  onBlur?: (event: FocusEvent<HTMLSelectElement>) => unknown;
+}
+
+const Select = ({
+  label: _label,
+  displayEmpty: _displayEmpty,
+  fullWidth: _fullWidth,
+  size: sizeProp,
+  id,
+  ref,
+  className,
+  style,
+  children,
+  ...rest
+}: SelectProps) => {
+  const { size: ctxSize, id: ctxId } = useContext(FormControlContext);
+  const size = sizeProp ?? ctxSize;
+  const sx = stylex.props(styles.select, size === "small" && styles.selectSmall);
+  const wrapSx = stylex.props(styles.selectWrap);
+  const chevronSx = stylex.props(styles.chevron);
+
+  return (
+    <span {...wrapSx}>
+      <select
+        ref={ref}
+        id={(id ?? ctxId) || undefined}
+        {...rest}
+        className={cx(sx.className, className)}
+        style={{ ...sx.style, ...style }}
+      >
+        {children}
+      </select>
+      <span {...chevronSx}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M7 10l5 5 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      </span>
+    </span>
+  );
+};
+
+const Option = (props: OptionHTMLAttributes<HTMLOptionElement>) => <option {...props} />;
+
+interface ControlLabelProps {
+  value?: string;
+  label?: ReactNode;
+  control: ReactElement<{
+    checked?: boolean;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    name?: string;
+    value?: string;
+    disabled?: boolean;
+  }>;
+  disabled?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const ControlLabel = ({ value, label, control, disabled, className, style }: ControlLabelProps) => {
+  const group = useContext(RadioGroupContext);
+  const checked = group ? group.value === value : undefined;
+  const sx = stylex.props(styles.controlLabel, disabled && styles.controlLabelDisabled);
+
+  const controlEl = isValidElement(control)
+    ? cloneElement(control, {
+        checked,
+        disabled,
+        name: group?.name,
+        value,
+        onChange:
+          group && value !== undefined ? (event) => group.onChange(event, value) : undefined,
+      })
+    : control;
+
+  return (
+    <label className={cx(sx.className, className)} style={{ ...sx.style, ...style }}>
+      {controlEl}
+      {label}
+    </label>
+  );
+};
+
+export const Form = { Control, Label, Helper, Select, Option, ControlLabel };

--- a/packages/hobom-design-system/src/components/Form/Form.tsx
+++ b/packages/hobom-design-system/src/components/Form/Form.tsx
@@ -1,20 +1,23 @@
 import {
+  Children,
   cloneElement,
   createContext,
   isValidElement,
+  useCallback,
   useContext,
+  useEffect,
   useId,
+  useRef,
+  useState,
   type ChangeEvent,
   type CSSProperties,
-  type FocusEvent,
   type HTMLAttributes,
+  type KeyboardEvent,
   type LabelHTMLAttributes,
-  type OptionHTMLAttributes,
   type ReactElement,
   type ReactNode,
-  type Ref,
-  type SelectHTMLAttributes,
 } from "react";
+import { createPortal } from "react-dom";
 import * as stylex from "@stylexjs/stylex";
 import { RadioGroupContext } from "../Radio/Radio";
 
@@ -44,35 +47,76 @@ const styles = stylex.create({
     color: "var(--hb-color-text-secondary)",
     margin: 0,
   },
-  selectWrap: { position: "relative", display: "inline-flex", width: "100%" },
-  select: {
+  trigger: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
     boxSizing: "border-box",
     width: "100%",
-    appearance: "none",
     paddingBlock: 8,
     paddingLeft: 12,
-    paddingRight: 32,
+    paddingRight: 10,
     borderWidth: 1,
     borderStyle: "solid",
-    borderColor: { default: "var(--hb-color-border)", ":focus": "var(--hb-color-accent)" },
+    borderColor: {
+      default: "var(--hb-color-border)",
+      ":focus-visible": "var(--hb-color-accent)",
+    },
     borderRadius: 8,
     backgroundColor: "var(--hb-color-surface)",
     color: "var(--hb-color-text-primary)",
     fontFamily: "'Inter', 'Roboto', 'Helvetica', 'Arial', sans-serif",
     fontSize: "0.875rem",
     lineHeight: 1.5,
+    textAlign: "left",
     cursor: "pointer",
+    appearance: "none",
     outline: "none",
   },
-  selectSmall: { paddingBlock: 5, fontSize: "0.8125rem" },
-  chevron: {
-    position: "absolute",
-    right: 10,
-    top: "50%",
-    transform: "translateY(-50%)",
-    pointerEvents: "none",
-    color: "var(--hb-color-text-secondary)",
-    display: "inline-flex",
+  triggerSmall: { paddingBlock: 5, fontSize: "0.8125rem" },
+  triggerDisabled: { cursor: "default", opacity: 0.6, pointerEvents: "none" },
+  triggerValue: {
+    flex: 1,
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  placeholder: { color: "var(--hb-color-text-disabled)" },
+  chevron: { flexShrink: 0, display: "inline-flex", color: "var(--hb-color-text-secondary)" },
+  listbox: {
+    position: "fixed",
+    zIndex: 1300,
+    listStyle: "none",
+    margin: 0,
+    marginTop: 4,
+    padding: 4,
+    maxHeight: 320,
+    overflowY: "auto",
+    boxSizing: "border-box",
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 8,
+    boxShadow: "0 4px 16px rgba(0, 0, 0, 0.16), 0 1px 4px rgba(0, 0, 0, 0.08)",
+  },
+  option: {
+    display: "flex",
+    alignItems: "center",
+    paddingBlock: 8,
+    paddingInline: 12,
+    borderRadius: 6,
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  },
+  optionHighlighted: { backgroundColor: "rgba(0, 0, 0, 0.04)" },
+  optionSelected: {
+    backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
+    fontWeight: 500,
   },
   controlLabel: {
     display: "inline-flex",
@@ -84,8 +128,16 @@ const styles = stylex.create({
   controlLabelDisabled: { cursor: "default", opacity: 0.6 },
 });
 
-const cx = (a: string | undefined, b: string | undefined): string | undefined =>
-  [a, b].filter(Boolean).join(" ") || undefined;
+const cx = (...names: (string | undefined | false)[]): string | undefined =>
+  names.filter(Boolean).join(" ") || undefined;
+
+const Chevron = () => (
+  <span {...stylex.props(styles.chevron)}>
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M7 10l5 5 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  </span>
+);
 
 interface ControlProps extends HTMLAttributes<HTMLDivElement> {
   size?: FieldSize;
@@ -146,60 +198,228 @@ const Helper = ({ className, style, children, ...rest }: HTMLAttributes<HTMLPara
   );
 };
 
-interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "size" | "onChange" | "onBlur"> {
+interface OptionProps {
+  value?: string;
+  disabled?: boolean;
+  children?: ReactNode;
+}
+
+/** Marker read by `Select`; never rendered on its own. */
+const Option = (_props: OptionProps): null => null;
+
+interface SelectChangeShim {
+  target: { value: string };
+}
+
+interface SelectProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (event: SelectChangeShim, value: string) => void;
   /** No-op kept for API compatibility (the label sits above via `Form.Label`). */
   label?: ReactNode;
-  /** No-op kept for API compatibility. */
+  /** No-op kept for API compatibility (an empty-value option acts as placeholder). */
   displayEmpty?: boolean;
   /** No-op kept for API compatibility (the select fills its control). */
   fullWidth?: boolean;
+  placeholder?: ReactNode;
   size?: FieldSize;
-  /** Forwarded to the native `<select>` (e.g. a react-hook-form ref). */
-  ref?: Ref<HTMLSelectElement>;
-  // Loosened so a react-hook-form handler (which returns a Promise) is accepted.
-  onChange?: (event: ChangeEvent<HTMLSelectElement>) => unknown;
-  onBlur?: (event: FocusEvent<HTMLSelectElement>) => unknown;
+  disabled?: boolean;
+  id?: string;
+  name?: string;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+interface ExtractedOption {
+  value: string;
+  label: ReactNode;
+  disabled: boolean;
 }
 
 const Select = ({
+  value,
+  defaultValue,
+  onChange,
   label: _label,
   displayEmpty: _displayEmpty,
   fullWidth: _fullWidth,
+  placeholder,
   size: sizeProp,
+  disabled = false,
   id,
-  ref,
+  name: _name,
   className,
   style,
   children,
-  ...rest
 }: SelectProps) => {
   const { size: ctxSize, id: ctxId } = useContext(FormControlContext);
   const size = sizeProp ?? ctxSize;
-  const sx = stylex.props(styles.select, size === "small" && styles.selectSmall);
-  const wrapSx = stylex.props(styles.selectWrap);
-  const chevronSx = stylex.props(styles.chevron);
+
+  const [internal, setInternal] = useState(defaultValue ?? "");
+  const isControlled = value !== undefined;
+  const current = isControlled ? value : internal;
+
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const options: ExtractedOption[] = [];
+
+  // Treat every element child as an option (they are `Form.Option`s). Matching
+  // by reference identity is fragile across module reloads, so read props
+  // directly rather than checking `child.type === Option`.
+  Children.forEach(children, (child) => {
+    if (isValidElement(child)) {
+      const props = (child as ReactElement<OptionProps>).props;
+
+      options.push({
+        value: String(props.value ?? ""),
+        label: props.children,
+        disabled: props.disabled ?? false,
+      });
+    }
+  });
+
+  const selectedIndex = options.findIndex((option) => option.value === String(current ?? ""));
+  const selected = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+
+  const reposition = useCallback(() => {
+    const anchor = triggerRef.current;
+
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+
+    setCoords({ top: rect.bottom, left: rect.left, width: rect.width });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    reposition();
+
+    const onScrollOrResize = () => reposition();
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (triggerRef.current?.contains(target) || listRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    document.addEventListener("mousedown", onPointerDown);
+
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+      document.removeEventListener("mousedown", onPointerDown);
+    };
+  }, [open, reposition]);
+
+  const openMenu = () => {
+    setHighlight(selectedIndex >= 0 ? selectedIndex : 0);
+    setOpen(true);
+  };
+
+  const commit = (option: ExtractedOption) => {
+    if (option.disabled) return;
+    if (!isControlled) setInternal(option.value);
+    onChange?.({ target: { value: option.value } }, option.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (!open) {
+      if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        openMenu();
+      }
+
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setHighlight((prev) => Math.min(prev + 1, options.length - 1));
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlight((prev) => Math.max(prev - 1, 0));
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      const option = options[highlight];
+
+      if (option) commit(option);
+    } else if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const triggerSx = stylex.props(
+    styles.trigger,
+    size === "small" && styles.triggerSmall,
+    disabled && styles.triggerDisabled,
+  );
 
   return (
-    <span {...wrapSx}>
-      <select
-        ref={ref}
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
         id={(id ?? ctxId) || undefined}
-        {...rest}
-        className={cx(sx.className, className)}
-        style={{ ...sx.style, ...style }}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => (open ? setOpen(false) : openMenu())}
+        onKeyDown={onKeyDown}
+        className={cx(triggerSx.className, className)}
+        style={{ ...triggerSx.style, ...style }}
       >
-        {children}
-      </select>
-      <span {...chevronSx}>
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M7 10l5 5 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-      </span>
-    </span>
+        <span {...stylex.props(styles.triggerValue, !selected && styles.placeholder)}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <Chevron />
+      </button>
+      {open &&
+        coords &&
+        createPortal(
+          <ul
+            ref={listRef}
+            role="listbox"
+            {...stylex.props(styles.listbox)}
+            style={{
+              ...stylex.props(styles.listbox).style,
+              top: coords.top,
+              left: coords.left,
+              width: coords.width,
+            }}
+          >
+            {options.map((option, index) => (
+              <li
+                key={option.value}
+                role="option"
+                aria-selected={option.value === String(current ?? "")}
+                {...stylex.props(
+                  styles.option,
+                  index === highlight && styles.optionHighlighted,
+                  option.value === String(current ?? "") && styles.optionSelected,
+                )}
+                onClick={() => commit(option)}
+                onMouseEnter={() => setHighlight(index)}
+              >
+                {option.label}
+              </li>
+            ))}
+          </ul>,
+          document.body,
+        )}
+    </>
   );
 };
-
-const Option = (props: OptionHTMLAttributes<HTMLOptionElement>) => <option {...props} />;
 
 interface ControlLabelProps {
   value?: string;

--- a/packages/hobom-design-system/src/components/Radio/Radio.tsx
+++ b/packages/hobom-design-system/src/components/Radio/Radio.tsx
@@ -1,6 +1,84 @@
-import { Radio as MuiRadio, RadioGroup as MuiRadioGroup } from "@mui/material";
+import {
+  createContext,
+  useId,
+  type ChangeEvent,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
 
-const Root = MuiRadio;
-const Group = MuiRadioGroup;
+export interface RadioGroupContextValue {
+  value: unknown;
+  onChange: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
+  name: string;
+}
+
+export const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
+
+const styles = stylex.create({
+  group: { display: "flex", flexDirection: "column" },
+  radio: {
+    accentColor: "var(--hb-color-accent)",
+    cursor: "pointer",
+    margin: 0,
+    flexShrink: 0,
+  },
+  medium: { width: 20, height: 20 },
+  small: { width: 16, height: 16 },
+  disabled: { cursor: "default" },
+});
+
+const cx = (a: string | undefined, b: string | undefined): string | undefined =>
+  [a, b].filter(Boolean).join(" ") || undefined;
+
+interface GroupProps extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  value?: unknown;
+  onChange?: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
+  name?: string;
+  children?: ReactNode;
+}
+
+const Group = ({ value, onChange, name, className, style, children, ...rest }: GroupProps) => {
+  const generatedName = useId();
+  const sx = stylex.props(styles.group);
+
+  return (
+    <RadioGroupContext.Provider
+      value={{ value, onChange: onChange ?? (() => {}), name: name ?? generatedName }}
+    >
+      <div
+        role="radiogroup"
+        {...rest}
+        className={cx(sx.className, className)}
+        style={{ ...sx.style, ...style }}
+      >
+        {children}
+      </div>
+    </RadioGroupContext.Provider>
+  );
+};
+
+interface RootProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "type"> {
+  size?: "small" | "medium";
+}
+
+const Root = ({ size = "medium", disabled = false, className, style, ...rest }: RootProps) => {
+  const sx = stylex.props(
+    styles.radio,
+    size === "small" ? styles.small : styles.medium,
+    disabled && styles.disabled,
+  );
+
+  return (
+    <input
+      type="radio"
+      disabled={disabled}
+      {...rest}
+      className={cx(sx.className, className)}
+      style={{ ...sx.style, ...style }}
+    />
+  );
+};
 
 export const Radio = { Root, Group };


### PR DESCRIPTION
## What

Removes the `@mui/material` re-exports for the **Form** and **Radio** families — the last of the Hb.* building-block components on MUI.

## Form

- **`Select`** → native `<select>` (options are text-only, so this is simpler and accessible for free): styled control + chevron, `size` context, `fullWidth`/`label`/`displayEmpty` accepted, and `ref` + loosened `onChange`/`onBlur` so a **react-hook-form** `{...register()}` spreads cleanly.
- **`Control`** generates an id (via context) so **`Label`** (`htmlFor`) and `Select` associate for an accessible name.
- **`Option`** → native `<option>`; **`Label` / `Helper`** are top-label styled elements; **`ControlLabel`** wires its `control` to the RadioGroup context (checked/onChange/name).

## Radio

- **`Group`** provides `{value, onChange, name}` context; **`Root`** is a styled native radio input (`accent-color`).

## Consumers

- `Form.Control` / `Select` / `ControlLabel` `sx` → `style`.
- Rich selects that needed custom option content moved to plain options (issue meta) or an in-house **Menu** (label picker).
- Select handlers drop the `SelectChangeEvent` type; radio choice colors map to `--hb-color-*` vars.

## Milestone

Every `Hb.*` building-block component is now MUI-free. Only the theme engine (`Infra` + `theme.ts`) and the composition patterns (AppShell, dialogs, skeletons) still import MUI.

## ⚠️ Needs a visual pass

`Form.Select` is now a native `<select>` (OS-rendered dropdown list). Worth checking the selects across the app look/behave acceptably, plus the two quiz/exam radio cards.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 123 pass