### PR TITLE
Move the simple patterns off MUI

### DIFF
--- a/packages/hobom-design-system/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/hobom-design-system/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "./Skeleton";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Skeleton",
+  component: Skeleton,
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, width: 280 }}>
+      <Skeleton variant="text" />
+      <Skeleton variant="text" width="60%" />
+      <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+        <Skeleton variant="circular" width={40} height={40} />
+        <Skeleton variant="rectangular" width="100%" height={56} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Skeleton/Skeleton.tsx
+++ b/packages/hobom-design-system/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,77 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+type SkeletonVariant = "text" | "circular" | "rectangular";
+
+interface SkeletonProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: SkeletonVariant;
+  width?: number | string;
+  height?: number | string;
+  /** `"pulse"` (default) or `false` to disable. `"wave"` falls back to pulse. */
+  animation?: "pulse" | "wave" | false;
+  children?: ReactNode;
+}
+
+const pulse = stylex.keyframes({
+  "0%": { opacity: 1 },
+  "50%": { opacity: 0.4 },
+  "100%": { opacity: 1 },
+});
+
+const styles = stylex.create({
+  root: {
+    display: "block",
+    boxSizing: "border-box",
+    backgroundColor: "color-mix(in srgb, var(--hb-color-text-primary) 11%, transparent)",
+  },
+  animated: {
+    animationName: pulse,
+    animationDuration: "1.5s",
+    animationIterationCount: "infinite",
+    animationTimingFunction: "ease-in-out",
+  },
+  text: { height: "1.2em", borderRadius: 4, transformOrigin: "0 55%", transform: "scale(1, 0.6)" },
+  circular: { borderRadius: "50%" },
+  rectangular: { borderRadius: 4 },
+  sizer: { visibility: "hidden", display: "block" },
+});
+
+const cx = (a: string | undefined, b: string | undefined): string | undefined =>
+  [a, b].filter(Boolean).join(" ") || undefined;
+
+const VARIANT_STYLE = {
+  text: styles.text,
+  circular: styles.circular,
+  rectangular: styles.rectangular,
+} as const;
+
+export const Skeleton = ({
+  variant = "text",
+  width,
+  height,
+  animation = "pulse",
+  className,
+  style,
+  children,
+  ...rest
+}: SkeletonProps) => {
+  const sx = stylex.props(styles.root, VARIANT_STYLE[variant], animation !== false && styles.animated);
+  const dynamic: CSSProperties = {};
+
+  if (width != null) dynamic.width = width;
+  if (height != null) dynamic.height = height;
+  // With children the skeleton sizes to them; without an explicit width, text
+  // spans the full line.
+  if (width == null && !children && variant !== "circular") dynamic.width = "100%";
+
+  return (
+    <span
+      {...rest}
+      aria-hidden="true"
+      className={cx(sx.className, className)}
+      style={{ ...sx.style, ...dynamic, ...style }}
+    >
+      {children && <span {...stylex.props(styles.sizer)}>{children}</span>}
+    </span>
+  );
+};

--- a/packages/hobom-design-system/src/components/Skeleton/index.ts
+++ b/packages/hobom-design-system/src/components/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from "./Skeleton";

--- a/packages/hobom-design-system/src/components/index.ts
+++ b/packages/hobom-design-system/src/components/index.ts
@@ -27,6 +27,7 @@ import { Drawer } from "./Drawer";
 import { ToggleButton } from "./ToggleButton";
 // Batch 2 — compound
 import { Progress } from "./Progress";
+import { Skeleton } from "./Skeleton";
 import { Menu } from "./Menu";
 import { List } from "./List";
 import { Tabs } from "./Tabs";
@@ -67,6 +68,7 @@ export const Hb = {
   ToggleButton,
   // Batch 2 — compound
   Progress,
+  Skeleton,
   Menu,
   List,
   Tabs,

--- a/packages/hobom-design-system/src/patterns/BottomSheetCTA/BottomSheetCTA.tsx
+++ b/packages/hobom-design-system/src/patterns/BottomSheetCTA/BottomSheetCTA.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { Box, Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Box } from "../../components/Box/Box";
+import { Dialog } from "../../components/Dialog/Dialog";
 
 interface Props {
   children: ReactNode;
@@ -8,28 +9,26 @@ interface Props {
   onClose: () => void;
 }
 
-export const BottomSheetCTA = ({ children, open, height, onClose }: Props) => {
-  return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth disableEscapeKeyDown={false}>
-      <Box display="flex" flexDirection="column" height={height ?? "auto"}>
-        {children}
-      </Box>
-    </Dialog>
-  );
-};
-
-BottomSheetCTA.Title = ({ children }: Pick<Props, "children">) => {
-  return (
-    <DialogTitle sx={{ display: "flex", width: "100%", justifyContent: "center", pb: 1 }}>
+export const BottomSheetCTA = ({ children, open, height, onClose }: Props) => (
+  <Dialog.Root open={open} onClose={onClose} size="sm">
+    <Box style={{ display: "flex", flexDirection: "column", height: height ?? "auto" }}>
       {children}
-    </DialogTitle>
-  );
-};
+    </Box>
+  </Dialog.Root>
+);
 
-BottomSheetCTA.Body = ({ children }: Pick<Props, "children">) => {
-  return <DialogContent sx={{ flex: 1, overflowY: "auto" }}>{children}</DialogContent>;
-};
+BottomSheetCTA.Title = ({ children }: Pick<Props, "children">) => (
+  <Dialog.Title
+    style={{ display: "flex", width: "100%", justifyContent: "center", paddingBottom: 8 }}
+  >
+    {children}
+  </Dialog.Title>
+);
 
-BottomSheetCTA.Footer = ({ children }: Pick<Props, "children">) => {
-  return <DialogActions sx={{ px: 3, py: 2 }}>{children}</DialogActions>;
-};
+BottomSheetCTA.Body = ({ children }: Pick<Props, "children">) => (
+  <Dialog.Content style={{ flex: 1, overflowY: "auto" }}>{children}</Dialog.Content>
+);
+
+BottomSheetCTA.Footer = ({ children }: Pick<Props, "children">) => (
+  <Dialog.Actions style={{ paddingInline: 24, paddingBlock: 16 }}>{children}</Dialog.Actions>
+);

--- a/packages/hobom-design-system/src/patterns/ConfirmDialog/ConfirmDialog.tsx
+++ b/packages/hobom-design-system/src/patterns/ConfirmDialog/ConfirmDialog.tsx
@@ -1,12 +1,7 @@
 import type { ReactNode } from "react";
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Typography,
-} from "@mui/material";
+import { Button } from "../../components/Button/Button";
+import { Dialog } from "../../components/Dialog/Dialog";
+import { Text } from "../../components/Text/Text";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -29,20 +24,24 @@ export const ConfirmDialog = ({
   onConfirm,
   isPending = false,
 }: ConfirmDialogProps) => (
-  <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
-    <DialogTitle>{title}</DialogTitle>
-    <DialogContent>
-      <Typography variant="body2" color="text.secondary" component="div">
+  <Dialog.Root open={open} onClose={onClose} size="xs">
+    <Dialog.Title>{title}</Dialog.Title>
+    <Dialog.Content>
+      <Text variant="body2" style={{ color: "var(--hb-color-text-secondary)" }}>
         {description}
-      </Typography>
-    </DialogContent>
-    <DialogActions sx={{ px: 3, pb: 2 }}>
-      <Button variant="outlined" color="inherit" onClick={onClose}>
+      </Text>
+    </Dialog.Content>
+    <Dialog.Actions style={{ paddingInline: 24, paddingBottom: 16 }}>
+      <Button variant="secondary" onClick={onClose}>
         취소
       </Button>
-      <Button variant="contained" color={confirmColor} onClick={onConfirm} loading={isPending}>
+      <Button
+        variant={confirmColor === "error" ? "danger" : "primary"}
+        onClick={onConfirm}
+        loading={isPending}
+      >
         {confirmLabel}
       </Button>
-    </DialogActions>
-  </Dialog>
+    </Dialog.Actions>
+  </Dialog.Root>
 );

--- a/packages/hobom-design-system/src/patterns/EmptyState/EmptyState.tsx
+++ b/packages/hobom-design-system/src/patterns/EmptyState/EmptyState.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box } from "../../components/Box/Box";
+import { Text } from "../../components/Text/Text";
 
 interface EmptyStateProps {
   icon?: ReactNode;
@@ -9,18 +10,19 @@ interface EmptyStateProps {
 /** 데이터가 없을 때 표시하는 빈 상태 컴포넌트. */
 export const EmptyState = ({ icon, message }: EmptyStateProps) => (
   <Box
-    sx={{
+    style={{
       display: "flex",
       flexDirection: "column",
       alignItems: "center",
       justifyContent: "center",
-      py: 6,
-      gap: 1,
+      paddingTop: 48,
+      paddingBottom: 48,
+      gap: 8,
     }}
   >
     {icon}
-    <Typography variant="body2" color="text.disabled" sx={{ fontSize: 13 }}>
+    <Text variant="body2" style={{ color: "var(--hb-color-text-disabled)", fontSize: 13 }}>
       {message}
-    </Typography>
+    </Text>
   </Box>
 );

--- a/packages/hobom-design-system/src/patterns/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/hobom-design-system/src/patterns/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,10 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { Box, Button, Paper, Typography } from "@mui/material";
-import { ReportProblemOutlined, RefreshOutlined } from "@mui/icons-material";
 import { useDataLot, type DataLot } from "hobom-data";
+import { ReportProblemOutlined, RefreshOutlined } from "../../icons";
+import { Box } from "../../components/Box/Box";
+import { Button } from "../../components/Button/Button";
+import { Paper } from "../../components/Paper/Paper";
+import { Text } from "../../components/Text/Text";
 
 interface Props {
   children: ReactNode;
@@ -56,9 +59,9 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
 
       return (
         <Box
-          sx={{
+          style={{
             width: "100%",
-            ...(inline ? { flex: 1, minHeight: 120, py: 4 } : { height: "100vh" }),
+            ...(inline ? { flex: 1, minHeight: 120, paddingBlock: 32 } : { height: "100vh" }),
             display: "flex",
             justifyContent: "center",
             alignItems: "center",
@@ -66,82 +69,74 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
         >
           <Paper
             variant="outlined"
-            sx={{
+            style={{
               textAlign: "center",
-              px: 5,
-              py: 4,
-              borderRadius: 2,
+              paddingInline: 40,
+              paddingBlock: 32,
+              borderRadius: 16,
               maxWidth: 420,
               width: "100%",
             }}
           >
             <Box
-              sx={{
+              style={{
                 width: 48,
                 height: 48,
                 borderRadius: "50%",
-                bgcolor: "error.main",
+                backgroundColor: "var(--hb-color-danger)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                mx: "auto",
-                mb: 2,
+                margin: "0 auto 16px",
               }}
             >
               <ReportProblemOutlined sx={{ color: "#fff", fontSize: 24 }} />
             </Box>
-            <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 0.5 }}>
+            <Text variant="subtitle1" fontWeight={700} style={{ marginBottom: 4 }}>
               문제가 발생했어요
-            </Typography>
-            <Typography
+            </Text>
+            <Text
               variant="body2"
-              color="text.secondary"
-              sx={{ fontSize: 13, lineHeight: 1.6 }}
+              style={{ color: "var(--hb-color-text-secondary)", fontSize: 13, lineHeight: 1.6 }}
             >
               요청을 처리하는 중 오류가 발생했어요.
               <br />
               잠시 후 다시 시도해 주세요.
-            </Typography>
+            </Text>
             {error?.message ? (
               <Box
-                sx={{
-                  mt: 2,
-                  p: 1.5,
-                  bgcolor: "grey.50",
-                  borderRadius: 1,
-                  border: "1px solid",
-                  borderColor: "divider",
+                style={{
+                  marginTop: 16,
+                  padding: 12,
+                  backgroundColor: "var(--hb-color-canvas)",
+                  borderRadius: 8,
+                  borderWidth: 1,
+                  borderStyle: "solid",
+                  borderColor: "var(--hb-color-border)",
                 }}
               >
-                <Typography
+                <Text
                   variant="caption"
-                  color="error"
-                  sx={{
+                  style={{
                     display: "block",
                     whiteSpace: "pre-wrap",
                     wordBreak: "break-all",
                     fontFamily: "'JetBrains Mono', monospace",
                     fontSize: 11,
                     textAlign: "left",
+                    color: "var(--hb-color-danger)",
                   }}
                 >
                   {error.message}
-                </Typography>
+                </Text>
               </Box>
             ) : null}
             <Button
-              variant="contained"
+              variant="primary"
               size="small"
               startIcon={<RefreshOutlined />}
               onClick={this.handleReset}
-              sx={{
-                mt: 2.5,
-                textTransform: "none",
-                fontWeight: 600,
-                borderRadius: 1.5,
-                boxShadow: "none",
-                "&:hover": { boxShadow: "none" },
-              }}
+              style={{ marginTop: 20, fontWeight: 600, borderRadius: 12 }}
             >
               다시 시도
             </Button>

--- a/packages/hobom-design-system/src/patterns/SkeletonCard/SkeletonCard.tsx
+++ b/packages/hobom-design-system/src/patterns/SkeletonCard/SkeletonCard.tsx
@@ -1,23 +1,18 @@
-import { Avatar, Box, Skeleton, Typography } from "@mui/material";
+import { Box } from "../../components/Box/Box";
+import { Skeleton } from "../../components/Skeleton/Skeleton";
 
-export const SkeletonCard = () => {
-  return (
-    <div>
-      <Box sx={{ display: "flex", alignItems: "center" }}>
-        <Box sx={{ margin: 1 }}>
-          <Skeleton variant="circular">
-            <Avatar />
-          </Skeleton>
-        </Box>
-        <Box sx={{ width: "100%" }}>
-          <Skeleton width="100%">
-            <Typography>.</Typography>
-          </Skeleton>
-        </Box>
+export const SkeletonCard = () => (
+  <div>
+    <Box style={{ display: "flex", alignItems: "center" }}>
+      <Box style={{ margin: 8 }}>
+        <Skeleton variant="circular" width={40} height={40} />
       </Box>
-      <Skeleton variant="rectangular" width="100%">
-        <div style={{ paddingTop: "57%" }} />
-      </Skeleton>
-    </div>
-  );
-};
+      <Box style={{ width: "100%" }}>
+        <Skeleton width="100%" />
+      </Box>
+    </Box>
+    <Skeleton variant="rectangular" width="100%">
+      <div style={{ paddingTop: "57%" }} />
+    </Skeleton>
+  </div>
+);

--- a/packages/hobom-design-system/src/patterns/SkeletonList/SkeletonList.tsx
+++ b/packages/hobom-design-system/src/patterns/SkeletonList/SkeletonList.tsx
@@ -1,9 +1,8 @@
-import { Box, Skeleton } from "@mui/material";
+import { Box } from "../../components/Box/Box";
+import { Skeleton } from "../../components/Skeleton/Skeleton";
 
-export const SkeletonList = () => {
-  return (
-    <Box sx={{ width: "100%" }}>
-      <Skeleton animation="wave" />
-    </Box>
-  );
-};
+export const SkeletonList = () => (
+  <Box style={{ width: "100%" }}>
+    <Skeleton animation="wave" />
+  </Box>
+);

--- a/packages/hobom-design-system/src/patterns/SuspenseLoader/SuspenseLoader.tsx
+++ b/packages/hobom-design-system/src/patterns/SuspenseLoader/SuspenseLoader.tsx
@@ -1,32 +1,37 @@
-import { Box, LinearProgress, Typography } from "@mui/material";
+import type { CSSProperties } from "react";
+import { Box } from "../../components/Box/Box";
+import { Progress } from "../../components/Progress/Progress";
+import { Text } from "../../components/Text/Text";
 
 interface Props {
   /** true이면 100vh 풀스크린, false이면 가장 가까운 positioned 부모 영역 정중앙 */
   fullScreen?: boolean;
 }
 
-export const SuspenseLoader = ({ fullScreen = false }: Props) => (
-  <Box
-    sx={{
-      ...(fullScreen ? { width: "100%", height: "100vh" } : { position: "absolute", inset: 0 }),
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "center",
-      alignItems: "center",
-      gap: 3,
-      bgcolor: "background.default",
-    }}
-  >
-    <Typography
-      variant="h4"
-      sx={{
-        fontWeight: 800,
-        color: "primary.main",
-        letterSpacing: "-0.02em",
+export const SuspenseLoader = ({ fullScreen = false }: Props) => {
+  const placement: CSSProperties = fullScreen
+    ? { width: "100%", height: "100vh" }
+    : { position: "absolute", inset: 0 };
+
+  return (
+    <Box
+      style={{
+        ...placement,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 24,
+        backgroundColor: "var(--hb-color-canvas)",
       }}
     >
-      HoBom
-    </Typography>
-    <LinearProgress sx={{ width: 240, borderRadius: 1 }} />
-  </Box>
-);
+      <Text
+        variant="h4"
+        style={{ fontWeight: 800, color: "var(--hb-color-accent)", letterSpacing: "-0.02em" }}
+      >
+        HoBom
+      </Text>
+      <Progress.Linear style={{ width: 240, borderRadius: 2 }} />
+    </Box>
+  );
+};


### PR DESCRIPTION
## What

Adds an in-house **Skeleton** and rebuilds the composition **patterns** on the in-house components, instead of importing MUI primitives (`Box`/`Typography`/`Skeleton`/`Dialog`/`LinearProgress`) directly.

## Skeleton (new)

Pulse placeholder with `variant` (text/circular/rectangular), `width`/`height`, and child-based sizing (children render invisibly to size the box). `aria-hidden`.

## Patterns migrated

- **EmptyState / SkeletonCard / SkeletonList / SuspenseLoader** → `Box` / `Text` / `Skeleton` / `Progress.Linear`.
- **ConfirmDialog / BottomSheetCTA** → the in-house `Dialog` compound (`confirmColor` maps to Button variants; sx → style).
- **ErrorBoundary** → `Box` / `Paper` / `Text` / `Button` + DS icons.

## Remaining MUI

Only **AppShell** and the theme engine (**Infra** + `theme.ts` + `styling.ts`) still import MUI.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS Storybook a11y (Chromium): 124 pass