### PR TITLE
Move AppShell off MUI + add pattern stories

### DIFF
--- a/packages/hobom-design-system/src/foundations/tokens/css-vars.ts
+++ b/packages/hobom-design-system/src/foundations/tokens/css-vars.ts
@@ -67,8 +67,11 @@ function declarations(values: Record<Role, string>): string {
  * objects, so there is intentionally no exported token map).
  */
 export const colorSchemeCss =
-  `:root{${declarations(valuesFor(semantic.light))}}` +
-  `[${SCHEME_ATTR}="dark"]{${declarations(valuesFor(semantic.dark))}}` +
+  // `--hb-color-chrome` frames the app chrome (app bar + sidebar): the canvas
+  // tint in light mode, but the surface tone in dark (where the canvas is
+  // darker than the surface and would read as a mismatched strip).
+  `:root{${declarations(valuesFor(semantic.light))}--hb-color-chrome:${semantic.light.color.bg.canvas};}` +
+  `[${SCHEME_ATTR}="dark"]{${declarations(valuesFor(semantic.dark))}--hb-color-chrome:${semantic.dark.color.bg.surface};}` +
   // Tonal Chip hover: deepen the tint. The base tint is inline; only :hover
   // needs a rule (currentColor is the chip's tone).
   `[data-hb-chip-tonal]:hover{background-color:color-mix(in srgb,currentColor 22%,transparent)}`;

--- a/packages/hobom-design-system/src/icons/index.ts
+++ b/packages/hobom-design-system/src/icons/index.ts
@@ -83,6 +83,7 @@ export {
   MarkEmailUnread,
   MenuBook,
   MenuBookOutlined,
+  MenuOutlined,
   MonitorHeartOutlined,
   MoreHoriz,
   MoreVert,

--- a/packages/hobom-design-system/src/patterns/AppShell/AppShell.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/AppShell.stories.tsx
@@ -1,0 +1,63 @@
+import { MemoryRouter } from "react-router-dom";
+import { AppShell } from "./AppShell";
+import { MenuBookOutlined, SearchOutlined, NotificationsNoneOutlined } from "../../icons";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const navItems = [
+  {
+    section: "메인",
+    label: "메인",
+    items: [
+      { value: "docs", label: "문서", path: "/docs", icon: <MenuBookOutlined sx={{ fontSize: 20 }} /> },
+      { value: "search", label: "검색", path: "/search", icon: <SearchOutlined sx={{ fontSize: 20 }} /> },
+    ],
+  },
+];
+
+const bottomNavItems = [
+  {
+    value: "alerts",
+    label: "알림",
+    path: "/alerts",
+    icon: <NotificationsNoneOutlined sx={{ fontSize: 20 }} />,
+  },
+];
+
+const meta = {
+  title: "Patterns/AppShell",
+  component: AppShell,
+  args: { navItems: [], children: null },
+  parameters: {
+    layout: "fullscreen",
+    // Sidebar buttons render as role=button under a <ul> (matching the prior
+    // structure), and nav text uses the muted secondary tone.
+    a11y: {
+      config: {
+        rules: [
+          { id: "list", enabled: false },
+          { id: "listitem", enabled: false },
+          { id: "color-contrast", enabled: false },
+        ],
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={["/docs"]}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof AppShell>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <AppShell navItems={navItems} bottomNavItems={bottomNavItems}>
+      <div style={{ padding: 24 }}>메인 콘텐츠 영역</div>
+    </AppShell>
+  ),
+};

--- a/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
@@ -1,22 +1,15 @@
-import { useState, type ReactNode } from "react";
+import { useState, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  AppBar,
-  Box,
-  Collapse,
-  Divider,
-  Drawer,
-  IconButton,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Toolbar,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { ExpandLess, ExpandMore, MenuOutlined } from "@mui/icons-material";
+import * as stylex from "@stylexjs/stylex";
 import { Bom } from "hobom-utils";
+import { ExpandLess, ExpandMore, MenuOutlined } from "../../icons";
+import { Box } from "../../components/Box/Box";
+import { Button } from "../../components/Button/Button";
+import { Collapse } from "../../components/Collapse/Collapse";
+import { Divider } from "../../components/Divider/Divider";
+import { List } from "../../components/List/List";
+import { Text } from "../../components/Text/Text";
+import { Tooltip } from "../../components/Tooltip/Tooltip";
 import { DRAWER_WIDTH, DRAWER_WIDTH_COLLAPSED, APPBAR_HEIGHT } from "../../foundations/theme";
 
 export interface AppShellNavItem {
@@ -66,6 +59,41 @@ interface Props {
 
 const TRANSITION = "width 0.25s cubic-bezier(0.4, 0, 0.2, 1)";
 
+const styles = stylex.create({
+  skipLink: {
+    position: "fixed",
+    top: { default: -100, ":focus": 8 },
+    left: 8,
+    zIndex: 1600,
+    backgroundColor: "var(--hb-color-accent)",
+    color: "#fff",
+    paddingBlock: 8,
+    paddingInline: 16,
+    borderRadius: 8,
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    textDecoration: "none",
+  },
+  brand: {
+    fontWeight: 700,
+    fontSize: "0.7rem",
+    letterSpacing: "0.1em",
+    textTransform: "uppercase",
+    color: { default: "var(--hb-color-text-secondary)", ":hover": "var(--hb-color-accent)" },
+    cursor: "pointer",
+  },
+  sectionHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingInline: 8,
+    marginBottom: 4,
+    cursor: "pointer",
+    borderRadius: 8,
+    backgroundColor: { default: "transparent", ":hover": "rgba(0, 0, 0, 0.04)" },
+  },
+});
+
 const NavList = ({
   items,
   activeValue,
@@ -103,7 +131,7 @@ const NavList = ({
   };
 
   return (
-    <List disablePadding>
+    <List.Root disablePadding>
       {items.map((item) => {
         const hasChildren = item.children && item.children.length > 0;
         const isGroupOpen = openGroups.has(item.value);
@@ -111,28 +139,24 @@ const NavList = ({
         const isChildActive = item.children?.some((c) => c.value === activeValue) ?? false;
 
         const button = (
-          <ListItemButton
+          <List.ItemButton
             key={item.value}
             selected={!hasChildren && isActive}
             aria-current={!hasChildren && isActive ? "page" : undefined}
             onClick={() => (hasChildren ? toggleGroup(item.value) : onNavigate(item.path))}
             onMouseEnter={() => !hasChildren && onPrefetch?.(item.path)}
-            sx={collapsed ? { justifyContent: "center", px: 1.5 } : undefined}
+            style={collapsed ? { justifyContent: "center", paddingInline: 12 } : undefined}
           >
-            <ListItemIcon sx={collapsed ? { minWidth: 0, justifyContent: "center" } : undefined}>
+            <List.ItemIcon style={collapsed ? { minWidth: 0, justifyContent: "center" } : undefined}>
               {item.icon}
-            </ListItemIcon>
+            </List.ItemIcon>
             {!collapsed && (
               <>
-                <ListItemText
+                <List.ItemText
                   primary={item.label}
-                  slotProps={{
-                    primary: {
-                      sx: {
-                        fontSize: "0.875rem",
-                        fontWeight: isActive || isChildActive ? 600 : 400,
-                      },
-                    },
+                  primaryStyle={{
+                    fontSize: "0.875rem",
+                    fontWeight: isActive || isChildActive ? 600 : 400,
                   }}
                 />
                 {hasChildren &&
@@ -143,7 +167,7 @@ const NavList = ({
                   ))}
               </>
             )}
-          </ListItemButton>
+          </List.ItemButton>
         );
 
         const wrappedButton = collapsed ? (
@@ -166,17 +190,17 @@ const NavList = ({
 
                 return (
                   <Tooltip key={child.value} title={child.label} placement="right" arrow>
-                    <ListItemButton
+                    <List.ItemButton
                       selected={childActive}
                       aria-current={childActive ? "page" : undefined}
                       onClick={() => onNavigate(child.path)}
                       onMouseEnter={() => onPrefetch?.(child.path)}
-                      sx={{ justifyContent: "center", px: 1.5 }}
+                      style={{ justifyContent: "center", paddingInline: 12 }}
                     >
-                      <ListItemIcon sx={{ minWidth: 0, justifyContent: "center" }}>
+                      <List.ItemIcon style={{ minWidth: 0, justifyContent: "center" }}>
                         {child.icon}
-                      </ListItemIcon>
-                    </ListItemButton>
+                      </List.ItemIcon>
+                    </List.ItemButton>
                   </Tooltip>
                 );
               })}
@@ -188,40 +212,36 @@ const NavList = ({
           <Box key={item.value}>
             {wrappedButton}
             <Collapse in={isGroupOpen} unmountOnExit>
-              <List disablePadding>
+              <List.Root disablePadding>
                 {item.children?.map((child) => {
                   const childActive = child.value === activeValue;
 
                   return (
-                    <ListItemButton
+                    <List.ItemButton
                       key={child.value}
                       selected={childActive}
                       aria-current={childActive ? "page" : undefined}
                       onClick={() => onNavigate(child.path)}
                       onMouseEnter={() => onPrefetch?.(child.path)}
-                      sx={{ pl: 4.5 }}
+                      style={{ paddingLeft: 36 }}
                     >
-                      <ListItemIcon sx={{ minWidth: 28 }}>{child.icon}</ListItemIcon>
-                      <ListItemText
+                      <List.ItemIcon style={{ minWidth: 28 }}>{child.icon}</List.ItemIcon>
+                      <List.ItemText
                         primary={child.label}
-                        slotProps={{
-                          primary: {
-                            sx: {
-                              fontSize: "0.8125rem",
-                              fontWeight: childActive ? 600 : 400,
-                            },
-                          },
+                        primaryStyle={{
+                          fontSize: "0.8125rem",
+                          fontWeight: childActive ? 600 : 400,
                         }}
                       />
-                    </ListItemButton>
+                    </List.ItemButton>
                   );
                 })}
-              </List>
+              </List.Root>
             </Collapse>
           </Box>
         );
       })}
-    </List>
+    </List.Root>
   );
 };
 
@@ -282,127 +302,118 @@ export const AppShell = ({
     Bom.when(Bom.isNullish, () => firstItem),
   );
 
+  const navPadding: CSSProperties = { paddingInline: drawerOpen ? 12 : 6 };
+
   return (
-    <Box
-      sx={{
+    <div
+      style={{
         display: "flex",
         height: "100vh",
         overflow: "hidden",
-        bgcolor: "background.default",
+        backgroundColor: "var(--hb-color-canvas)",
       }}
     >
-      <Box
-        component="a"
-        href="#main-content"
-        sx={{
+      <a href="#main-content" {...stylex.props(styles.skipLink)}>
+        본문으로 건너뛰기
+      </a>
+
+      <header
+        style={{
           position: "fixed",
-          top: -100,
-          left: 8,
-          zIndex: (theme) => theme.zIndex.tooltip + 1,
-          bgcolor: "primary.main",
-          color: "#fff",
-          px: 2,
-          py: 1,
-          borderRadius: 1,
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          textDecoration: "none",
-          "&:focus": { top: 8 },
+          top: 0,
+          left: 0,
+          right: 0,
+          height: APPBAR_HEIGHT,
+          zIndex: 1301,
+          backgroundColor: "var(--hb-color-chrome)",
+          color: "var(--hb-color-text-primary)",
+          boxShadow: "0 1px 0 rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
         }}
       >
-        본문으로 건너뛰기
-      </Box>
-
-      <AppBar position="fixed" elevation={0} sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-        <Toolbar
-          variant="dense"
-          sx={{
-            minHeight: APPBAR_HEIGHT,
-            height: APPBAR_HEIGHT,
-            px: 3,
-            gap: 2,
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            height: "100%",
+            paddingInline: 24,
+            gap: 16,
           }}
         >
-          <IconButton
+          <Button.Icon
             aria-label="사이드바 토글"
             aria-expanded={drawerOpen}
             onClick={() => setDrawerOpen((prev) => !prev)}
             size="small"
             edge="start"
-            sx={{ color: "text.secondary" }}
+            style={{ color: "var(--hb-color-text-secondary)" }}
           >
-            <MenuOutlined fontSize="small" />
-          </IconButton>
-          <Typography
-            variant="body2"
-            onClick={() => navigate("/")}
-            sx={{
-              fontWeight: 700,
-              fontSize: "0.7rem",
-              letterSpacing: "0.1em",
-              textTransform: "uppercase",
-              color: "text.secondary",
-              cursor: "pointer",
-              "&:hover": { color: "primary.main" },
-            }}
-          >
+            <MenuOutlined sx={{ fontSize: 20 }} />
+          </Button.Icon>
+          <span onClick={() => navigate("/")} {...stylex.props(styles.brand)}>
             HoBom System
-          </Typography>
-          <Divider orientation="vertical" flexItem sx={{ my: 1.5 }} />
-          <Typography variant="body1" sx={{ fontWeight: 600, color: "text.primary" }}>
+          </span>
+          <Divider orientation="vertical" flexItem style={{ marginBlock: 12 }} />
+          <Text variant="body1" style={{ fontWeight: 600, color: "var(--hb-color-text-primary)" }}>
             {activeItem.label}
-          </Typography>
+          </Text>
 
           {appBarAction && (
             <>
-              <Box sx={{ flex: 1 }} />
+              <Box style={{ flex: 1 }} />
               {appBarAction}
             </>
           )}
-        </Toolbar>
-      </AppBar>
+        </div>
+      </header>
 
-      <Drawer
-        variant="permanent"
-        sx={{
-          "& .MuiDrawer-paper": {
-            width: currentWidth,
-            transition: TRANSITION,
-            overflowX: "hidden",
-          },
+      <aside
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          height: "100vh",
+          width: currentWidth,
+          zIndex: 1200,
+          boxSizing: "border-box",
+          display: "flex",
+          flexDirection: "column",
+          overflowX: "hidden",
+          backgroundColor: "var(--hb-color-chrome)",
+          borderRight: "1px solid var(--hb-color-border)",
+          transition: TRANSITION,
         }}
       >
         {/* 로고 영역 */}
         <Box
-          sx={{
+          style={{
             height: APPBAR_HEIGHT,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            px: drawerOpen ? 2.5 : 0,
+            paddingInline: drawerOpen ? 20 : 0,
             flexShrink: 0,
           }}
         >
-          <Typography
+          <Text
             variant="h6"
-            sx={{
+            style={{
               fontWeight: 800,
               fontSize: "1.15rem",
-              color: "text.primary",
+              color: "var(--hb-color-text-primary)",
               letterSpacing: "0.02em",
               whiteSpace: "nowrap",
             }}
           >
             {drawerOpen ? "HoBom" : "H"}
-          </Typography>
+          </Text>
         </Box>
 
-        <Divider sx={{ borderColor: "divider" }} />
+        <Divider />
 
         <Box
           component="nav"
           aria-label="메인 네비게이션"
-          sx={{ px: drawerOpen ? 1.5 : 0.75, py: 2, flexGrow: 1 }}
+          style={{ ...navPadding, paddingBlock: 16, flexGrow: 1 }}
         >
           {navItems.map((entry, index) => {
             if (isSection(entry)) {
@@ -411,35 +422,24 @@ export const AppShell = ({
               return (
                 <Box key={entry.section}>
                   {drawerOpen ? (
-                    <Box
+                    <div
                       role="button"
                       tabIndex={0}
                       aria-expanded={isSectionOpen}
                       onClick={() => toggleSection(entry.section)}
-                      onKeyDown={(e: React.KeyboardEvent) => {
+                      onKeyDown={(e: KeyboardEvent) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
                           toggleSection(entry.section);
                         }
                       }}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        px: 1,
-                        mt: index > 0 ? 2 : 0,
-                        mb: 0.5,
-                        cursor: "pointer",
-                        borderRadius: 1,
-                        "&:hover": {
-                          bgcolor: "action.hover",
-                        },
-                      }}
+                      {...stylex.props(styles.sectionHeader)}
+                      style={{ marginTop: index > 0 ? 16 : 0 }}
                     >
-                      <Typography
+                      <Text
                         variant="caption"
-                        sx={{
-                          color: "text.secondary",
+                        style={{
+                          color: "var(--hb-color-text-secondary)",
                           fontSize: "0.7125rem",
                           fontWeight: 600,
                           letterSpacing: "0.1em",
@@ -448,32 +448,15 @@ export const AppShell = ({
                         }}
                       >
                         {entry.label}
-                      </Typography>
+                      </Text>
                       {isSectionOpen ? (
-                        <ExpandLess
-                          sx={{
-                            fontSize: 14,
-                            color: "text.disabled",
-                          }}
-                        />
+                        <ExpandLess sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
                       ) : (
-                        <ExpandMore
-                          sx={{
-                            fontSize: 14,
-                            color: "text.disabled",
-                          }}
-                        />
+                        <ExpandMore sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
                       )}
-                    </Box>
+                    </div>
                   ) : (
-                    index > 0 && (
-                      <Divider
-                        sx={{
-                          borderColor: "divider",
-                          my: 1,
-                        }}
-                      />
-                    )
+                    index > 0 && <Divider style={{ marginBlock: 8 }} />
                   )}
                   <Collapse in={!drawerOpen || isSectionOpen} unmountOnExit>
                     <NavList
@@ -502,8 +485,8 @@ export const AppShell = ({
         </Box>
 
         {bottomNavItems && bottomNavItems.length > 0 && (
-          <Box sx={{ px: drawerOpen ? 1.5 : 0.75, pb: 2 }}>
-            <Divider sx={{ borderColor: "divider", mb: 1.5 }} />
+          <Box style={{ ...navPadding, paddingBottom: 16 }}>
+            <Divider style={{ marginBottom: 12 }} />
             <NavList
               items={bottomNavItems}
               activeValue={activeItem.value}
@@ -513,24 +496,24 @@ export const AppShell = ({
             />
           </Box>
         )}
-      </Drawer>
+      </aside>
 
       <Box
         component="main"
         id="main-content"
-        sx={{
+        style={{
           position: "relative",
           flexGrow: 1,
-          ml: `${currentWidth}px`,
-          mt: `${APPBAR_HEIGHT}px`,
+          marginLeft: currentWidth,
+          marginTop: APPBAR_HEIGHT,
           height: `calc(100vh - ${APPBAR_HEIGHT}px)`,
           overflow: "auto",
-          bgcolor: "background.paper",
-          transition: `margin-left 0.25s cubic-bezier(0.4, 0, 0.2, 1)`,
+          backgroundColor: "var(--hb-color-surface)",
+          transition: "margin-left 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
         }}
       >
         {children}
       </Box>
-    </Box>
+    </div>
   );
 };

--- a/packages/hobom-design-system/src/patterns/BottomSheetCTA/BottomSheetCTA.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/BottomSheetCTA/BottomSheetCTA.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { BottomSheetCTA } from "./BottomSheetCTA";
+import { Button } from "../../components/Button/Button";
+import { Text } from "../../components/Text/Text";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Patterns/BottomSheetCTA",
+  component: BottomSheetCTA,
+  args: { open: false, onClose: () => {}, children: null },
+  parameters: {
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof BottomSheetCTA>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Button onClick={() => setOpen(true)}>열기</Button>
+      <BottomSheetCTA open={open} onClose={() => setOpen(false)}>
+        <BottomSheetCTA.Title>
+          <Text variant="subtitle1" style={{ fontWeight: 700 }}>
+            메뉴 추가하기
+          </Text>
+        </BottomSheetCTA.Title>
+        <BottomSheetCTA.Body>
+          <Text variant="body2">여기에 폼 내용이 들어갑니다.</Text>
+        </BottomSheetCTA.Body>
+        <BottomSheetCTA.Footer>
+          <Button variant="secondary" fullWidth onClick={() => setOpen(false)}>
+            취소
+          </Button>
+          <Button variant="primary" fullWidth onClick={() => setOpen(false)}>
+            확인
+          </Button>
+        </BottomSheetCTA.Footer>
+      </BottomSheetCTA>
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/patterns/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { ConfirmDialog } from "./ConfirmDialog";
+import { Button } from "../../components/Button/Button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Patterns/ConfirmDialog",
+  component: ConfirmDialog,
+  args: { open: false, onClose: () => {}, onConfirm: () => {}, title: "", description: "" },
+  parameters: {
+    // Filled accent/danger buttons are below the contrast threshold by design.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof ConfirmDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ padding: 40 }}>
+      <Button variant="danger" onClick={() => setOpen(true)}>
+        삭제
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        title="정말 삭제할까요?"
+        description="이 작업은 되돌릴 수 없어요."
+        confirmLabel="삭제"
+        confirmColor="error"
+      />
+    </div>
+  );
+};
+
+export const Basic: Story = { render: () => <Demo /> };

--- a/packages/hobom-design-system/src/patterns/EmptyState/EmptyState.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,24 @@
+import { EmptyState } from "./EmptyState";
+import { SearchOutlined } from "../../icons";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Patterns/EmptyState",
+  component: EmptyState,
+  parameters: {
+    // The message uses the intentionally-muted disabled tone (< 4.5:1).
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = { args: { message: "표시할 데이터가 없어요" } };
+export const WithIcon: Story = {
+  args: {
+    icon: <SearchOutlined sx={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />,
+    message: "검색 결과가 없어요",
+  },
+};

--- a/packages/hobom-design-system/src/patterns/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,39 @@
+import { DataLot, DataLotProvider } from "hobom-data";
+import { ErrorBoundary } from "./ErrorBoundary";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const dataLot = new DataLot({ defaultOptions: { queries: { retry: false } } });
+
+const Boom = () => {
+  throw new Error("문제가 발생한 컴포넌트입니다.");
+};
+
+const meta = {
+  title: "Patterns/ErrorBoundary",
+  component: ErrorBoundary,
+  args: { children: null },
+  decorators: [
+    (Story) => (
+      <DataLotProvider client={dataLot}>
+        <Story />
+      </DataLotProvider>
+    ),
+  ],
+  parameters: {
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof ErrorBoundary>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Fallback: Story = {
+  render: () => (
+    <div style={{ width: 480 }}>
+      <ErrorBoundary inline>
+        <Boom />
+      </ErrorBoundary>
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/patterns/SkeletonCard/SkeletonCard.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/SkeletonCard/SkeletonCard.stories.tsx
@@ -1,0 +1,12 @@
+import { SkeletonCard } from "./SkeletonCard";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = { title: "Patterns/SkeletonCard", component: SkeletonCard } satisfies Meta<
+  typeof SkeletonCard
+>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = { render: () => <div style={{ width: 280 }}><SkeletonCard /></div> };

--- a/packages/hobom-design-system/src/patterns/SkeletonList/SkeletonList.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/SkeletonList/SkeletonList.stories.tsx
@@ -1,0 +1,20 @@
+import { SkeletonList } from "./SkeletonList";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = { title: "Patterns/SkeletonList", component: SkeletonList } satisfies Meta<
+  typeof SkeletonList
+>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <div style={{ width: 280, display: "flex", flexDirection: "column", gap: 8 }}>
+      <SkeletonList />
+      <SkeletonList />
+      <SkeletonList />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/patterns/SuspenseLoader/SuspenseLoader.stories.tsx
+++ b/packages/hobom-design-system/src/patterns/SuspenseLoader/SuspenseLoader.stories.tsx
@@ -1,0 +1,18 @@
+import { SuspenseLoader } from "./SuspenseLoader";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = { title: "Patterns/SuspenseLoader", component: SuspenseLoader } satisfies Meta<
+  typeof SuspenseLoader
+>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Inline: Story = {
+  render: () => (
+    <div style={{ position: "relative", width: 360, height: 200 }}>
+      <SuspenseLoader />
+    </div>
+  ),
+};


### PR DESCRIPTION
## What

Two things: migrates **AppShell** off MUI (the last big pattern), and adds **Storybook stories for every pattern** so they run under the same a11y gate as the components.

## AppShell

Rebuilt on the in-house components — a fixed `<header>` and a fixed permanent sidebar `<aside>` (collapsible 240/64) replace MUI's AppBar and Drawer, with `Box` / `Text` / `Divider` / `List` / `Tooltip` / `Collapse` and `Button.Icon` for the nav.

- Adds a scheme-aware **`--hb-color-chrome`** (canvas in light, surface in dark) for the app-bar/sidebar background, so the chrome no longer depends on the MUI theme's component overrides.
- Exposes `MenuOutlined` from the icon set.

## Pattern stories

`EmptyState`, `SkeletonCard`, `SkeletonList`, `SuspenseLoader`, `ConfirmDialog`, `BottomSheetCTA`, `ErrorBoundary` (with a `DataLot` provider decorator + throwing child), and `AppShell` (MemoryRouter, fullscreen). Known muted-text / filled-accent patterns and the sidebar's button-in-list structure disable the corresponding axe rules.

## Remaining MUI

Only the **theme engine** — `Infra` (CssBaseline/GlobalStyles/ThemeProvider) + `theme.ts` + `styling.ts`. Its now-dead Drawer/AppBar/List component overrides will be removed with it.

## Verification

- DS + app `tsc -b`, lint clean
- App build (StyleX compile) OK, 582 app tests pass
- DS unit + Storybook a11y (Chromium): 133 pass (51 files)