### PR TITLE
Give board columns a fixed height with internal issue scroll

### DIFF
--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -135,14 +135,19 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
           </Hb.ToggleButton>
         </Hb.Box>
 
-        {/* Columns */}
+        {/* Columns — fixed viewport-bounded height so each column stays a
+            uniform grid box and scrolls its issues internally instead of
+            growing with the issue count. The offset accounts for the app bar
+            and the project/board chrome stacked above this region. */}
         <Hb.Box
           style={{
             display: "flex",
             gap: 16,
             overflowX: "auto",
+            overflowY: "hidden",
             paddingBottom: 8,
-            minHeight: 480,
+            height: "calc(100vh - 300px)",
+            minHeight: 360,
           }}
         >
           {boardColumns.map((col) => (

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanColumn.tsx
@@ -26,7 +26,7 @@ export const KanbanColumn = ({ column, issues }: KanbanColumnProps) => {
       ref={setNodeRef}
       style={{
         flex: "0 0 296px",
-        minHeight: 400,
+        minHeight: 0,
         display: "flex",
         flexDirection: "column",
         backgroundColor: isOver ? `${config.color}14` : "action.hover",
@@ -85,6 +85,10 @@ export const KanbanColumn = ({ column, issues }: KanbanColumnProps) => {
             gap: 8,
             flex: 1,
             minHeight: 60,
+            overflowY: "auto",
+            overflowX: "hidden",
+            marginRight: -4,
+            paddingRight: 4,
           }}
         >
           {swimlaneGroups


### PR DESCRIPTION
## What
Board columns used to grow taller as issues piled up, stretching the whole board and pushing the create-issue action out of view.

Now the columns row is bound to a viewport-relative height and each column fills it, so the columns stay a uniform grid of boxes. The column header and the inline create-issue form stay pinned; only the issue list scrolls inside each column.

## Changes
- `KanbanBoard.tsx` — columns container gets a fixed `calc(100vh - …)` height (offset for the app bar + project/board chrome) instead of an unbounded `minHeight`.
- `KanbanColumn.tsx` — column fills the container height (`minHeight: 0`); the issue list becomes the internal scroll region.

## Verify
- app `tsc -b`: clean
- eslint (kanban): clean
- app build: ok
- 582 app tests pass