### PR TITLE
Build in-house date picker and drop the last of MUI

### DIFF
--- a/apps/hobom-system/package.json
+++ b/apps/hobom-system/package.json
@@ -25,7 +25,7 @@
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
-    "date-fns": "^4.1.0",
+    "date-fns": "^4.4.0",
     "dompurify": "^3.3.1",
     "hobom-data": "workspace:*",
     "hobom-design-system": "workspace:*",

--- a/apps/hobom-system/src/features/calendar/ui/Calendar.tsx
+++ b/apps/hobom-system/src/features/calendar/ui/Calendar.tsx
@@ -1,12 +1,6 @@
 import { type ReactNode, Suspense } from "react";
 import { useSuspenseQuery } from "hobom-data";
-import {
-  DayCalendarSkeleton,
-  LocalizationProvider,
-  StaticDatePicker,
-  type PickersDayProps,
-} from "hobom-design-system/date-pickers";
-import { AdapterDateFns } from "hobom-design-system/date-pickers";
+import { Calendar as HbCalendar } from "hobom-design-system/date-pickers";
 import { startOfMonth } from "date-fns";
 import { ko } from "date-fns/locale";
 import { Bom } from "hobom-utils";
@@ -36,47 +30,15 @@ export const Calendar = () => {
 
   return (
     <Hb.Box>
-      <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ko}>
-        <StaticDatePicker
-          displayStaticWrapperAs="desktop"
-          value={selectedDate}
-          slots={{
-            toolbar: () => null,
-            day: CalendarDay,
-          }}
-          slotProps={{
-            actionBar: { actions: [] },
-            day: { days } as unknown as PickersDayProps,
-          }}
-          onMonthChange={(month) => {
-            const date = Bom.pipe(month as Date, formatDate);
-
-            updateQuery({ selectedDate: date }, { replace: true });
-          }}
-          renderLoading={() => <DayCalendarSkeleton />}
-          sx={{
-            "& .MuiPickersLayout-root": {
-              minWidth: "unset",
-            },
-            "& .MuiPickersCalendarHeader-root": {
-              px: 1.5,
-              mt: 1,
-            },
-            "& .MuiPickersCalendarHeader-label": {
-              fontSize: "0.9375rem",
-              fontWeight: 700,
-            },
-            "& .MuiDayCalendar-weekDayLabel": {
-              fontSize: "0.75rem",
-              fontWeight: 600,
-              color: "text.secondary",
-            },
-            "& .MuiDayCalendar-slideTransition": {
-              minHeight: 240,
-            },
-          }}
-        />
-      </LocalizationProvider>
+      <HbCalendar
+        value={selectedDate}
+        locale={ko}
+        labelFormat="yyyy년 M월"
+        renderDay={(dayProps) => <CalendarDay {...dayProps} days={days} />}
+        onMonthChange={(month) => {
+          updateQuery({ selectedDate: formatDate(month) }, { replace: true });
+        }}
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/calendar/ui/CalendarDay.tsx
+++ b/apps/hobom-system/src/features/calendar/ui/CalendarDay.tsx
@@ -1,59 +1,20 @@
-import { format, isSameDay, isToday } from "date-fns";
-import { PickersDay, type PickersDayProps } from "hobom-design-system/date-pickers";
+import { format, isSameDay } from "date-fns";
+import { Calendar, type CalendarDayProps } from "hobom-design-system/date-pickers";
 import { useRouterQuery } from "@/shared/model";
 
-type Props = PickersDayProps & { days?: Date[] };
+type Props = CalendarDayProps & { days: Date[] };
 
-export const CalendarDay = ({ days = [], ...pickersDayProps }: Props) => {
+export const CalendarDay = ({ days, ...day }: Props) => {
   const { updateQuery } = useRouterQuery();
-  const { day, selected, outsideCurrentMonth } = pickersDayProps;
 
-  const hasTodo = days.some((d) => isSameDay(d, day as Date));
-  const isCurrentDay = isToday(day as Date);
+  const hasTodo = days.some((d) => isSameDay(d, day.date));
 
   return (
-    <PickersDay
-      {...pickersDayProps}
-      onDaySelect={(selectedDate) => {
-        updateQuery(
-          { selectedDate: format(selectedDate as Date, "yyyy-MM-dd") },
-          { replace: true },
-        );
-      }}
-      sx={{
-        position: "relative",
-        fontWeight: isCurrentDay ? 700 : 400,
-        fontSize: "0.8125rem",
-        borderRadius: "50%",
-        transition: "all 0.15s ease",
-        "&.Mui-selected": {
-          bgcolor: "primary.main",
-          color: "primary.contrastText",
-          fontWeight: 600,
-          "&:hover": { bgcolor: "primary.dark" },
-          "&:focus": { bgcolor: "primary.main" },
-        },
-        ...(!selected &&
-          isCurrentDay && {
-            border: "1.5px solid",
-            borderColor: "primary.main",
-            color: "primary.main",
-          }),
-        ...(hasTodo &&
-          !outsideCurrentMonth && {
-            "&::after": {
-              content: '""',
-              position: "absolute",
-              bottom: 2,
-              left: "50%",
-              transform: "translateX(-50%)",
-              width: 5,
-              height: 5,
-              borderRadius: "50%",
-              bgcolor: selected ? "primary.contrastText" : "success.main",
-              transition: "background-color 0.15s ease",
-            },
-          }),
+    <Calendar.DayButton
+      {...day}
+      dot={hasTodo && !day.outsideMonth}
+      onSelect={(selectedDate) => {
+        updateQuery({ selectedDate: format(selectedDate, "yyyy-MM-dd") }, { replace: true });
       }}
     />
   );

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
@@ -53,10 +53,10 @@ export const FutureMessageScheduleFunnel = ({ onPrevStep }: Props) => {
       <Hb.Form.Control fullWidth>
         <DatePicker
           label="보낼 날짜"
-          sx={{ width: "100%" }}
-          onChange={(evt) => {
-            if (!evt) return;
-            setValue("scheduledAt", format(evt as Date, "yyyy-MM-dd"));
+          style={{ width: "100%" }}
+          onChange={(date) => {
+            if (!date) return;
+            setValue("scheduledAt", format(date, "yyyy-MM-dd"));
           }}
         />
         <Hb.Form.Helper>발송 예정일을 선택해 주세요.</Hb.Form.Helper>

--- a/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
+++ b/apps/hobom-system/src/pages/message-send/ui/FutureMessageSendPage.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { LocalizationProvider, AdapterDateFns } from "hobom-design-system/date-pickers";
 import { FutureMessageFunnel } from "@/features/send-future-message";
 import type { FutureMessageSendSchemaType } from "@/entities/future-message";
 import { Hb } from "@/shared/ui";
@@ -28,11 +27,9 @@ export default function FutureMessageSendPage() {
       }}
     >
       <FormProvider {...formMethods}>
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
-          <Layout>
-            <FutureMessageFunnel />
-          </Layout>
-        </LocalizationProvider>
+        <Layout>
+          <FutureMessageFunnel />
+        </Layout>
       </FormProvider>
     </Hb.Box>
   );

--- a/packages/hobom-design-system/package.json
+++ b/packages/hobom-design-system/package.json
@@ -27,12 +27,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^7.1.0",
-    "@mui/material": "^7.1.0",
-    "@mui/x-date-pickers": "^8.11.2",
     "@stylexjs/stylex": "^0.19.0",
+    "date-fns": "^4.4.0",
     "hobom-utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/hobom-design-system/src/date-pickers/Calendar.stories.tsx
+++ b/packages/hobom-design-system/src/date-pickers/Calendar.stories.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { ko } from "date-fns/locale";
+import { Calendar } from "./Calendar";
+import { DatePicker } from "./DatePicker";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "DatePickers/Calendar",
+  component: Calendar,
+  parameters: {
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Calendar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const InlineDemo = () => {
+  const [value, setValue] = useState<Date | null>(null);
+
+  return <Calendar value={value} locale={ko} onSelect={setValue} />;
+};
+
+export const Inline: Story = {
+  render: () => <InlineDemo />,
+};
+
+export const Input: Story = {
+  render: () => (
+    <div style={{ width: 260, padding: 40 }}>
+      <DatePicker label="보낼 날짜" locale={ko} />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/date-pickers/Calendar.tsx
+++ b/packages/hobom-design-system/src/date-pickers/Calendar.tsx
@@ -1,0 +1,265 @@
+import { type CSSProperties, type ReactNode, useState } from "react";
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+  type Locale,
+} from "date-fns";
+import * as stylex from "@stylexjs/stylex";
+import { ChevronRight } from "../icons";
+import { Button } from "../components/Button/Button";
+
+/** Info passed to each rendered day cell. */
+export interface CalendarDayProps {
+  date: Date;
+  selected: boolean;
+  today: boolean;
+  outsideMonth: boolean;
+  onSelect: (date: Date) => void;
+}
+
+type WeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+interface CalendarProps {
+  /** The currently selected date, if any. */
+  value?: Date | null;
+  /** Controlled visible month (any date within it). */
+  month?: Date;
+  /** Initial visible month when uncontrolled. */
+  defaultMonth?: Date;
+  onSelect?: (date: Date) => void;
+  onMonthChange?: (month: Date) => void;
+  /** Custom day cell renderer; defaults to {@link Calendar.DayButton}. */
+  renderDay?: (props: CalendarDayProps) => ReactNode;
+  locale?: Locale;
+  weekStartsOn?: WeekStart;
+  /** date-fns format for the month header label. */
+  labelFormat?: string;
+  style?: CSSProperties;
+}
+
+const styles = stylex.create({
+  root: {
+    width: 288,
+    userSelect: "none",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingInline: 2,
+    marginBottom: 10,
+  },
+  label: {
+    fontSize: "1rem",
+    fontWeight: 700,
+    letterSpacing: "-0.01em",
+    color: "var(--hb-color-text-primary)",
+  },
+  weekRow: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    marginBottom: 6,
+  },
+  weekLabel: {
+    textAlign: "center",
+    fontSize: "0.6875rem",
+    fontWeight: 600,
+    letterSpacing: "0.02em",
+    color: "var(--hb-color-text-secondary)",
+    paddingBlock: 4,
+  },
+  weekLabelWeekend: {
+    color: "var(--hb-color-text-disabled)",
+  },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(7, 1fr)",
+    rowGap: 4,
+    justifyItems: "center",
+  },
+  prevIcon: {
+    transform: "rotate(180deg)",
+  },
+});
+
+/** An inline month grid. Round-trips the visible month through `onMonthChange`. */
+const CalendarBase = ({
+  value,
+  month,
+  defaultMonth,
+  onSelect,
+  onMonthChange,
+  renderDay,
+  locale,
+  weekStartsOn = 0,
+  labelFormat = "yyyy.MM",
+  style,
+}: CalendarProps) => {
+  const [internalMonth, setInternalMonth] = useState(() =>
+    startOfMonth(month ?? value ?? defaultMonth ?? new Date()),
+  );
+  const viewMonth = month ? startOfMonth(month) : internalMonth;
+
+  const goToMonth = (next: Date) => {
+    const normalized = startOfMonth(next);
+
+    if (!month) setInternalMonth(normalized);
+
+    onMonthChange?.(normalized);
+  };
+
+  const gridStart = startOfWeek(startOfMonth(viewMonth), { weekStartsOn, locale });
+  const gridEnd = endOfWeek(endOfMonth(viewMonth), { weekStartsOn, locale });
+  const days = eachDayOfInterval({ start: gridStart, end: gridEnd });
+
+  return (
+    <div {...stylex.props(styles.root)} style={style}>
+      <div {...stylex.props(styles.header)}>
+        <Button.Icon
+          size="small"
+          aria-label="Previous month"
+          onClick={() => goToMonth(addMonths(viewMonth, -1))}
+        >
+          <ChevronRight {...stylex.props(styles.prevIcon)} />
+        </Button.Icon>
+        <span {...stylex.props(styles.label)}>{format(viewMonth, labelFormat, { locale })}</span>
+        <Button.Icon
+          size="small"
+          aria-label="Next month"
+          onClick={() => goToMonth(addMonths(viewMonth, 1))}
+        >
+          <ChevronRight />
+        </Button.Icon>
+      </div>
+
+      <div {...stylex.props(styles.weekRow)}>
+        {days.slice(0, 7).map((day) => {
+          const weekend = day.getDay() === 0 || day.getDay() === 6;
+
+          return (
+            <span
+              key={day.getTime()}
+              {...stylex.props(styles.weekLabel, weekend && styles.weekLabelWeekend)}
+            >
+              {format(day, "eee", { locale })}
+            </span>
+          );
+        })}
+      </div>
+
+      <div {...stylex.props(styles.grid)}>
+        {days.map((day) => {
+          const dayProps: CalendarDayProps = {
+            date: day,
+            selected: value ? isSameDay(day, value) : false,
+            today: isToday(day),
+            outsideMonth: !isSameMonth(day, viewMonth),
+            onSelect: (d) => onSelect?.(d),
+          };
+
+          return renderDay ? (
+            <div key={day.getTime()}>{renderDay(dayProps)}</div>
+          ) : (
+            <DayButton key={day.getTime()} {...dayProps} />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const dayStyles = stylex.create({
+  base: {
+    position: "relative",
+    width: 36,
+    height: 36,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderStyle: "none",
+    borderRadius: "50%",
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-color-neutral)" },
+    color: "var(--hb-color-text-primary)",
+    fontSize: "0.8125rem",
+    fontWeight: 500,
+    fontVariantNumeric: "tabular-nums",
+    cursor: "pointer",
+    transition: "background-color 0.15s ease, color 0.15s ease, transform 0.1s ease",
+    transform: { default: "scale(1)", ":active": "scale(0.9)" },
+  },
+  weekend: {
+    color: "var(--hb-color-text-secondary)",
+  },
+  today: {
+    fontWeight: 700,
+    borderWidth: 1.5,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-accent)",
+    color: "var(--hb-color-accent)",
+  },
+  outsideMonth: {
+    color: "var(--hb-color-text-disabled)",
+  },
+  selected: {
+    fontWeight: 700,
+    backgroundColor: { default: "var(--hb-color-accent)", ":hover": "var(--hb-color-accent-dark)" },
+    color: "var(--hb-color-accent-contrast)",
+    borderStyle: "none",
+  },
+  dot: {
+    "::after": {
+      content: "''",
+      position: "absolute",
+      bottom: 2,
+      left: "50%",
+      transform: "translateX(-50%)",
+      width: 5,
+      height: 5,
+      borderRadius: "50%",
+      backgroundColor: "var(--hb-color-success)",
+    },
+  },
+  dotSelected: {
+    "::after": {
+      backgroundColor: "var(--hb-color-accent-contrast)",
+    },
+  },
+});
+
+interface DayButtonProps extends CalendarDayProps {
+  /** Renders a small indicator dot under the day number. */
+  dot?: boolean;
+}
+
+/** The default circular day cell — usable as a base for custom day slots. */
+const DayButton = ({ date, selected, today, outsideMonth, onSelect, dot }: DayButtonProps) => {
+  const weekend = date.getDay() === 0 || date.getDay() === 6;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(date)}
+      {...stylex.props(
+        dayStyles.base,
+        weekend && dayStyles.weekend,
+        outsideMonth && dayStyles.outsideMonth,
+        today && !selected && dayStyles.today,
+        selected && dayStyles.selected,
+        dot && dayStyles.dot,
+        dot && selected && dayStyles.dotSelected,
+      )}
+    >
+      {date.getDate()}
+    </button>
+  );
+};
+
+export const Calendar = Object.assign(CalendarBase, { DayButton });

--- a/packages/hobom-design-system/src/date-pickers/DatePicker.tsx
+++ b/packages/hobom-design-system/src/date-pickers/DatePicker.tsx
@@ -1,0 +1,122 @@
+import { type CSSProperties, useRef, useState } from "react";
+import { format, type Locale } from "date-fns";
+import * as stylex from "@stylexjs/stylex";
+import { CalendarTodayOutlined } from "../icons";
+import { Popover } from "../components/Popover/Popover";
+import { Calendar } from "./Calendar";
+
+interface DatePickerProps {
+  value?: Date | null;
+  onChange?: (date: Date | null) => void;
+  label?: string;
+  placeholder?: string;
+  /** display format for the selected date (date-fns tokens). */
+  displayFormat?: string;
+  locale?: Locale;
+  disabled?: boolean;
+  style?: CSSProperties;
+}
+
+const styles = stylex.create({
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+  label: {
+    fontSize: "0.75rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+  },
+  trigger: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+    width: "100%",
+    minHeight: 40,
+    paddingInline: 12,
+    paddingBlock: 8,
+    textAlign: "left",
+    fontSize: "0.875rem",
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: { default: "var(--hb-color-border)", ":hover": "var(--hb-color-text-secondary)" },
+    borderRadius: 8,
+    cursor: "pointer",
+    transition: "border-color 0.15s ease",
+  },
+  triggerOpen: {
+    borderColor: "var(--hb-color-accent)",
+  },
+  disabled: {
+    cursor: "not-allowed",
+    opacity: 0.6,
+  },
+  placeholder: {
+    color: "var(--hb-color-text-disabled)",
+  },
+  icon: {
+    color: "var(--hb-color-text-secondary)",
+    flexShrink: 0,
+  },
+  popoverBody: {
+    padding: 12,
+  },
+});
+
+/** A text-field trigger that opens a {@link Calendar} popover. */
+export const DatePicker = ({
+  value,
+  onChange,
+  label,
+  placeholder = "날짜 선택",
+  displayFormat = "yyyy-MM-dd",
+  locale,
+  disabled,
+  style,
+}: DatePickerProps) => {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [internal, setInternal] = useState<Date | null>(value ?? null);
+  const selected = value !== undefined ? value : internal;
+
+  const handleSelect = (date: Date) => {
+    if (value === undefined) setInternal(date);
+    onChange?.(date);
+    setOpen(false);
+  };
+
+  return (
+    <div {...stylex.props(styles.field)} style={style}>
+      {label && <span {...stylex.props(styles.label)}>{label}</span>}
+      <button
+        ref={anchorRef}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => !disabled && setOpen(true)}
+        {...stylex.props(styles.trigger, open && styles.triggerOpen, disabled && styles.disabled)}
+      >
+        <span {...(selected ? {} : stylex.props(styles.placeholder))}>
+          {selected ? format(selected, displayFormat, { locale }) : placeholder}
+        </span>
+        <CalendarTodayOutlined sx={{ fontSize: 18 }} {...stylex.props(styles.icon)} />
+      </button>
+
+      <Popover open={open} anchorEl={anchorRef.current} onClose={() => setOpen(false)}>
+        <div {...stylex.props(styles.popoverBody)}>
+          <Calendar
+            value={selected}
+            defaultMonth={selected ?? undefined}
+            onSelect={handleSelect}
+            locale={locale}
+          />
+        </div>
+      </Popover>
+    </div>
+  );
+};

--- a/packages/hobom-design-system/src/date-pickers/index.ts
+++ b/packages/hobom-design-system/src/date-pickers/index.ts
@@ -1,9 +1,2 @@
-export {
-  DatePicker,
-  StaticDatePicker,
-  LocalizationProvider,
-  PickersDay,
-  DayCalendarSkeleton,
-} from "@mui/x-date-pickers";
-export type { PickersDayProps } from "@mui/x-date-pickers";
-export { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+export { Calendar, type CalendarDayProps } from "./Calendar";
+export { DatePicker } from "./DatePicker";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         specifier: ^3.20.0
         version: 3.27.2
       date-fns:
-        specifier: ^4.1.0
+        specifier: ^4.4.0
         version: 4.4.0
       dompurify:
         specifier: '>=3.4.11'
@@ -189,24 +189,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
-      '@emotion/react':
-        specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/styled':
-        specifier: ^11.14.0
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@mui/icons-material':
-        specifier: ^7.1.0
-        version: 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@mui/material':
-        specifier: ^7.1.0
-        version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/x-date-pickers':
-        specifier: ^8.11.2
-        version: 8.29.2(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stylexjs/stylex':
         specifier: ^0.19.0
         version: 0.19.0
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       hobom-data:
         specifier: workspace:*
         version: link:../hobom-data
@@ -514,60 +502,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
-
-  '@emotion/babel-plugin@11.13.5':
-    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
-
-  '@emotion/cache@11.14.0':
-    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
-
-  '@emotion/hash@0.9.2':
-    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
-
-  '@emotion/is-prop-valid@1.4.0':
-    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
-
-  '@emotion/memoize@0.9.0':
-    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
-
-  '@emotion/react@11.14.0':
-    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@emotion/serialize@1.3.3':
-    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
-
-  '@emotion/sheet@1.4.0':
-    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
-
-  '@emotion/styled@11.14.1':
-    resolution: {integrity: sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==}
-    peerDependencies:
-      '@emotion/react': ^11.0.0-rc.0
-      '@types/react': '*'
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@emotion/unitless@0.10.0':
-    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
-    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
-    peerDependencies:
-      react: 19.2.7
-
-  '@emotion/utils@1.4.2':
-    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
-
-  '@emotion/weak-memoize@0.4.0':
-    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -877,140 +811,6 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
-  '@mui/core-downloads-tracker@7.3.11':
-    resolution: {integrity: sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==}
-
-  '@mui/icons-material@7.3.11':
-    resolution: {integrity: sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@mui/material': ^7.3.11
-      '@types/react': 19.2.14
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/material@7.3.11':
-    resolution: {integrity: sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@mui/material-pigment-css': ^7.3.11
-      '@types/react': 19.2.14
-      react: 19.2.7
-      react-dom: 19.2.7
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@mui/material-pigment-css':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/private-theming@7.3.11':
-    resolution: {integrity: sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': 19.2.14
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/styled-engine@7.3.10':
-    resolution: {integrity: sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/styled': ^11.3.0
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-
-  '@mui/system@7.3.11':
-    resolution: {integrity: sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.5.0
-      '@emotion/styled': ^11.3.0
-      '@types/react': 19.2.14
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      '@types/react':
-        optional: true
-
-  '@mui/types@7.4.12':
-    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
-    peerDependencies:
-      '@types/react': 19.2.14
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@7.3.11':
-    resolution: {integrity: sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': 19.2.14
-      react: 19.2.7
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/x-date-pickers@8.29.2':
-    resolution: {integrity: sha512-02efypE9TqoBEMAJ/kzS5al1suo9E2iStuItZnBlQ8/DdLtKHpeeXgK4KNabCg+e4SeF+XuBbu06vL7sNnbXvg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@emotion/react': ^11.9.0
-      '@emotion/styled': ^11.8.1
-      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
-      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
-      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
-      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
-      dayjs: ^1.10.7
-      luxon: ^3.0.2
-      moment: ^2.29.4
-      moment-hijri: ^2.1.2 || ^3.0.0
-      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
-      react: 19.2.7
-      react-dom: 19.2.7
-    peerDependenciesMeta:
-      '@emotion/react':
-        optional: true
-      '@emotion/styled':
-        optional: true
-      date-fns:
-        optional: true
-      date-fns-jalali:
-        optional: true
-      dayjs:
-        optional: true
-      luxon:
-        optional: true
-      moment:
-        optional: true
-      moment-hijri:
-        optional: true
-      moment-jalaali:
-        optional: true
-
-  '@mui/x-internals@8.29.2':
-    resolution: {integrity: sha512-TLILyHia5NHh3MGErFDh0bXZ4V6iS45hdStofsV5wklF6dpgZjduo65oJB0h81mI5mexNlhHANEVfw0KV6BxBg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: 19.2.7
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1277,9 +1077,6 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
-
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -1852,19 +1649,8 @@ packages:
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
 
-  '@types/parse-json@4.0.2':
-    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
-    peerDependencies:
-      '@types/react': 19.2.14
-
-  '@types/react-transition-group@4.4.12':
-    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': 19.2.14
 
@@ -2163,10 +1949,6 @@ packages:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
-  babel-plugin-macros@3.1.0:
-    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
-    engines: {node: '>=10', npm: '>=6'}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2199,10 +1981,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
@@ -2242,19 +2020,12 @@ packages:
     resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
     engines: {node: '>= 12.0.0'}
 
-  convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
-
-  cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
-    engines: {node: '>=10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2376,9 +2147,6 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dom-helpers@5.2.1:
-    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
-
   dompurify@3.4.11:
     resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
@@ -2399,9 +2167,6 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
-
-  error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -2572,9 +2337,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-root@1.1.0:
-    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
-
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2656,9 +2418,6 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2677,10 +2436,6 @@ packages:
   immer@11.1.11:
     resolution: {integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==}
 
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2695,9 +2450,6 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
-  is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2780,9 +2532,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2879,9 +2628,6 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
@@ -2981,10 +2727,6 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -3017,14 +2759,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
-  parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
-
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -3045,10 +2779,6 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3097,9 +2827,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
@@ -3167,9 +2894,6 @@ packages:
     peerDependencies:
       react: 19.2.7
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -3207,12 +2931,6 @@ packages:
 
   react-toastify@11.1.0:
     resolution: {integrity: sha512-e9h23x3phN0wbFeB6yovmWp7lobzV4CaCH0LO8nVP6H7Y+3GbcLpIzMm9dJhcp1RXbpyfvjgpfXqO80QAmn7sg==}
-    peerDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7
-
-  react-transition-group@4.4.5:
-    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
       react: 19.2.7
       react-dom: 19.2.7
@@ -3255,10 +2973,6 @@ packages:
 
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3339,10 +3053,6 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3405,9 +3115,6 @@ packages:
 
   styleq@0.2.1:
     resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
-
-  stylis@4.2.0:
-    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3713,11 +3420,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -4049,89 +3751,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emotion/babel-plugin@11.13.5':
-    dependencies:
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/runtime': 7.28.6
-      '@emotion/hash': 0.9.2
-      '@emotion/memoize': 0.9.0
-      '@emotion/serialize': 1.3.3
-      babel-plugin-macros: 3.1.0
-      convert-source-map: 1.9.0
-      escape-string-regexp: 4.0.0
-      find-root: 1.1.0
-      source-map: 0.5.7
-      stylis: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/cache@11.14.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-      '@emotion/sheet': 1.4.0
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      stylis: 4.2.0
-
-  '@emotion/hash@0.9.2': {}
-
-  '@emotion/is-prop-valid@1.4.0':
-    dependencies:
-      '@emotion/memoize': 0.9.0
-
-  '@emotion/memoize@0.9.0': {}
-
-  '@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.7)
-      '@emotion/utils': 1.4.2
-      '@emotion/weak-memoize': 0.4.0
-      hoist-non-react-statics: 3.3.2
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.14
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/serialize@1.3.3':
-    dependencies:
-      '@emotion/hash': 0.9.2
-      '@emotion/memoize': 0.9.0
-      '@emotion/unitless': 0.10.0
-      '@emotion/utils': 1.4.2
-      csstype: 3.2.3
-
-  '@emotion/sheet@1.4.0': {}
-
-  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@emotion/babel-plugin': 11.13.5
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.7)
-      '@emotion/utils': 1.4.2
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.14
-    transitivePeerDependencies:
-      - supports-color
-
-  '@emotion/unitless@0.10.0': {}
-
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-
-  '@emotion/utils@1.4.2': {}
-
-  '@emotion/weak-memoize@0.4.0': {}
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -4348,123 +3967,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@mui/core-downloads-tracker@7.3.11': {}
-
-  '@mui/icons-material@7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/core-downloads-tracker': 7.3.11
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@mui/types': 7.4.12(@types/react@19.2.14)
-      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-is: 19.2.4
-      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@types/react': 19.2.14
-
-  '@mui/private-theming@7.3.11(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      prop-types: 15.8.1
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@mui/styled-engine@7.3.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@emotion/cache': 11.14.0
-      '@emotion/serialize': 1.3.3
-      '@emotion/sheet': 1.4.0
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.7
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-
-  '@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/private-theming': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      '@mui/styled-engine': 7.3.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(react@19.2.7)
-      '@mui/types': 7.4.12(@types/react@19.2.14)
-      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      clsx: 2.1.1
-      csstype: 3.2.3
-      prop-types: 15.8.1
-      react: 19.2.7
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@types/react': 19.2.14
-
-  '@mui/types@7.4.12(@types/react@19.2.14)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@mui/utils@7.3.11(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/types': 7.4.12(@types/react@19.2.14)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-is: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@mui/x-date-pickers@8.29.2(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      '@mui/x-internals': 8.29.2(@types/react@19.2.14)(react@19.2.7)
-      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.7)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.7))(@types/react@19.2.14)(react@19.2.7)
-      date-fns: 4.4.0
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-internals@8.29.2(@types/react@19.2.14)(react@19.2.7)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/utils': 7.3.11(@types/react@19.2.14)(react@19.2.7)
-      react: 19.2.7
-      reselect: 5.2.0
-      use-sync-external-store: 1.6.0(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.9.0
@@ -4649,8 +4151,6 @@ snapshots:
   '@package-json/types@0.0.12': {}
 
   '@polka/url@1.0.0-next.29': {}
-
-  '@popperjs/core@2.11.8': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
@@ -5221,15 +4721,7 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/parse-json@4.0.2': {}
-
-  '@types/prop-types@15.7.15': {}
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-
-  '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
 
@@ -5567,12 +5059,6 @@ snapshots:
 
   axe-core@4.12.1: {}
 
-  babel-plugin-macros@3.1.0:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      cosmiconfig: 7.1.0
-      resolve: 1.22.11
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -5604,8 +5090,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001778: {}
 
@@ -5639,19 +5123,9 @@ snapshots:
 
   comment-parser@1.4.5: {}
 
-  convert-source-map@1.9.0: {}
-
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
-
-  cosmiconfig@7.1.0:
-    dependencies:
-      '@types/parse-json': 4.0.2
-      import-fresh: 3.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 2.8.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5750,11 +5224,6 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dom-helpers@5.2.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      csstype: 3.2.3
-
   dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -5768,10 +5237,6 @@ snapshots:
   entities@7.0.1: {}
 
   entities@8.0.0: {}
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
 
   es-module-lexer@2.0.0: {}
 
@@ -5982,8 +5447,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-root@1.1.0: {}
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -6064,10 +5527,6 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
-
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
@@ -6082,11 +5541,6 @@ snapshots:
 
   immer@11.1.11: {}
 
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -6096,8 +5550,6 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
-
-  is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -6177,8 +5629,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
-
-  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -6261,8 +5711,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
-
-  lines-and-columns@1.2.4: {}
 
   linkifyjs@4.3.3: {}
 
@@ -6356,8 +5804,6 @@ snapshots:
 
   node-releases@2.0.36: {}
 
-  object-assign@4.1.1: {}
-
   obug@2.1.1: {}
 
   open@10.2.0:
@@ -6436,17 +5882,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
-  parse-json@5.2.0:
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
-
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -6463,8 +5898,6 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
-
-  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -6501,12 +5934,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
 
   prosemirror-changeset@2.4.1:
     dependencies:
@@ -6614,8 +6041,6 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  react-is@16.13.1: {}
-
   react-is@17.0.2: {}
 
   react-is@19.2.4: {}
@@ -6646,15 +6071,6 @@ snapshots:
   react-toastify@11.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       clsx: 2.1.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
-  react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -6704,8 +6120,6 @@ snapshots:
   require-from-string@2.0.2: {}
 
   reselect@5.2.0: {}
-
-  resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6782,8 +6196,6 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.5.7: {}
-
   source-map@0.6.1: {}
 
   stable-hash-x@0.2.0: {}
@@ -6843,8 +6255,6 @@ snapshots:
   strip-json-comments@5.0.3: {}
 
   styleq@0.2.1: {}
-
-  stylis@4.2.0: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -7102,8 +6512,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.8.2: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## What
The final MUI surface — `@mui/x-date-pickers` — is replaced with an in-house `Calendar` and `DatePicker` in the design system.

- **`Calendar`** — inline month grid on StyleX + `--hb-*` tokens, with a custom day slot (`renderDay` / `Calendar.DayButton`), month navigation that round-trips through `onMonthChange`, and a `labelFormat` for a localized header. Takes a `date-fns` locale directly.
- **`DatePicker`** — a field trigger that opens a `Calendar` popover; `onChange(date)`.
- Styling stays on the neutral Astryx palette: weekends and outside-month days are de-emphasised by lightness (no color), today gets an accent ring, selected is a filled accent circle.

The app's calendar, future-message funnel and send page move to the new API; `LocalizationProvider` / `AdapterDateFns` are dropped.

## Package cleanup
With the pickers gone, all remaining MUI/Emotion packages are removed from the design system: `@mui/x-date-pickers`, `@mui/material`, `@mui/icons-material`, `@emotion/react`, `@emotion/styled`. No `@mui/*` or `@emotion/*` import or dependency remains anywhere in the workspace (lockfile pruned by ~595 lines). A depcheck sweep across every package found no other unused runtime dependencies. `date-fns` bumped to `^4.4.0`.

## Verify
- DS + app `tsc -b`: clean
- eslint (DS + app touched paths): clean
- app build (StyleX compile): ok
- 582 app tests pass
- DS Storybook a11y suite: 136 tests pass (incl. new Calendar stories)
- no `@mui`/`@emotion` in source or any package.json