### PR TITLE
Show a status icon on the left of each toast

### DIFF
--- a/apps/hobom-system/src/apps/ui/AppProvider.tsx
+++ b/apps/hobom-system/src/apps/ui/AppProvider.tsx
@@ -6,6 +6,7 @@ import { GLOBAL_STYLES } from "@/shared/config";
 import { Hb, ErrorBoundary, OverlayProvider, ColorSchemeVars } from "@/shared/ui";
 import { reportError } from "@/shared/lib";
 import { ColorSchemeBridge } from "./ColorSchemeBridge";
+import { renderToastIcon } from "./toast-icon";
 
 import "react-toastify/dist/ReactToastify.css";
 
@@ -39,7 +40,7 @@ export const AppProvider = ({ children }: Props) => {
         pauseOnHover
         transition={Slide}
         autoClose={TOAST_AUTO_CLOSE_MS}
-        icon={false}
+        icon={renderToastIcon}
         closeButton={false}
       />
       <DataLotProvider client={dataLot}>

--- a/apps/hobom-system/src/apps/ui/toast-icon.tsx
+++ b/apps/hobom-system/src/apps/ui/toast-icon.tsx
@@ -1,0 +1,28 @@
+import {
+  CheckCircle,
+  ErrorOutline,
+  WarningAmberOutlined,
+  InfoOutlined,
+} from "hobom-design-system/icons";
+import type { IconProps } from "react-toastify";
+
+/**
+ * Status icon shown at the left of each toast. Colors are light shades that
+ * read on the dark toast surface; `default` toasts (e.g. undo) get no icon.
+ */
+const STATUS_ICON = {
+  success: { Icon: CheckCircle, color: "#4ade80" },
+  error: { Icon: ErrorOutline, color: "#f87171" },
+  warning: { Icon: WarningAmberOutlined, color: "#fbbf24" },
+  info: { Icon: InfoOutlined, color: "#60a5fa" },
+} as const;
+
+export const renderToastIcon = ({ type }: IconProps) => {
+  const entry = STATUS_ICON[type as keyof typeof STATUS_ICON];
+
+  if (!entry) return null;
+
+  const { Icon, color } = entry;
+
+  return <Icon sx={{ fontSize: 20, color }} />;
+};

--- a/packages/hobom-design-system/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/hobom-design-system/src/components/Skeleton/Skeleton.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
 } satisfies Meta<typeof Skeleton>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Variants: Story = {

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
 } satisfies Meta<typeof Tabs.Root>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 const BasicDemo = () => {


### PR DESCRIPTION
## What
Toasts rendered without a leading icon (`icon={false}`), so success and error looked identical at a glance.

Each toast type now shows a status icon on the left:
- **success** → filled check circle (green)
- **error** → error outline (red)
- **warning** → warning triangle (amber)
- **info** → info outline (blue)

Colors are light shades chosen to stay legible on the dark toast surface. Default toasts (the undo action) keep no icon.

## Implementation
- `apps/ui/toast-icon.tsx` — a small `renderToastIcon({ type })` mapping, kept out of `AppProvider` to keep the container config lean.
- `AppProvider` wires it via the `ToastContainer` `icon` prop.

Uses the in-house icon set (`CheckCircle` / `ErrorOutline` / `WarningAmberOutlined` / `InfoOutlined`).

## Verify
- app `tsc -b`: clean
- eslint: clean
- app build: ok
- 582 app tests pass