### PR TITLE
Mark invalidated queries stale so unobserved ones refetch on remount

### DIFF
--- a/packages/hobom-data/src/core/data-lot.spec.ts
+++ b/packages/hobom-data/src/core/data-lot.spec.ts
@@ -68,6 +68,41 @@ describe("DataLot", () => {
     query.removeObserver();
   });
 
+  it("invalidates가 관찰자 없는 쿼리를 stale로 마킹한다 (재방문 시 refetch)", async () => {
+    const lot = new DataLot({ defaultOptions: { queries: { staleTime: 5 * 60_000 } } });
+    const cache = lot.getQueryCache();
+    let fetchCount = 0;
+
+    const query = cache.build(
+      {
+        queryKey: ["notes"],
+        queryFn: async () => {
+          fetchCount++;
+
+          return `data-${fetchCount}`;
+        },
+        staleTime: 5 * 60_000,
+      },
+      5 * 60_000,
+    );
+
+    // Simulate a mounted-then-unmounted list: fetch once, then no observers.
+    query.addObserver();
+    await query.fetch();
+    query.removeObserver();
+    expect(fetchCount).toBe(1);
+    expect(query.isStale()).toBe(false); // still fresh within staleTime
+
+    // A mutation elsewhere invalidates it while it is unobserved.
+    await lot.invalidates({ queryKey: ["notes"] });
+
+    // It is not refetched now (no observers), but it is marked stale so the
+    // next mount refetches instead of serving 5-minute-old data.
+    expect(fetchCount).toBe(1);
+    expect(query.getState().isInvalidated).toBe(true);
+    expect(query.isStale()).toBe(true);
+  });
+
   it("cancelQueries가 진행 중인 fetch를 취소한다", async () => {
     const lot = new DataLot();
     const cache = lot.getQueryCache();

--- a/packages/hobom-data/src/core/data-lot.ts
+++ b/packages/hobom-data/src/core/data-lot.ts
@@ -55,6 +55,10 @@ export class DataLot {
   async invalidates(filters?: QueryFilters): Promise<void> {
     const queries = this.queryCache.findAll(filters);
     const refetchPromises = queries.map((query) => {
+      // Mark every match stale — active observers refetch now, inactive ones
+      // refetch on their next mount instead of serving cached data for staleTime.
+      query.invalidate();
+
       if (query.getObserverCount() > 0) {
         query.cancel();
 

--- a/packages/hobom-data/src/core/query.spec.ts
+++ b/packages/hobom-data/src/core/query.spec.ts
@@ -94,6 +94,42 @@ describe("Query", () => {
     });
   });
 
+  describe("invalidate", () => {
+    it("marks a fresh query stale regardless of staleTime", async () => {
+      const query = createQuery({ staleTime: 60_000 });
+
+      await query.fetch();
+      expect(query.isStale()).toBe(false);
+
+      query.invalidate();
+
+      expect(query.getState().isInvalidated).toBe(true);
+      expect(query.isStale()).toBe(true);
+    });
+
+    it("clears the invalidated flag on the next successful fetch", async () => {
+      const query = createQuery({ staleTime: 60_000 });
+
+      await query.fetch();
+      query.invalidate();
+      await query.fetch();
+
+      expect(query.getState().isInvalidated).toBe(false);
+      expect(query.isStale()).toBe(false);
+    });
+
+    it("clears the invalidated flag when data is set directly", async () => {
+      const query = createQuery<string>({ staleTime: 60_000 });
+
+      await query.fetch();
+      query.invalidate();
+      query.setData("fresh");
+
+      expect(query.getState().isInvalidated).toBe(false);
+      expect(query.isStale()).toBe(false);
+    });
+  });
+
   it("cancel()이 AbortController를 abort한다", async () => {
     const captured: { signal: AbortSignal | null } = { signal: null };
 

--- a/packages/hobom-data/src/core/query.ts
+++ b/packages/hobom-data/src/core/query.ts
@@ -31,6 +31,7 @@ export class Query<TData = unknown, TError = Error> extends Subscribable {
       error: null,
       fetchStatus: "idle",
       dataUpdatedAt: 0,
+      isInvalidated: false,
     };
   }
 
@@ -39,10 +40,21 @@ export class Query<TData = unknown, TError = Error> extends Subscribable {
   }
 
   isStale(): boolean {
+    if (this.state.isInvalidated) return true;
     if (this.state.status !== "success") return true;
     const staleTime = this.options.staleTime ?? DEFAULT_STALE_TIME;
 
     return Date.now() - this.state.dataUpdatedAt > staleTime;
+  }
+
+  /**
+   * Flag the query stale independent of `staleTime`. Active observers refetch
+   * immediately (driven by `DataLot`); inactive ones refetch on their next mount.
+   */
+  invalidate(): void {
+    if (!this.state.isInvalidated) {
+      this.setState({ isInvalidated: true });
+    }
   }
 
   async fetch(): Promise<TData> {
@@ -74,6 +86,7 @@ export class Query<TData = unknown, TError = Error> extends Subscribable {
       data,
       error: null,
       dataUpdatedAt: Date.now(),
+      isInvalidated: false,
     });
   }
 
@@ -125,6 +138,7 @@ export class Query<TData = unknown, TError = Error> extends Subscribable {
           error: null,
           fetchStatus: "idle",
           dataUpdatedAt: Date.now(),
+          isInvalidated: false,
         });
 
         return data;

--- a/packages/hobom-data/src/core/types.ts
+++ b/packages/hobom-data/src/core/types.ts
@@ -9,6 +9,8 @@ export interface QueryState<TData = unknown, TError = Error> {
   error: TError | null;
   fetchStatus: FetchStatus;
   dataUpdatedAt: number;
+  /** Marked stale by `invalidateQueries` regardless of `staleTime`; cleared on the next successful fetch. */
+  isInvalidated: boolean;
 }
 
 export interface QueryOptions<TData = unknown, TQueryKey extends QueryKey = QueryKey> {


### PR DESCRIPTION
## The bug
`invalidateQueries` (`data-lot.ts`) only cancelled-and-refetched queries that had **active observers**. Queries with zero observers (an unmounted list) were skipped with a bare `Promise.resolve()`. There was no `isInvalidated` concept, and `isStale()` only checked `status` + `staleTime`.

Combined with the app-wide `staleTime: 5min`, a mutation that invalidated an unmounted list left it considered *fresh* — returning to that screen served up to five minutes of stale data. App-wide data-freshness bug, previously untested.

## The fix
- `QueryState` gains an `isInvalidated` flag.
- `Query.invalidate()` sets it; `Query.isStale()` returns true when it is set, regardless of `staleTime`.
- `DataLot.invalidates()` now marks **every** matching query invalidated, then refetches the active ones (unchanged) — inactive ones stay marked and refetch on their next mount (`QueryObserver.mount()` already refetches when `isStale()`).
- The flag clears on the next successful fetch or a direct `setData`.

## Tests
- `query.spec.ts` — invalidate marks a fresh query stale within staleTime; flag clears on refetch and on setData.
- `data-lot.spec.ts` — invalidating an unobserved query marks it stale (refetches on next mount) without refetching immediately.

## Verify
- hobom-data `tsc`/lint clean, 86 unit tests pass
- app `tsc -b` clean, 582 app tests pass (backward compatible — `isInvalidated` is additive)