### PR TITLE
Thread cancellation signals through GET query requests

### DIFF
--- a/apps/hobom-system/src/entities/admin-user/api/admin-user.api.ts
+++ b/apps/hobom-system/src/entities/admin-user/api/admin-user.api.ts
@@ -1,8 +1,8 @@
 import { httpClient, type HttpResponseType } from "@/shared/api";
 import type { PendingUserType } from "./admin-user.type";
 
-export const fetchPendingUsers = async () =>
-  await httpClient.get<HttpResponseType<PendingUserType[]>>(`/admin/users/pending`);
+export const fetchPendingUsers = async (signal?: AbortSignal) =>
+  await httpClient.get<HttpResponseType<PendingUserType[]>>(`/admin/users/pending`, { signal });
 
 export const patchApproveUser = async ({ id }: { id: string }) =>
   await httpClient.patch(`/admin/users/${id}/approve`, {});

--- a/apps/hobom-system/src/entities/admin-user/api/admin-user.queries.ts
+++ b/apps/hobom-system/src/entities/admin-user/api/admin-user.queries.ts
@@ -7,6 +7,6 @@ export const adminUserQueries = {
   pending: () =>
     queryOptions({
       queryKey: [...adminUserQueries.all(), "pending"],
-      queryFn: fetchPendingUsers,
+      queryFn: ({ signal }) => fetchPendingUsers(signal),
     }),
 } as const;

--- a/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
@@ -19,4 +19,5 @@ export const postAuthLogout = async () => {
   await httpClient.post("/auth/logout", {});
 };
 
-export const fetchUsers = async () => await httpClient.get<HttpResponseType<UserType[]>>("/users");
+export const fetchUsers = async (signal?: AbortSignal) =>
+  await httpClient.get<HttpResponseType<UserType[]>>("/users", { signal });

--- a/apps/hobom-system/src/entities/auth/api/auth.queries.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth.queries.ts
@@ -7,6 +7,6 @@ export const authQueries = {
   users: () =>
     queryOptions({
       queryKey: ["auth", "users"],
-      queryFn: () => fetchUsers(),
+      queryFn: ({ signal }) => fetchUsers(signal),
     }),
 } as const;

--- a/apps/hobom-system/src/entities/board/api/board.api.ts
+++ b/apps/hobom-system/src/entities/board/api/board.api.ts
@@ -2,19 +2,28 @@ import { httpClient } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
 import type { BoardDto, CreateBoardRequest, UpdateBoardRequest } from "./board.type";
 
-export const fetchBoardsByProject = async ({ projectId }: { projectId: string }) => {
-  return await httpClient.get<HttpResponseType<BoardDto[]>>(`/projects/${projectId}/boards`);
+export const fetchBoardsByProject = async (
+  { projectId }: { projectId: string },
+  signal?: AbortSignal,
+) => {
+  return await httpClient.get<HttpResponseType<BoardDto[]>>(`/projects/${projectId}/boards`, {
+    signal,
+  });
 };
 
-export const fetchBoardById = async ({
-  projectId,
-  boardId,
-}: {
-  projectId: string;
-  boardId: string;
-}) => {
+export const fetchBoardById = async (
+  {
+    projectId,
+    boardId,
+  }: {
+    projectId: string;
+    boardId: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<BoardDto>>(
     `/projects/${projectId}/boards/${boardId}`,
+    { signal },
   );
 };
 

--- a/apps/hobom-system/src/entities/board/api/board.queries.ts
+++ b/apps/hobom-system/src/entities/board/api/board.queries.ts
@@ -8,14 +8,14 @@ export const boardQueries = {
   listByProject: (projectId: string) =>
     queryOptions({
       queryKey: ["boards", "list", projectId],
-      queryFn: () => fetchBoardsByProject({ projectId }),
+      queryFn: ({ signal }) => fetchBoardsByProject({ projectId }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 
   detail: (projectId: string, boardId: string) =>
     queryOptions({
       queryKey: ["boards", "detail", projectId, boardId],
-      queryFn: () => fetchBoardById({ projectId, boardId }),
+      queryFn: ({ signal }) => fetchBoardById({ projectId, boardId }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
@@ -1,8 +1,8 @@
 import { httpClient, type HttpResponseType } from "@/shared/api";
 import type { CategoryType } from "@/entities/daily-todo";
 
-export const fetchDailyTodoCategories = async () => {
-  return await httpClient.get<HttpResponseType<CategoryType[]>>(`/categories`);
+export const fetchDailyTodoCategories = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<CategoryType[]>>(`/categories`, { signal });
 };
 
 export const postCategory = async ({ title }: { title: string }) => {

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo.api.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo.api.ts
@@ -2,12 +2,16 @@ import { httpClient } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
 import type { DailyTodoType, ProgressType } from "./daily-todo.type.ts";
 
-export const fetchDailyTodos = async ({ date }: { date: string }) => {
-  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos?date=${date}`);
+export const fetchDailyTodos = async ({ date }: { date: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos?date=${date}`, {
+    signal,
+  });
 };
 
-export const fetchDailyTodosByDate = async ({ date }: { date: string }) => {
-  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos/by-date/${date}`);
+export const fetchDailyTodosByDate = async ({ date }: { date: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos/by-date/${date}`, {
+    signal,
+  });
 };
 
 export const patchDailyTodoCompleteStatusChange = async ({

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo.queries.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo.queries.ts
@@ -9,21 +9,21 @@ export const todoQueries = {
   list: (date: string) =>
     queryOptions({
       queryKey: ["todos", date],
-      queryFn: () => fetchDailyTodos({ date }),
+      queryFn: ({ signal }) => fetchDailyTodos({ date }, signal),
       ...CACHE_PROFILE.FAST,
     }),
 
   byDate: (date: string) =>
     queryOptions({
       queryKey: ["todos", "by-date", date],
-      queryFn: () => fetchDailyTodosByDate({ date }),
+      queryFn: ({ signal }) => fetchDailyTodosByDate({ date }, signal),
       ...CACHE_PROFILE.FAST,
     }),
 
   categories: () =>
     queryOptions({
       queryKey: ["todos", "categories"],
-      queryFn: () => fetchDailyTodoCategories(),
+      queryFn: ({ signal }) => fetchDailyTodoCategories(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/dashboard/api/dashboard.api.ts
+++ b/apps/hobom-system/src/entities/dashboard/api/dashboard.api.ts
@@ -13,86 +13,118 @@ import type {
   SprintDashboardDto,
 } from "./dashboard.type";
 
-export const fetchDailyTodoDashboard = async ({
-  period,
-  date,
-}: {
-  period: PeriodType;
-  date: string;
-}) => {
+export const fetchDailyTodoDashboard = async (
+  {
+    period,
+    date,
+  }: {
+    period: PeriodType;
+    date: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<DailyTodoDashboardType>>(
     `/dashboard/daily-todos?period=${period}&date=${date}`,
+    { signal },
   );
 };
 
-export const fetchNoteDashboard = async ({
-  period,
-  date,
-}: {
-  period: PeriodType;
-  date: string;
-}) => {
+export const fetchNoteDashboard = async (
+  {
+    period,
+    date,
+  }: {
+    period: PeriodType;
+    date: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<NoteDashboardType>>(
     `/dashboard/notes?period=${period}&date=${date}`,
+    { signal },
   );
 };
 
-export const fetchMessageDashboard = async ({
-  period,
-  date,
-}: {
-  period: PeriodType;
-  date: string;
-}) => {
+export const fetchMessageDashboard = async (
+  {
+    period,
+    date,
+  }: {
+    period: PeriodType;
+    date: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<MessageDashboardType>>(
     `/dashboard/future-messages?period=${period}&date=${date}`,
+    { signal },
   );
 };
 
-export const fetchNotificationDashboard = async ({
-  period,
-  date,
-}: {
-  period: PeriodType;
-  date: string;
-}) => {
+export const fetchNotificationDashboard = async (
+  {
+    period,
+    date,
+  }: {
+    period: PeriodType;
+    date: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<NotificationDashboardType>>(
     `/dashboard/notifications?period=${period}&date=${date}`,
+    { signal },
   );
 };
 
-export const fetchSystemDashboard = async ({ period }: { period: SystemPeriodType }) => {
+export const fetchSystemDashboard = async (
+  { period }: { period: SystemPeriodType },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<SystemDashboardType>>(
     `/dashboard/system?period=${period}`,
+    { signal },
   );
 };
 
-export const fetchActivityDashboard = async ({
-  period,
-  date,
-}: {
-  period: PeriodType;
-  date: string;
-}) => {
+export const fetchActivityDashboard = async (
+  {
+    period,
+    date,
+  }: {
+    period: PeriodType;
+    date: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<ActivityDashboardType>>(
     `/dashboard/activity?period=${period}&date=${date}`,
+    { signal },
   );
 };
 
-export const fetchProjectIssueDashboard = async ({ projectId }: { projectId: string }) => {
+export const fetchProjectIssueDashboard = async (
+  { projectId }: { projectId: string },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<ProjectIssueDashboardDto>>(
     `/dashboard/projects/${projectId}/issues`,
+    { signal },
   );
 };
 
-export const fetchSprintDashboard = async ({
-  projectId,
-  sprintId,
-}: {
-  projectId: string;
-  sprintId: string;
-}) => {
+export const fetchSprintDashboard = async (
+  {
+    projectId,
+    sprintId,
+  }: {
+    projectId: string;
+    sprintId: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<SprintDashboardDto>>(
     `/dashboard/projects/${projectId}/sprints/${sprintId}`,
+    { signal },
   );
 };

--- a/apps/hobom-system/src/entities/dashboard/api/dashboard.queries.ts
+++ b/apps/hobom-system/src/entities/dashboard/api/dashboard.queries.ts
@@ -18,50 +18,50 @@ export const dashboardQueries = {
   dailyTodos: (period: PeriodType, date: string) =>
     queryOptions({
       queryKey: ["dashboard", "daily-todos", period, date],
-      queryFn: () => fetchDailyTodoDashboard({ period, date }),
+      queryFn: ({ signal }) => fetchDailyTodoDashboard({ period, date }, signal),
     }),
 
   notes: (period: PeriodType, date: string) =>
     queryOptions({
       queryKey: ["dashboard", "notes", period, date],
-      queryFn: () => fetchNoteDashboard({ period, date }),
+      queryFn: ({ signal }) => fetchNoteDashboard({ period, date }, signal),
     }),
 
   messages: (period: PeriodType, date: string) =>
     queryOptions({
       queryKey: ["dashboard", "messages", period, date],
-      queryFn: () => fetchMessageDashboard({ period, date }),
+      queryFn: ({ signal }) => fetchMessageDashboard({ period, date }, signal),
     }),
 
   notifications: (period: PeriodType, date: string) =>
     queryOptions({
       queryKey: ["dashboard", "notifications", period, date],
-      queryFn: () => fetchNotificationDashboard({ period, date }),
+      queryFn: ({ signal }) => fetchNotificationDashboard({ period, date }, signal),
     }),
 
   system: (period: SystemPeriodType) =>
     queryOptions({
       queryKey: ["dashboard", "system", period],
-      queryFn: () => fetchSystemDashboard({ period }),
+      queryFn: ({ signal }) => fetchSystemDashboard({ period }, signal),
     }),
 
   activity: (period: PeriodType, date: string) =>
     queryOptions({
       queryKey: ["dashboard", "activity", period, date],
-      queryFn: () => fetchActivityDashboard({ period, date }),
+      queryFn: ({ signal }) => fetchActivityDashboard({ period, date }, signal),
     }),
 
   projectIssues: (projectId: string) =>
     queryOptions({
       queryKey: ["dashboard", "project-issues", projectId],
-      queryFn: () => fetchProjectIssueDashboard({ projectId }),
+      queryFn: ({ signal }) => fetchProjectIssueDashboard({ projectId }, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   sprint: (projectId: string, sprintId: string) =>
     queryOptions({
       queryKey: ["dashboard", "sprint", projectId, sprintId],
-      queryFn: () => fetchSprintDashboard({ projectId, sprintId }),
+      queryFn: ({ signal }) => fetchSprintDashboard({ projectId, sprintId }, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/dlq/api/dlq.api.ts
+++ b/apps/hobom-system/src/entities/dlq/api/dlq.api.ts
@@ -3,10 +3,13 @@ import type { DlqListResponse, DlqDetailResponse, DlqRetryResponse } from "./dlq
 
 const BASE = "/dlq";
 
-export const fetchDlqKeys = () => httpClient.get<HttpResponseType<DlqListResponse>>(BASE);
+export const fetchDlqKeys = (signal?: AbortSignal) =>
+  httpClient.get<HttpResponseType<DlqListResponse>>(BASE, { signal });
 
-export const fetchDlqDetail = (key: string) =>
-  httpClient.get<HttpResponseType<DlqDetailResponse>>(`${BASE}/${encodeURIComponent(key)}`);
+export const fetchDlqDetail = (key: string, signal?: AbortSignal) =>
+  httpClient.get<HttpResponseType<DlqDetailResponse>>(`${BASE}/${encodeURIComponent(key)}`, {
+    signal,
+  });
 
 export const retryDlqItem = (key: string) =>
   httpClient.post<HttpResponseType<DlqRetryResponse>>(

--- a/apps/hobom-system/src/entities/dlq/api/dlq.queries.ts
+++ b/apps/hobom-system/src/entities/dlq/api/dlq.queries.ts
@@ -8,14 +8,14 @@ export const dlqQueries = {
   list: () =>
     queryOptions({
       queryKey: ["dlq", "list"],
-      queryFn: () => fetchDlqKeys(),
+      queryFn: ({ signal }) => fetchDlqKeys(signal),
       ...CACHE_PROFILE.FAST,
     }),
 
   detail: (key: string) =>
     queryOptions({
       queryKey: ["dlq", "detail", key],
-      queryFn: () => fetchDlqDetail(key),
+      queryFn: ({ signal }) => fetchDlqDetail(key, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/error-event/api/error-event.api.ts
+++ b/apps/hobom-system/src/entities/error-event/api/error-event.api.ts
@@ -4,7 +4,7 @@ import type { ErrorEventDto, ErrorEventSearchParams } from "./error-event.type";
 
 const BASE = "/api/v1/errors";
 
-export const fetchErrorEvents = (params: ErrorEventSearchParams) => {
+export const fetchErrorEvents = (params: ErrorEventSearchParams, signal?: AbortSignal) => {
   const query = new URLSearchParams();
 
   if (params.errorType) query.set("errorType", params.errorType);
@@ -14,8 +14,9 @@ export const fetchErrorEvents = (params: ErrorEventSearchParams) => {
 
   return spaceHttpClient.get<HttpResponseType<PaginatedItems<ErrorEventDto>>>(
     `${BASE}?${query.toString()}`,
+    { signal },
   );
 };
 
-export const fetchErrorEventById = (id: number) =>
-  spaceHttpClient.get<HttpResponseType<ErrorEventDto>>(`${BASE}/${id}`);
+export const fetchErrorEventById = (id: number, signal?: AbortSignal) =>
+  spaceHttpClient.get<HttpResponseType<ErrorEventDto>>(`${BASE}/${id}`, { signal });

--- a/apps/hobom-system/src/entities/error-event/api/error-event.queries.ts
+++ b/apps/hobom-system/src/entities/error-event/api/error-event.queries.ts
@@ -9,14 +9,14 @@ export const errorEventQueries = {
   list: (params: ErrorEventSearchParams) =>
     HoBom.DataLot.queryOptions({
       queryKey: ["error-events", "list", params],
-      queryFn: () => fetchErrorEvents(params),
+      queryFn: ({ signal }) => fetchErrorEvents(params, signal),
       ...CACHE_PROFILE.FAST,
     }),
 
   detail: (id: number) =>
     HoBom.DataLot.queryOptions({
       queryKey: ["error-events", "detail", id],
-      queryFn: () => fetchErrorEventById(id),
+      queryFn: ({ signal }) => fetchErrorEventById(id, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/future-message/api/future-message.api.ts
+++ b/apps/hobom-system/src/entities/future-message/api/future-message.api.ts
@@ -3,13 +3,17 @@ import type { FutureMessageSendStatusType } from "../model/future-message-send-s
 import type { FutureMessageType } from "./future-message.type";
 import type { FutureMessageSendSchemaType } from "../model/future-message-send.model";
 
-export const fetchFutureMessageByStatus = async ({
-  status,
-}: {
-  status: FutureMessageSendStatusType;
-}) =>
+export const fetchFutureMessageByStatus = async (
+  {
+    status,
+  }: {
+    status: FutureMessageSendStatusType;
+  },
+  signal?: AbortSignal,
+) =>
   httpClient.get<HttpResponseType<FutureMessageType[]>>(
     `/future-messages/by-status?status=${status}`,
+    { signal },
   );
 
 export const postFutureMessage = async (body: FutureMessageSendSchemaType) =>

--- a/apps/hobom-system/src/entities/future-message/api/future-message.queries.ts
+++ b/apps/hobom-system/src/entities/future-message/api/future-message.queries.ts
@@ -9,7 +9,7 @@ export const futureMessageQueries = {
   byStatus: ({ status }: { status: FutureMessageSendStatusType }) =>
     queryOptions({
       queryKey: ["future-messages", "status", status],
-      queryFn: () => fetchFutureMessageByStatus({ status }),
+      queryFn: ({ signal }) => fetchFutureMessageByStatus({ status }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/issue-comment/api/issue-comment.api.ts
+++ b/apps/hobom-system/src/entities/issue-comment/api/issue-comment.api.ts
@@ -6,15 +6,19 @@ import type {
   UpdateIssueCommentRequest,
 } from "./issue-comment.type";
 
-export const fetchIssueComments = async ({
-  projectId,
-  issueId,
-}: {
-  projectId: string;
-  issueId: string;
-}) => {
+export const fetchIssueComments = async (
+  {
+    projectId,
+    issueId,
+  }: {
+    projectId: string;
+    issueId: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<IssueCommentType[]>>(
     `/projects/${projectId}/issues/${issueId}/comments`,
+    { signal },
   );
 };
 

--- a/apps/hobom-system/src/entities/issue-comment/api/issue-comment.queries.ts
+++ b/apps/hobom-system/src/entities/issue-comment/api/issue-comment.queries.ts
@@ -8,7 +8,7 @@ export const issueCommentQueries = {
   list: (projectId: string, issueId: string) =>
     queryOptions({
       queryKey: ["issue-comments", "list", projectId, issueId],
-      queryFn: () => fetchIssueComments({ projectId, issueId }),
+      queryFn: ({ signal }) => fetchIssueComments({ projectId, issueId }, signal),
       ...CACHE_PROFILE.FAST,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/issue/api/issue.api.ts
+++ b/apps/hobom-system/src/entities/issue/api/issue.api.ts
@@ -8,19 +8,28 @@ import type {
   AssignIssueRequest,
 } from "./issue.type";
 
-export const fetchIssuesByProject = async ({ projectId }: { projectId: string }) => {
-  return await httpClient.get<HttpResponseType<IssueType[]>>(`/projects/${projectId}/issues`);
+export const fetchIssuesByProject = async (
+  { projectId }: { projectId: string },
+  signal?: AbortSignal,
+) => {
+  return await httpClient.get<HttpResponseType<IssueType[]>>(`/projects/${projectId}/issues`, {
+    signal,
+  });
 };
 
-export const fetchIssueById = async ({
-  projectId,
-  issueId,
-}: {
-  projectId: string;
-  issueId: string;
-}) => {
+export const fetchIssueById = async (
+  {
+    projectId,
+    issueId,
+  }: {
+    projectId: string;
+    issueId: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<IssueType>>(
     `/projects/${projectId}/issues/${issueId}`,
+    { signal },
   );
 };
 

--- a/apps/hobom-system/src/entities/issue/api/issue.queries.ts
+++ b/apps/hobom-system/src/entities/issue/api/issue.queries.ts
@@ -8,14 +8,14 @@ export const issueQueries = {
   listByProject: (projectId: string) =>
     queryOptions({
       queryKey: ["issues", "list", projectId],
-      queryFn: () => fetchIssuesByProject({ projectId }),
+      queryFn: ({ signal }) => fetchIssuesByProject({ projectId }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 
   detail: (projectId: string, issueId: string) =>
     queryOptions({
       queryKey: ["issues", "detail", projectId, issueId],
-      queryFn: () => fetchIssueById({ projectId, issueId }),
+      queryFn: ({ signal }) => fetchIssueById({ projectId, issueId }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/label/api/label.api.ts
+++ b/apps/hobom-system/src/entities/label/api/label.api.ts
@@ -2,12 +2,12 @@ import { httpClient } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
 import type { LabelItemType, CreateLabelRequest, UpdateLabelRequest } from "./label.type";
 
-export const fetchLabels = async () => {
-  return await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels");
+export const fetchLabels = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels", { signal });
 };
 
-export const fetchLabelById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`);
+export const fetchLabelById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`, { signal });
 };
 
 export const postCreateLabel = async (data: CreateLabelRequest) => {

--- a/apps/hobom-system/src/entities/label/api/label.queries.ts
+++ b/apps/hobom-system/src/entities/label/api/label.queries.ts
@@ -8,14 +8,14 @@ export const labelQueries = {
   list: () =>
     queryOptions({
       queryKey: ["labels", "list"],
-      queryFn: fetchLabels,
+      queryFn: ({ signal }) => fetchLabels(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   detail: (id: string) =>
     queryOptions({
       queryKey: ["labels", "detail", id],
-      queryFn: () => fetchLabelById({ id }),
+      queryFn: ({ signal }) => fetchLabelById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/log/api/log.api.ts
+++ b/apps/hobom-system/src/entities/log/api/log.api.ts
@@ -12,30 +12,36 @@ import type {
 
 const BASE = "/logs";
 
-export const fetchLogLevelSummary = (hours: number) =>
-  internalHttpClient.get<HttpResponseType<LogLevelCount[]>>(`${BASE}/level-summary?hours=${hours}`);
+export const fetchLogLevelSummary = (hours: number, signal?: AbortSignal) =>
+  internalHttpClient.get<HttpResponseType<LogLevelCount[]>>(`${BASE}/level-summary?hours=${hours}`, {
+    signal,
+  });
 
-export const fetchLogServiceSummary = (hours: number) =>
+export const fetchLogServiceSummary = (hours: number, signal?: AbortSignal) =>
   internalHttpClient.get<HttpResponseType<LogServiceCount[]>>(
     `${BASE}/service-summary?hours=${hours}`,
+    { signal },
   );
 
-export const fetchLogStatusSummary = (hours: number) =>
+export const fetchLogStatusSummary = (hours: number, signal?: AbortSignal) =>
   internalHttpClient.get<HttpResponseType<LogStatusCount[]>>(
     `${BASE}/status-summary?hours=${hours}`,
+    { signal },
   );
 
-export const fetchLogRequestSummary = (hours: number) =>
+export const fetchLogRequestSummary = (hours: number, signal?: AbortSignal) =>
   internalHttpClient.get<HttpResponseType<LogRequestCount[]>>(
     `${BASE}/request-summary?hours=${hours}`,
+    { signal },
   );
 
-export const fetchLogEndpointErrors = (hours: number, limit = 20) =>
+export const fetchLogEndpointErrors = (hours: number, limit = 20, signal?: AbortSignal) =>
   internalHttpClient.get<HttpResponseType<LogEndpointError[]>>(
     `${BASE}/endpoint-errors?hours=${hours}&limit=${limit}`,
+    { signal },
   );
 
-export const fetchLogSearch = (params: LogSearchParams) => {
+export const fetchLogSearch = (params: LogSearchParams, signal?: AbortSignal) => {
   const query = new URLSearchParams();
 
   if (params.serviceType) query.set("serviceType", params.serviceType);
@@ -50,5 +56,6 @@ export const fetchLogSearch = (params: LogSearchParams) => {
 
   return internalHttpClient.get<HttpResponseType<PaginatedItems<LogEntry>>>(
     `${BASE}?${query.toString()}`,
+    { signal },
   );
 };

--- a/apps/hobom-system/src/entities/log/api/log.queries.ts
+++ b/apps/hobom-system/src/entities/log/api/log.queries.ts
@@ -16,42 +16,42 @@ export const logQueries = {
   levelSummary: (hours: number) =>
     queryOptions({
       queryKey: ["logs", "level-summary", hours],
-      queryFn: () => fetchLogLevelSummary(hours),
+      queryFn: ({ signal }) => fetchLogLevelSummary(hours, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   serviceSummary: (hours: number) =>
     queryOptions({
       queryKey: ["logs", "service-summary", hours],
-      queryFn: () => fetchLogServiceSummary(hours),
+      queryFn: ({ signal }) => fetchLogServiceSummary(hours, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   statusSummary: (hours: number) =>
     queryOptions({
       queryKey: ["logs", "status-summary", hours],
-      queryFn: () => fetchLogStatusSummary(hours),
+      queryFn: ({ signal }) => fetchLogStatusSummary(hours, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   requestSummary: (hours: number) =>
     queryOptions({
       queryKey: ["logs", "request-summary", hours],
-      queryFn: () => fetchLogRequestSummary(hours),
+      queryFn: ({ signal }) => fetchLogRequestSummary(hours, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   endpointErrors: (hours: number, limit?: number) =>
     queryOptions({
       queryKey: ["logs", "endpoint-errors", hours, limit],
-      queryFn: () => fetchLogEndpointErrors(hours, limit),
+      queryFn: ({ signal }) => fetchLogEndpointErrors(hours, limit, signal),
       ...CACHE_PROFILE.DASHBOARD,
     }),
 
   search: (params: LogSearchParams) =>
     queryOptions({
       queryKey: ["logs", "search", params],
-      queryFn: () => fetchLogSearch(params),
+      queryFn: ({ signal }) => fetchLogSearch(params, signal),
       ...CACHE_PROFILE.FAST,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.api.ts
+++ b/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.api.ts
@@ -10,8 +10,10 @@ import type {
   TodayMenuCandidateInput,
 } from "../model/menu-recommendation.model";
 
-export const fetchMenuRecommendationList = async () => {
-  return await httpClient.get<HttpResponseType<MenuRecommendationType[]>>("/menu-recommendation");
+export const fetchMenuRecommendationList = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<MenuRecommendationType[]>>("/menu-recommendation", {
+    signal,
+  });
 };
 
 export const postMenuRecommendation = async ({
@@ -42,8 +44,10 @@ export const putMenuRecommendationTodayMenu = async ({
   });
 };
 
-export const fetchTodayRecommendedMenu = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<TodayRecommendedMenuType>>(`/today-menu/${id}`);
+export const fetchTodayRecommendedMenu = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<TodayRecommendedMenuType>>(`/today-menu/${id}`, {
+    signal,
+  });
 };
 
 export const postSelectTodayMenu = async ({ id }: { id: string }) => {

--- a/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.queries.ts
+++ b/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.queries.ts
@@ -7,12 +7,12 @@ export const menuQueries = {
   recommendationList: () =>
     queryOptions({
       queryKey: ["menus", "recommendation", "list"],
-      queryFn: () => fetchMenuRecommendationList(),
+      queryFn: ({ signal }) => fetchMenuRecommendationList(signal),
     }),
 
   selectedTodayMenu: ({ id }: { id: string }) =>
     queryOptions({
       queryKey: ["menus", "today", "selected-menu", id],
-      queryFn: () => fetchTodayRecommendedMenu({ id }),
+      queryFn: ({ signal }) => fetchTodayRecommendedMenu({ id }, signal),
     }),
 } as const;

--- a/apps/hobom-system/src/entities/note/api/note.api.ts
+++ b/apps/hobom-system/src/entities/note/api/note.api.ts
@@ -19,15 +19,15 @@ const normalizeNote = (raw: RawNoteItemType): NoteItemType => ({
   members: raw.members.map((m) => m.value),
 });
 
-export const fetchNotes = async (status?: NoteStatus) => {
+export const fetchNotes = async (status?: NoteStatus, signal?: AbortSignal) => {
   const query = status ? `?status=${status}` : "";
-  const res = await httpClient.get<HttpResponseType<RawNoteItemType[]>>(`/notes${query}`);
+  const res = await httpClient.get<HttpResponseType<RawNoteItemType[]>>(`/notes${query}`, { signal });
 
   return { ...res, items: res.items.map(normalizeNote) };
 };
 
-export const fetchNoteById = async ({ id }: { id: string }) => {
-  const res = await httpClient.get<HttpResponseType<RawNoteItemType>>(`/notes/${id}`);
+export const fetchNoteById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<RawNoteItemType>>(`/notes/${id}`, { signal });
 
   return { ...res, items: normalizeNote(res.items) };
 };

--- a/apps/hobom-system/src/entities/note/api/note.queries.ts
+++ b/apps/hobom-system/src/entities/note/api/note.queries.ts
@@ -9,14 +9,14 @@ export const noteQueries = {
   list: (status?: NoteStatus) =>
     queryOptions({
       queryKey: ["notes", status ?? "ALL"],
-      queryFn: () => fetchNotes(status),
+      queryFn: ({ signal }) => fetchNotes(status, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 
   detail: (id: string) =>
     queryOptions({
       queryKey: ["notes", "detail", id],
-      queryFn: () => fetchNoteById({ id }),
+      queryFn: ({ signal }) => fetchNoteById({ id }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/notification/api/notification.api.ts
+++ b/apps/hobom-system/src/entities/notification/api/notification.api.ts
@@ -4,7 +4,10 @@ import type { NotificationPageParams, NotificationPageResponse } from "./notific
 
 const DEFAULT_PAGE_SIZE = 10;
 
-export const fetchNotificationPage = async (params: NotificationPageParams = {}) => {
+export const fetchNotificationPage = async (
+  params: NotificationPageParams = {},
+  signal?: AbortSignal,
+) => {
   const searchParams = new URLSearchParams();
 
   if (params.cursor) searchParams.set("cursor", params.cursor);
@@ -13,6 +16,7 @@ export const fetchNotificationPage = async (params: NotificationPageParams = {})
   const qs = searchParams.toString();
   const res = await httpClient.get<HttpResponseType<NotificationPageResponse>>(
     `/notifications/scroll?${qs}`,
+    { signal },
   );
 
   return res.items;

--- a/apps/hobom-system/src/entities/notification/api/notification.queries.ts
+++ b/apps/hobom-system/src/entities/notification/api/notification.queries.ts
@@ -7,7 +7,7 @@ export const notificationQueries = {
   pages: () =>
     infiniteQueryOptions({
       queryKey: [...notificationQueries.all(), "scroll"] as const,
-      queryFn: ({ pageParam }) => fetchNotificationPage({ cursor: pageParam }),
+      queryFn: ({ pageParam, signal }) => fetchNotificationPage({ cursor: pageParam }, signal),
       getNextPageParam: (lastPage) =>
         lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
       initialPageParam: undefined as string | undefined,

--- a/apps/hobom-system/src/entities/privacy-law/api/privacy-law.api.ts
+++ b/apps/hobom-system/src/entities/privacy-law/api/privacy-law.api.ts
@@ -15,38 +15,42 @@ const BASE = "/privacy-law";
 
 // ── Versions ──
 
-export const fetchVersions = async () => {
-  return await httpClient.get<HttpResponseType<LawVersion[]>>(`${BASE}/versions`);
+export const fetchVersions = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LawVersion[]>>(`${BASE}/versions`, { signal });
 };
 
-export const fetchVersionById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<LawVersion>>(`${BASE}/versions/${id}`);
+export const fetchVersionById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LawVersion>>(`${BASE}/versions/${id}`, { signal });
 };
 
 // ── Diffs ──
 
-export const fetchDiffs = async () => {
-  return await httpClient.get<HttpResponseType<LawDiff[]>>(`${BASE}/diffs`);
+export const fetchDiffs = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LawDiff[]>>(`${BASE}/diffs`, { signal });
 };
 
-export const fetchDiffById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<LawDiff>>(`${BASE}/diffs/${id}`);
+export const fetchDiffById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<LawDiff>>(`${BASE}/diffs/${id}`, { signal });
 };
 
 // ── Study Materials ──
 
-export const fetchStudyMaterials = async () => {
-  return await httpClient.get<HttpResponseType<StudyMaterial[]>>(`${BASE}/study-materials`);
+export const fetchStudyMaterials = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<StudyMaterial[]>>(`${BASE}/study-materials`, {
+    signal,
+  });
 };
 
-export const fetchStudyMaterialById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<StudyMaterial>>(`${BASE}/study-materials/${id}`);
+export const fetchStudyMaterialById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<StudyMaterial>>(`${BASE}/study-materials/${id}`, {
+    signal,
+  });
 };
 
 // ── Questions ──
 
-export const fetchQuestionHistory = async () => {
-  return await httpClient.get<HttpResponseType<QuestionHistory[]>>(`${BASE}/questions`);
+export const fetchQuestionHistory = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<QuestionHistory[]>>(`${BASE}/questions`, { signal });
 };
 
 export const postAskQuestion = async (data: AskQuestionRequest) => {
@@ -55,12 +59,12 @@ export const postAskQuestion = async (data: AskQuestionRequest) => {
 
 // ── Exams ──
 
-export const fetchExams = async () => {
-  return await httpClient.get<HttpResponseType<ExamSet[]>>(`${BASE}/exams`);
+export const fetchExams = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<ExamSet[]>>(`${BASE}/exams`, { signal });
 };
 
-export const fetchExamById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<ExamSetDetail>>(`${BASE}/exams/${id}`);
+export const fetchExamById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<ExamSetDetail>>(`${BASE}/exams/${id}`, { signal });
 };
 
 export const postGenerateExam = async () => {

--- a/apps/hobom-system/src/entities/privacy-law/api/privacy-law.queries.ts
+++ b/apps/hobom-system/src/entities/privacy-law/api/privacy-law.queries.ts
@@ -18,62 +18,62 @@ export const privacyLawQueries = {
   versions: () =>
     queryOptions({
       queryKey: ["privacy-law", "versions"] as const,
-      queryFn: fetchVersions,
+      queryFn: ({ signal }) => fetchVersions(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   version: (id: string) =>
     queryOptions({
       queryKey: ["privacy-law", "versions", id] as const,
-      queryFn: () => fetchVersionById({ id }),
+      queryFn: ({ signal }) => fetchVersionById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   diffs: () =>
     queryOptions({
       queryKey: ["privacy-law", "diffs"] as const,
-      queryFn: fetchDiffs,
+      queryFn: ({ signal }) => fetchDiffs(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   diff: (id: string) =>
     queryOptions({
       queryKey: ["privacy-law", "diffs", id] as const,
-      queryFn: () => fetchDiffById({ id }),
+      queryFn: ({ signal }) => fetchDiffById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   studyMaterials: () =>
     queryOptions({
       queryKey: ["privacy-law", "study-materials"] as const,
-      queryFn: fetchStudyMaterials,
+      queryFn: ({ signal }) => fetchStudyMaterials(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   studyMaterial: (id: string) =>
     queryOptions({
       queryKey: ["privacy-law", "study-materials", id] as const,
-      queryFn: () => fetchStudyMaterialById({ id }),
+      queryFn: ({ signal }) => fetchStudyMaterialById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   questionHistory: () =>
     queryOptions({
       queryKey: ["privacy-law", "questions"] as const,
-      queryFn: fetchQuestionHistory,
+      queryFn: ({ signal }) => fetchQuestionHistory(signal),
     }),
 
   exams: () =>
     queryOptions({
       queryKey: ["privacy-law", "exams"] as const,
-      queryFn: fetchExams,
+      queryFn: ({ signal }) => fetchExams(signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 
   exam: (id: string) =>
     queryOptions({
       queryKey: ["privacy-law", "exams", id] as const,
-      queryFn: () => fetchExamById({ id }),
+      queryFn: ({ signal }) => fetchExamById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/project-label/api/project-label.api.ts
+++ b/apps/hobom-system/src/entities/project-label/api/project-label.api.ts
@@ -6,9 +6,13 @@ import type {
   UpdateProjectLabelRequest,
 } from "./project-label.type";
 
-export const fetchProjectLabels = async ({ projectId }: { projectId: string }) => {
+export const fetchProjectLabels = async (
+  { projectId }: { projectId: string },
+  signal?: AbortSignal,
+) => {
   return await httpClient.get<HttpResponseType<ProjectLabelType[]>>(
     `/projects/${projectId}/labels`,
+    { signal },
   );
 };
 

--- a/apps/hobom-system/src/entities/project-label/api/project-label.queries.ts
+++ b/apps/hobom-system/src/entities/project-label/api/project-label.queries.ts
@@ -8,7 +8,7 @@ export const projectLabelQueries = {
   listByProject: (projectId: string) =>
     queryOptions({
       queryKey: ["project-labels", "list", projectId],
-      queryFn: () => fetchProjectLabels({ projectId }),
+      queryFn: ({ signal }) => fetchProjectLabels({ projectId }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/project/api/project.api.ts
+++ b/apps/hobom-system/src/entities/project/api/project.api.ts
@@ -2,12 +2,12 @@ import { httpClient } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
 import type { ProjectType, CreateProjectRequest, UpdateProjectRequest } from "./project.type";
 
-export const fetchProjects = async () => {
-  return await httpClient.get<HttpResponseType<ProjectType[]>>("/projects/me");
+export const fetchProjects = async (signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<ProjectType[]>>("/projects/me", { signal });
 };
 
-export const fetchProjectById = async ({ id }: { id: string }) => {
-  return await httpClient.get<HttpResponseType<ProjectType>>(`/projects/${id}`);
+export const fetchProjectById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  return await httpClient.get<HttpResponseType<ProjectType>>(`/projects/${id}`, { signal });
 };
 
 export const postCreateProject = async (data: CreateProjectRequest) => {

--- a/apps/hobom-system/src/entities/project/api/project.queries.ts
+++ b/apps/hobom-system/src/entities/project/api/project.queries.ts
@@ -8,14 +8,14 @@ export const projectQueries = {
   list: () =>
     queryOptions({
       queryKey: ["projects", "list"],
-      queryFn: fetchProjects,
+      queryFn: ({ signal }) => fetchProjects(signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   detail: (id: string) =>
     queryOptions({
       queryKey: ["projects", "detail", id],
-      queryFn: () => fetchProjectById({ id }),
+      queryFn: ({ signal }) => fetchProjectById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/sprint/api/sprint.api.ts
+++ b/apps/hobom-system/src/entities/sprint/api/sprint.api.ts
@@ -2,8 +2,13 @@ import { httpClient } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
 import type { SprintType, CreateSprintRequest, UpdateSprintRequest } from "./sprint.type";
 
-export const fetchSprintsByProject = async ({ projectId }: { projectId: string }) => {
-  return await httpClient.get<HttpResponseType<SprintType[]>>(`/projects/${projectId}/sprints`);
+export const fetchSprintsByProject = async (
+  { projectId }: { projectId: string },
+  signal?: AbortSignal,
+) => {
+  return await httpClient.get<HttpResponseType<SprintType[]>>(`/projects/${projectId}/sprints`, {
+    signal,
+  });
 };
 
 export const postCreateSprint = async ({

--- a/apps/hobom-system/src/entities/sprint/api/sprint.queries.ts
+++ b/apps/hobom-system/src/entities/sprint/api/sprint.queries.ts
@@ -8,7 +8,7 @@ export const sprintQueries = {
   listByProject: (projectId: string) =>
     queryOptions({
       queryKey: ["sprints", "list", projectId],
-      queryFn: () => fetchSprintsByProject({ projectId }),
+      queryFn: ({ signal }) => fetchSprintsByProject({ projectId }, signal),
       ...CACHE_PROFILE.MODERATE,
     }),
 } as const;

--- a/apps/hobom-system/src/entities/user/api/user.api.ts
+++ b/apps/hobom-system/src/entities/user/api/user.api.ts
@@ -1,13 +1,14 @@
 import { httpClient, type HttpResponseType } from "@/shared/api";
 import type { UserType } from "./user.type";
 
-export const fetchMe = async () => {
-  const res = await httpClient.get<HttpResponseType<UserType>>(`/auth/me`);
+export const fetchMe = async (signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<UserType>>(`/auth/me`, { signal });
 
   return res.items;
 };
 
-export const fetchUsers = async () => await httpClient.get<HttpResponseType<UserType[]>>(`/users`);
+export const fetchUsers = async (signal?: AbortSignal) =>
+  await httpClient.get<HttpResponseType<UserType[]>>(`/users`, { signal });
 
-export const fetchUserById = async ({ id }: { id: string }) =>
-  await httpClient.get<HttpResponseType<UserType>>(`/users/${id}`);
+export const fetchUserById = async ({ id }: { id: string }, signal?: AbortSignal) =>
+  await httpClient.get<HttpResponseType<UserType>>(`/users/${id}`, { signal });

--- a/apps/hobom-system/src/entities/user/api/user.queries.ts
+++ b/apps/hobom-system/src/entities/user/api/user.queries.ts
@@ -8,19 +8,19 @@ export const userQueries = {
   me: () =>
     queryOptions({
       queryKey: [...userQueries.users().queryKey, "me"],
-      queryFn: fetchMe,
+      queryFn: ({ signal }) => fetchMe(signal),
       ...CACHE_PROFILE.STATIC,
     }),
   list: () =>
     queryOptions({
       queryKey: [...userQueries.users().queryKey, "list"],
-      queryFn: fetchUsers,
+      queryFn: ({ signal }) => fetchUsers(signal),
       ...CACHE_PROFILE.SLOW,
     }),
   detail: (id: string) =>
     queryOptions({
       queryKey: [...userQueries.users().queryKey, id],
-      queryFn: () => fetchUserById({ id }),
+      queryFn: ({ signal }) => fetchUserById({ id }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 };

--- a/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.api.ts
+++ b/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.api.ts
@@ -2,19 +2,23 @@ import { spaceHttpClient } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
 import type { CommentType, CreateCommentRequest, UpdateCommentRequest } from "./wiki-comment.type";
 
-export const fetchComments = async ({
-  spaceKey,
-  pageId,
-  offset = 0,
-  limit = 50,
-}: {
-  spaceKey: string;
-  pageId: string;
-  offset?: number;
-  limit?: number;
-}) => {
+export const fetchComments = async (
+  {
+    spaceKey,
+    pageId,
+    offset = 0,
+    limit = 50,
+  }: {
+    spaceKey: string;
+    pageId: string;
+    offset?: number;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<PaginatedItems<CommentType>>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/comments?offset=${offset}&limit=${limit}`,
+    { signal },
   );
 };
 

--- a/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.queries.ts
+++ b/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.queries.ts
@@ -11,13 +11,16 @@ export const wikiCommentQueries = {
     infiniteQueryOptions({
       queryKey: ["wiki-comments", "list", spaceKey, pageId] as const,
       ...CACHE_PROFILE.FAST,
-      queryFn: ({ pageParam }) =>
-        fetchComments({
-          spaceKey,
-          pageId,
-          offset: pageParam,
-          limit: COMMENTS_PAGE_SIZE,
-        }),
+      queryFn: ({ pageParam, signal }) =>
+        fetchComments(
+          {
+            spaceKey,
+            pageId,
+            offset: pageParam,
+            limit: COMMENTS_PAGE_SIZE,
+          },
+          signal,
+        ),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => {
         const { offset, items, totalCount } = lastPage.items;

--- a/apps/hobom-system/src/entities/wiki-label/api/wiki-label.api.ts
+++ b/apps/hobom-system/src/entities/wiki-label/api/wiki-label.api.ts
@@ -10,9 +10,10 @@ import type {
 
 // ── Space Labels ──
 
-export const fetchLabels = async ({ spaceKey }: { spaceKey: string }) => {
+export const fetchLabels = async ({ spaceKey }: { spaceKey: string }, signal?: AbortSignal) => {
   return await spaceHttpClient.get<HttpResponseType<LabelType[]>>(
     `/api/v1/spaces/${spaceKey}/labels`,
+    { signal },
   );
 };
 
@@ -72,14 +73,18 @@ export const deletePageLabel = async ({
 
 // ── Label Pages ──
 
-export const fetchPagesByLabel = async ({
-  spaceKey,
-  labelId,
-}: {
-  spaceKey: string;
-  labelId: string;
-}) => {
+export const fetchPagesByLabel = async (
+  {
+    spaceKey,
+    labelId,
+  }: {
+    spaceKey: string;
+    labelId: string;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<LabelPageType[]>>(
     `/api/v1/spaces/${spaceKey}/labels/${labelId}/pages`,
+    { signal },
   );
 };

--- a/apps/hobom-system/src/entities/wiki-label/api/wiki-label.queries.ts
+++ b/apps/hobom-system/src/entities/wiki-label/api/wiki-label.queries.ts
@@ -8,13 +8,13 @@ export const wikiLabelQueries = {
   list: (spaceKey: string) =>
     queryOptions({
       queryKey: ["wiki-labels", "list", spaceKey] as const,
-      queryFn: () => fetchLabels({ spaceKey }),
+      queryFn: ({ signal }) => fetchLabels({ spaceKey }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   pagesByLabel: (spaceKey: string, labelId: string) =>
     queryOptions({
       queryKey: ["wiki-labels", "pages", spaceKey, labelId] as const,
-      queryFn: () => fetchPagesByLabel({ spaceKey, labelId }),
+      queryFn: ({ signal }) => fetchPagesByLabel({ spaceKey, labelId }, signal),
     }),
 } as const;

--- a/apps/hobom-system/src/entities/wiki-page/api/wiki-page.api.ts
+++ b/apps/hobom-system/src/entities/wiki-page/api/wiki-page.api.ts
@@ -15,15 +15,20 @@ import type {
 
 // ── Pages ──
 
-export const fetchPageTree = async ({ spaceKey }: { spaceKey: string }) => {
+export const fetchPageTree = async ({ spaceKey }: { spaceKey: string }, signal?: AbortSignal) => {
   return await spaceHttpClient.get<HttpResponseType<PageTreeNode[]>>(
     `/api/v1/spaces/${spaceKey}/pages`,
+    { signal },
   );
 };
 
-export const fetchPageById = async ({ spaceKey, pageId }: { spaceKey: string; pageId: string }) => {
+export const fetchPageById = async (
+  { spaceKey, pageId }: { spaceKey: string; pageId: string },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<PageType>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}`,
+    { signal },
   );
 };
 
@@ -56,33 +61,41 @@ export const deletePage = async ({ spaceKey, pageId }: { spaceKey: string; pageI
 
 // ── Versions ──
 
-export const fetchPageVersions = async ({
-  spaceKey,
-  pageId,
-  offset = 0,
-  limit = 20,
-}: {
-  spaceKey: string;
-  pageId: string;
-  offset?: number;
-  limit?: number;
-}) => {
+export const fetchPageVersions = async (
+  {
+    spaceKey,
+    pageId,
+    offset = 0,
+    limit = 20,
+  }: {
+    spaceKey: string;
+    pageId: string;
+    offset?: number;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<PaginatedItems<PageVersionType>>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions?offset=${offset}&limit=${limit}`,
+    { signal },
   );
 };
 
-export const fetchPageVersion = async ({
-  spaceKey,
-  pageId,
-  version,
-}: {
-  spaceKey: string;
-  pageId: string;
-  version: number;
-}) => {
+export const fetchPageVersion = async (
+  {
+    spaceKey,
+    pageId,
+    version,
+  }: {
+    spaceKey: string;
+    pageId: string;
+    version: number;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<PageVersionType>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions/${version}`,
+    { signal },
   );
 };
 
@@ -127,35 +140,43 @@ export const postCopyPage = async ({
 
 // ── Version Diff ──
 
-export const fetchVersionDiff = async ({
-  spaceKey,
-  pageId,
-  fromVersion,
-  toVersion,
-}: {
-  spaceKey: string;
-  pageId: string;
-  fromVersion: number;
-  toVersion: number;
-}) => {
+export const fetchVersionDiff = async (
+  {
+    spaceKey,
+    pageId,
+    fromVersion,
+    toVersion,
+  }: {
+    spaceKey: string;
+    pageId: string;
+    fromVersion: number;
+    toVersion: number;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<DiffEntryType[]>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions/diff?from=${fromVersion}&to=${toVersion}`,
+    { signal },
   );
 };
 
 // ── Trash ──
 
-export const fetchTrashPages = async ({
-  spaceKey,
-  offset = 0,
-  limit = 20,
-}: {
-  spaceKey: string;
-  offset?: number;
-  limit?: number;
-}) => {
+export const fetchTrashPages = async (
+  {
+    spaceKey,
+    offset = 0,
+    limit = 20,
+  }: {
+    spaceKey: string;
+    offset?: number;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+) => {
   return await spaceHttpClient.get<HttpResponseType<PaginatedItems<TrashPageType>>>(
     `/api/v1/spaces/${spaceKey}/trash?offset=${offset}&limit=${limit}`,
+    { signal },
   );
 };
 
@@ -186,20 +207,24 @@ export const deleteTrashPagePermanently = async ({
 
 // ── Search ──
 
-export const searchPages = async ({
-  q,
-  spaceKey,
-  offset = 0,
-  limit = 20,
-}: {
-  q: string;
-  spaceKey?: string;
-  offset?: number;
-  limit?: number;
-}) => {
+export const searchPages = async (
+  {
+    q,
+    spaceKey,
+    offset = 0,
+    limit = 20,
+  }: {
+    q: string;
+    spaceKey?: string;
+    offset?: number;
+    limit?: number;
+  },
+  signal?: AbortSignal,
+) => {
   const base = spaceKey ? `/api/v1/search/spaces/${spaceKey}` : "/api/v1/search";
 
   return await spaceHttpClient.get<HttpResponseType<PaginatedItems<SearchResultType>>>(
     `${base}?q=${encodeURIComponent(q)}&offset=${offset}&limit=${limit}`,
+    { signal },
   );
 };

--- a/apps/hobom-system/src/entities/wiki-page/api/wiki-page.queries.ts
+++ b/apps/hobom-system/src/entities/wiki-page/api/wiki-page.queries.ts
@@ -18,25 +18,28 @@ export const wikiPageQueries = {
   tree: (spaceKey: string) =>
     queryOptions({
       queryKey: ["wiki-pages", "tree", spaceKey] as const,
-      queryFn: () => fetchPageTree({ spaceKey }),
+      queryFn: ({ signal }) => fetchPageTree({ spaceKey }, signal),
     }),
 
   detail: (spaceKey: string, pageId: string) =>
     queryOptions({
       queryKey: ["wiki-pages", "detail", spaceKey, pageId] as const,
-      queryFn: () => fetchPageById({ spaceKey, pageId }),
+      queryFn: ({ signal }) => fetchPageById({ spaceKey, pageId }, signal),
     }),
 
   versions: (spaceKey: string, pageId: string) =>
     infiniteQueryOptions({
       queryKey: ["wiki-pages", "versions", spaceKey, pageId] as const,
-      queryFn: ({ pageParam }) =>
-        fetchPageVersions({
-          spaceKey,
-          pageId,
-          offset: pageParam,
-          limit: VERSIONS_PAGE_SIZE,
-        }),
+      queryFn: ({ pageParam, signal }) =>
+        fetchPageVersions(
+          {
+            spaceKey,
+            pageId,
+            offset: pageParam,
+            limit: VERSIONS_PAGE_SIZE,
+          },
+          signal,
+        ),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => {
         const { offset, items, totalCount } = lastPage.items;
@@ -49,20 +52,20 @@ export const wikiPageQueries = {
   version: (spaceKey: string, pageId: string, version: number) =>
     queryOptions({
       queryKey: ["wiki-pages", "version", spaceKey, pageId, version] as const,
-      queryFn: () => fetchPageVersion({ spaceKey, pageId, version }),
+      queryFn: ({ signal }) => fetchPageVersion({ spaceKey, pageId, version }, signal),
     }),
 
   versionDiff: (spaceKey: string, pageId: string, fromVersion: number, toVersion: number) =>
     queryOptions({
       queryKey: ["wiki-pages", "versionDiff", spaceKey, pageId, fromVersion, toVersion] as const,
-      queryFn: () => fetchVersionDiff({ spaceKey, pageId, fromVersion, toVersion }),
+      queryFn: ({ signal }) => fetchVersionDiff({ spaceKey, pageId, fromVersion, toVersion }, signal),
     }),
 
   trash: (spaceKey: string) =>
     infiniteQueryOptions({
       queryKey: ["wiki-pages", "trash", spaceKey] as const,
-      queryFn: ({ pageParam }) =>
-        fetchTrashPages({ spaceKey, offset: pageParam, limit: TRASH_PAGE_SIZE }),
+      queryFn: ({ pageParam, signal }) =>
+        fetchTrashPages({ spaceKey, offset: pageParam, limit: TRASH_PAGE_SIZE }, signal),
       initialPageParam: 0,
       getNextPageParam: (lastPage) => {
         const { offset, items, totalCount } = lastPage.items;
@@ -75,6 +78,6 @@ export const wikiPageQueries = {
   search: (spaceKey: string, q: string) =>
     queryOptions({
       queryKey: ["wiki-pages", "search", spaceKey, q] as const,
-      queryFn: () => searchPages({ q, spaceKey }),
+      queryFn: ({ signal }) => searchPages({ q, spaceKey }, signal),
     }),
 } as const;

--- a/apps/hobom-system/src/entities/wiki-space/api/wiki-space.api.ts
+++ b/apps/hobom-system/src/entities/wiki-space/api/wiki-space.api.ts
@@ -2,17 +2,21 @@ import { spaceHttpClient } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
 import type { SpaceType, CreateSpaceRequest, UpdateSpaceRequest } from "./wiki-space.type";
 
-export const fetchSpaces = async (params?: { offset?: number; limit?: number }) => {
+export const fetchSpaces = async (
+  params?: { offset?: number; limit?: number },
+  signal?: AbortSignal,
+) => {
   const offset = params?.offset ?? 0;
   const limit = params?.limit ?? 20;
 
   return await spaceHttpClient.get<HttpResponseType<PaginatedItems<SpaceType>>>(
     `/api/v1/spaces?offset=${offset}&limit=${limit}`,
+    { signal },
   );
 };
 
-export const fetchSpaceByKey = async ({ key }: { key: string }) => {
-  return await spaceHttpClient.get<HttpResponseType<SpaceType>>(`/api/v1/spaces/${key}`);
+export const fetchSpaceByKey = async ({ key }: { key: string }, signal?: AbortSignal) => {
+  return await spaceHttpClient.get<HttpResponseType<SpaceType>>(`/api/v1/spaces/${key}`, { signal });
 };
 
 export const postCreateSpace = async (data: CreateSpaceRequest) => {

--- a/apps/hobom-system/src/entities/wiki-space/api/wiki-space.queries.ts
+++ b/apps/hobom-system/src/entities/wiki-space/api/wiki-space.queries.ts
@@ -8,14 +8,14 @@ export const wikiSpaceQueries = {
   list: (params?: { offset?: number; limit?: number }) =>
     queryOptions({
       queryKey: ["wiki-spaces", "list", params] as const,
-      queryFn: () => fetchSpaces(params),
+      queryFn: ({ signal }) => fetchSpaces(params, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 
   detail: (key: string) =>
     queryOptions({
       queryKey: ["wiki-spaces", "detail", key] as const,
-      queryFn: () => fetchSpaceByKey({ key }),
+      queryFn: ({ signal }) => fetchSpaceByKey({ key }, signal),
       ...CACHE_PROFILE.SLOW,
     }),
 } as const;

--- a/apps/hobom-system/src/shared/api/http-client.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/http-client.api.spec.ts
@@ -107,6 +107,43 @@ describe("createHttpClient", () => {
     await expect(client.get("/slow", { timeout: 50 })).rejects.toThrow();
   });
 
+  // Mirror real fetch: reject on abort, including when the signal is already
+  // aborted by the time fetch is invoked.
+  const pendingUntilAbort = (_url: string, init: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      const abort = () => reject(new DOMException("aborted", "AbortError"));
+
+      if (init.signal?.aborted) {
+        abort();
+
+        return;
+      }
+
+      init.signal?.addEventListener("abort", abort);
+    });
+
+  it("외부 signal이 abort되면 요청도 abort된다", async () => {
+    mockFetch.mockImplementation(pendingUntilAbort);
+    const client = createHttpClient("https://api.test");
+    const controller = new AbortController();
+
+    const promise = client.get("/slow", { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow();
+  });
+
+  it("외부 signal이 붙어 있어도 timeout이 동작한다", async () => {
+    mockFetch.mockImplementation(pendingUntilAbort);
+    const client = createHttpClient("https://api.test");
+    const controller = new AbortController(); // never aborted
+
+    await expect(
+      client.get("/slow", { signal: controller.signal, timeout: 50 }),
+    ).rejects.toThrow();
+  });
+
   it("미들웨어 onRequest가 요청 전에 호출된다", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
     const client = createHttpClient("https://api.test");

--- a/apps/hobom-system/src/shared/api/http-client.api.ts
+++ b/apps/hobom-system/src/shared/api/http-client.api.ts
@@ -53,9 +53,21 @@ export const createHttpClient = (baseUrl = ""): HttpClient => {
       init.body = JSON.stringify(json);
     }
 
+    // Compose the caller's signal (e.g. a query's cancel signal) with the
+    // timeout into one controller, so a fetch aborts when either fires. Using
+    // the external signal directly would silently disable the timeout.
+    const externalSignal = init.signal ?? undefined;
     const controller = new AbortController();
 
-    init.signal = init.signal ?? controller.signal;
+    const onExternalAbort = () => controller.abort(externalSignal?.reason);
+
+    if (externalSignal?.aborted) {
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+    }
+
+    init.signal = controller.signal;
     const timeoutId = setTimeout(() => controller.abort(), timeout ?? DEFAULT_TIMEOUT_MS);
 
     const ctx: MiddlewareContext = { input: fullUrl, init };
@@ -100,6 +112,7 @@ export const createHttpClient = (baseUrl = ""): HttpClient => {
       }
     } finally {
       clearTimeout(timeoutId);
+      externalSignal?.removeEventListener("abort", onExternalAbort);
     }
   };
 


### PR DESCRIPTION
## The bug
`hobom-data` creates an `AbortController` per query and passes its `signal` into every `queryFn({ queryKey, signal })`. But the app threw it away — every read was `queryFn: () => fetchX(args)`. So `cancelQueries` / `invalidateQueries` aborted the query's controller while the actual `fetch` kept running.

Impact:
- **Optimistic updates** (note / daily-todo / issue) call `cancelQueries` in `onMutate` to stop an in-flight GET from resolving late and overwriting the optimistic value. That protection was a no-op → possible out-of-order write.
- Navigating away left pending GETs running → wasted bandwidth.

## The fix
Forward the signal end to end for every GET read-path:
`queryFn({ signal })` → `fetchX(args, signal)` → `httpClient.get(url, { signal })`.

- 19 `*.api.ts` GET fetch functions take an optional trailing `signal?: AbortSignal` (optional → non-query callers are unaffected).
- 24 `*.queries.ts` queryFns forward it (including the 3 infinite queries via `{ pageParam, signal }`).
- `httpClient` now **composes** the caller's signal with its timeout into one controller, so a request aborts when *either* fires. Previously passing an external signal silently disabled the 30s timeout.
- Mutations (`post/put/patch/delete`) are untouched.

## Tests
- `http-client.api.spec.ts` — an external signal aborts the request; the timeout still fires when a (non-aborted) external signal is present.
- The library-level contract (cancel aborts the signal handed to `queryFn`) is already covered in `hobom-data`.

## Verify
- app `tsc -b` clean, eslint clean, build ok
- 584 app tests pass (582 + 2 new)

Note: pairs with #165 (invalidation freshness) as the second of the two data-layer correctness fixes.