### PR TITLE
Split AppShell into focused units by concern

### DIFF
--- a/packages/hobom-design-system/src/patterns/AppShell/AppBar.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/AppBar.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { MenuOutlined } from "../../icons";
+import { Box } from "../../components/Box/Box";
+import { Button } from "../../components/Button/Button";
+import { Divider } from "../../components/Divider/Divider";
+import { Text } from "../../components/Text/Text";
+import { APPBAR_HEIGHT } from "../../foundations/layout";
+
+interface AppBarProps {
+  drawerOpen: boolean;
+  onToggleDrawer: () => void;
+  activeLabel: string;
+  action?: ReactNode;
+}
+
+const styles = stylex.create({
+  brand: {
+    fontWeight: 700,
+    fontSize: "0.7rem",
+    letterSpacing: "0.1em",
+    textTransform: "uppercase",
+    color: { default: "var(--hb-color-text-secondary)", ":hover": "var(--hb-color-accent)" },
+    cursor: "pointer",
+  },
+});
+
+export const AppBar = ({ drawerOpen, onToggleDrawer, activeLabel, action }: AppBarProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <header
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: APPBAR_HEIGHT,
+        zIndex: 1301,
+        backgroundColor: "var(--hb-color-chrome)",
+        color: "var(--hb-color-text-primary)",
+        boxShadow: "0 1px 0 rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: "100%",
+          paddingInline: 24,
+          gap: 16,
+        }}
+      >
+        <Button.Icon
+          aria-label="사이드바 토글"
+          aria-expanded={drawerOpen}
+          onClick={onToggleDrawer}
+          size="small"
+          edge="start"
+          style={{ color: "var(--hb-color-text-secondary)" }}
+        >
+          <MenuOutlined sx={{ fontSize: 20 }} />
+        </Button.Icon>
+        <span onClick={() => navigate("/")} {...stylex.props(styles.brand)}>
+          HoBom System
+        </span>
+        <Divider orientation="vertical" flexItem style={{ marginBlock: 12 }} />
+        <Text variant="body1" style={{ fontWeight: 600, color: "var(--hb-color-text-primary)" }}>
+          {activeLabel}
+        </Text>
+
+        {action && (
+          <>
+            <Box style={{ flex: 1 }} />
+            {action}
+          </>
+        )}
+      </div>
+    </header>
+  );
+};

--- a/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/AppShell.tsx
@@ -1,63 +1,19 @@
-import { useState, type CSSProperties, type KeyboardEvent, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
-import { Bom } from "hobom-utils";
-import { ExpandLess, ExpandMore, MenuOutlined } from "../../icons";
 import { Box } from "../../components/Box/Box";
-import { Button } from "../../components/Button/Button";
-import { Collapse } from "../../components/Collapse/Collapse";
-import { Divider } from "../../components/Divider/Divider";
-import { List } from "../../components/List/List";
-import { Text } from "../../components/Text/Text";
-import { Tooltip } from "../../components/Tooltip/Tooltip";
 import { DRAWER_WIDTH, DRAWER_WIDTH_COLLAPSED, APPBAR_HEIGHT } from "../../foundations/layout";
+import { AppBar } from "./AppBar";
+import { Sidebar } from "./Sidebar";
+import { resolveActiveItem, type AppShellNavItem, type NavEntry } from "./nav-items.lib";
 
-export interface AppShellNavItem {
-  /** 네비게이션 아이템의 고유 식별자. 활성 상태 판별에 사용. */
-  value: string;
-  /** 사이드바에 표시할 텍스트. 접힘 모드에서는 Tooltip으로 표시. */
-  label: string;
-  /** 클릭 시 이동할 경로. `location.pathname.startsWith(path)`로 활성 상태 판별. */
-  path: string;
-  icon: ReactNode;
-  /** 접이식 서브 메뉴 아이템. 부모 아이템 클릭 시 토글. */
-  children?: AppShellNavItem[];
-}
-
-/** 섹션 헤더로 그룹화된 네비게이션 아이템 모음. */
-export interface AppShellNavSection {
-  /** 섹션 고유 키. */
-  section: string;
-  /** 사이드바에 표시할 섹션 헤더 텍스트. */
-  label: string;
-  /** 이 섹션에 속하는 아이템 목록. */
-  items: AppShellNavItem[];
-}
-
-/** 독립 아이템 또는 섹션. navItems prop의 엘리먼트 타입. */
-export type NavEntry = AppShellNavItem | AppShellNavSection;
-
-const isSection = (entry: NavEntry): entry is AppShellNavSection => "items" in entry;
-
-/** children 포함 전체 아이템을 1차원 배열로 펼친다. */
-const flattenNavItems = (items: AppShellNavItem[]): AppShellNavItem[] =>
-  items.flatMap((item) => (item.children ? [item, ...item.children] : [item]));
-
-/** NavEntry[]에서 모든 AppShellNavItem을 1차원 배열로 추출한다. */
-const flattenNavEntries = (entries: NavEntry[]): AppShellNavItem[] =>
-  entries.flatMap((entry) =>
-    isSection(entry) ? flattenNavItems(entry.items) : flattenNavItems([entry]),
-  );
-
-interface Props {
+interface AppShellProps {
   children: ReactNode;
   navItems: NavEntry[];
   bottomNavItems?: AppShellNavItem[];
   appBarAction?: ReactNode;
   onPrefetch?: (path: string) => void;
 }
-
-const TRANSITION = "width 0.25s cubic-bezier(0.4, 0, 0.2, 1)";
 
 const styles = stylex.create({
   skipLink: {
@@ -74,179 +30,10 @@ const styles = stylex.create({
     fontWeight: 600,
     textDecoration: "none",
   },
-  brand: {
-    fontWeight: 700,
-    fontSize: "0.7rem",
-    letterSpacing: "0.1em",
-    textTransform: "uppercase",
-    color: { default: "var(--hb-color-text-secondary)", ":hover": "var(--hb-color-accent)" },
-    cursor: "pointer",
-  },
-  sectionHeader: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingInline: 8,
-    marginBottom: 4,
-    cursor: "pointer",
-    borderRadius: 8,
-    backgroundColor: { default: "transparent", ":hover": "rgba(0, 0, 0, 0.04)" },
-  },
 });
 
-const NavList = ({
-  items,
-  activeValue,
-  collapsed,
-  onNavigate,
-  onPrefetch,
-}: {
-  items: AppShellNavItem[];
-  activeValue: string;
-  collapsed: boolean;
-  onNavigate: (path: string) => void;
-  onPrefetch?: (path: string) => void;
-}) => {
-  const [openGroups, setOpenGroups] = useState<Set<string>>(() => {
-    const initial = new Set<string>();
-
-    for (const item of items) {
-      if (item.children?.some((child) => child.value === activeValue)) {
-        initial.add(item.value);
-      }
-    }
-
-    return initial;
-  });
-
-  const toggleGroup = (value: string) => {
-    setOpenGroups((prev) => {
-      const next = new Set(prev);
-
-      if (next.has(value)) next.delete(value);
-      else next.add(value);
-
-      return next;
-    });
-  };
-
-  return (
-    <List.Root disablePadding>
-      {items.map((item) => {
-        const hasChildren = item.children && item.children.length > 0;
-        const isGroupOpen = openGroups.has(item.value);
-        const isActive = item.value === activeValue;
-        const isChildActive = item.children?.some((c) => c.value === activeValue) ?? false;
-
-        const button = (
-          <List.ItemButton
-            key={item.value}
-            selected={!hasChildren && isActive}
-            aria-current={!hasChildren && isActive ? "page" : undefined}
-            onClick={() => (hasChildren ? toggleGroup(item.value) : onNavigate(item.path))}
-            onMouseEnter={() => !hasChildren && onPrefetch?.(item.path)}
-            style={collapsed ? { justifyContent: "center", paddingInline: 12 } : undefined}
-          >
-            <List.ItemIcon style={collapsed ? { minWidth: 0, justifyContent: "center" } : undefined}>
-              {item.icon}
-            </List.ItemIcon>
-            {!collapsed && (
-              <>
-                <List.ItemText
-                  primary={item.label}
-                  primaryStyle={{
-                    fontSize: "0.875rem",
-                    fontWeight: isActive || isChildActive ? 600 : 400,
-                  }}
-                />
-                {hasChildren &&
-                  (isGroupOpen ? (
-                    <ExpandLess sx={{ fontSize: 18, opacity: 0.5 }} />
-                  ) : (
-                    <ExpandMore sx={{ fontSize: 18, opacity: 0.5 }} />
-                  ))}
-              </>
-            )}
-          </List.ItemButton>
-        );
-
-        const wrappedButton = collapsed ? (
-          <Tooltip key={item.value} title={item.label} placement="right" arrow>
-            {button}
-          </Tooltip>
-        ) : (
-          button
-        );
-
-        if (!hasChildren) return wrappedButton;
-
-        // 접힘 모드: children을 부모 아이콘 Tooltip에 flat 렌더링
-        if (collapsed) {
-          return (
-            <Box key={item.value}>
-              {wrappedButton}
-              {item.children?.map((child) => {
-                const childActive = child.value === activeValue;
-
-                return (
-                  <Tooltip key={child.value} title={child.label} placement="right" arrow>
-                    <List.ItemButton
-                      selected={childActive}
-                      aria-current={childActive ? "page" : undefined}
-                      onClick={() => onNavigate(child.path)}
-                      onMouseEnter={() => onPrefetch?.(child.path)}
-                      style={{ justifyContent: "center", paddingInline: 12 }}
-                    >
-                      <List.ItemIcon style={{ minWidth: 0, justifyContent: "center" }}>
-                        {child.icon}
-                      </List.ItemIcon>
-                    </List.ItemButton>
-                  </Tooltip>
-                );
-              })}
-            </Box>
-          );
-        }
-
-        return (
-          <Box key={item.value}>
-            {wrappedButton}
-            <Collapse in={isGroupOpen} unmountOnExit>
-              <List.Root disablePadding>
-                {item.children?.map((child) => {
-                  const childActive = child.value === activeValue;
-
-                  return (
-                    <List.ItemButton
-                      key={child.value}
-                      selected={childActive}
-                      aria-current={childActive ? "page" : undefined}
-                      onClick={() => onNavigate(child.path)}
-                      onMouseEnter={() => onPrefetch?.(child.path)}
-                      style={{ paddingLeft: 36 }}
-                    >
-                      <List.ItemIcon style={{ minWidth: 28 }}>{child.icon}</List.ItemIcon>
-                      <List.ItemText
-                        primary={child.label}
-                        primaryStyle={{
-                          fontSize: "0.8125rem",
-                          fontWeight: childActive ? 600 : 400,
-                        }}
-                      />
-                    </List.ItemButton>
-                  );
-                })}
-              </List.Root>
-            </Collapse>
-          </Box>
-        );
-      })}
-    </List.Root>
-  );
-};
-
 /**
- * 데스크톱 레이아웃 쉘. AppBar(56px) + Drawer(240px/64px) + main 콘텐츠로 구성.
+ * 데스크톱 레이아웃 쉘. AppBar(56px) + Sidebar(240px/64px) + main 콘텐츠로 구성.
  * 현재 경로와 가장 긴 prefix 매칭되는 navItem이 활성 상태로 표시된다.
  */
 export const AppShell = ({
@@ -255,54 +42,13 @@ export const AppShell = ({
   bottomNavItems,
   appBarAction,
   onPrefetch,
-}: Props) => {
+}: AppShellProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [drawerOpen, setDrawerOpen] = useState(true);
 
-  // 현재 활성 아이템이 속한 섹션을 자동 펼침
-  const [openSections, setOpenSections] = useState<Set<string>>(() => {
-    const initial = new Set<string>();
-
-    for (const entry of navItems) {
-      if (isSection(entry)) {
-        initial.add(entry.section);
-      }
-    }
-
-    return initial;
-  });
-
-  const toggleSection = (section: string) => {
-    setOpenSections((prev) => {
-      const next = new Set(prev);
-
-      if (next.has(section)) next.delete(section);
-      else next.add(section);
-
-      return next;
-    });
-  };
-
+  const activeItem = resolveActiveItem(navItems, bottomNavItems, location.pathname);
   const currentWidth = drawerOpen ? DRAWER_WIDTH : DRAWER_WIDTH_COLLAPSED;
-
-  const allItems = [...flattenNavEntries(navItems), ...flattenNavItems(bottomNavItems ?? [])];
-  const firstItem = (() => {
-    const first = navItems[0];
-
-    return first && isSection(first) ? first.items[0] : first;
-  })();
-  const activeItem = Bom.pipe(
-    location.pathname,
-    (currentPath) => {
-      const sorted = [...allItems].sort((a, b) => b.path.length - a.path.length);
-
-      return sorted.find((item) => currentPath.startsWith(item.path));
-    },
-    Bom.when(Bom.isNullish, () => firstItem),
-  );
-
-  const navPadding: CSSProperties = { paddingInline: drawerOpen ? 12 : 6 };
 
   return (
     <div
@@ -317,186 +63,21 @@ export const AppShell = ({
         본문으로 건너뛰기
       </a>
 
-      <header
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          height: APPBAR_HEIGHT,
-          zIndex: 1301,
-          backgroundColor: "var(--hb-color-chrome)",
-          color: "var(--hb-color-text-primary)",
-          boxShadow: "0 1px 0 rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04)",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            height: "100%",
-            paddingInline: 24,
-            gap: 16,
-          }}
-        >
-          <Button.Icon
-            aria-label="사이드바 토글"
-            aria-expanded={drawerOpen}
-            onClick={() => setDrawerOpen((prev) => !prev)}
-            size="small"
-            edge="start"
-            style={{ color: "var(--hb-color-text-secondary)" }}
-          >
-            <MenuOutlined sx={{ fontSize: 20 }} />
-          </Button.Icon>
-          <span onClick={() => navigate("/")} {...stylex.props(styles.brand)}>
-            HoBom System
-          </span>
-          <Divider orientation="vertical" flexItem style={{ marginBlock: 12 }} />
-          <Text variant="body1" style={{ fontWeight: 600, color: "var(--hb-color-text-primary)" }}>
-            {activeItem.label}
-          </Text>
+      <AppBar
+        drawerOpen={drawerOpen}
+        onToggleDrawer={() => setDrawerOpen((prev) => !prev)}
+        activeLabel={activeItem?.label ?? ""}
+        action={appBarAction}
+      />
 
-          {appBarAction && (
-            <>
-              <Box style={{ flex: 1 }} />
-              {appBarAction}
-            </>
-          )}
-        </div>
-      </header>
-
-      <aside
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          height: "100vh",
-          width: currentWidth,
-          zIndex: 1200,
-          boxSizing: "border-box",
-          display: "flex",
-          flexDirection: "column",
-          overflowX: "hidden",
-          backgroundColor: "var(--hb-color-chrome)",
-          borderRight: "1px solid var(--hb-color-border)",
-          transition: TRANSITION,
-        }}
-      >
-        {/* 로고 영역 */}
-        <Box
-          style={{
-            height: APPBAR_HEIGHT,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            paddingInline: drawerOpen ? 20 : 0,
-            flexShrink: 0,
-          }}
-        >
-          <Text
-            variant="h6"
-            style={{
-              fontWeight: 800,
-              fontSize: "1.15rem",
-              color: "var(--hb-color-text-primary)",
-              letterSpacing: "0.02em",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {drawerOpen ? "HoBom" : "H"}
-          </Text>
-        </Box>
-
-        <Divider />
-
-        <Box
-          component="nav"
-          aria-label="메인 네비게이션"
-          style={{ ...navPadding, paddingBlock: 16, flexGrow: 1 }}
-        >
-          {navItems.map((entry, index) => {
-            if (isSection(entry)) {
-              const isSectionOpen = openSections.has(entry.section);
-
-              return (
-                <Box key={entry.section}>
-                  {drawerOpen ? (
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      aria-expanded={isSectionOpen}
-                      onClick={() => toggleSection(entry.section)}
-                      onKeyDown={(e: KeyboardEvent) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          toggleSection(entry.section);
-                        }
-                      }}
-                      {...stylex.props(styles.sectionHeader)}
-                      style={{ marginTop: index > 0 ? 16 : 0 }}
-                    >
-                      <Text
-                        variant="caption"
-                        style={{
-                          color: "var(--hb-color-text-secondary)",
-                          fontSize: "0.7125rem",
-                          fontWeight: 600,
-                          letterSpacing: "0.1em",
-                          textTransform: "uppercase",
-                          userSelect: "none",
-                        }}
-                      >
-                        {entry.label}
-                      </Text>
-                      {isSectionOpen ? (
-                        <ExpandLess sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
-                      ) : (
-                        <ExpandMore sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
-                      )}
-                    </div>
-                  ) : (
-                    index > 0 && <Divider style={{ marginBlock: 8 }} />
-                  )}
-                  <Collapse in={!drawerOpen || isSectionOpen} unmountOnExit>
-                    <NavList
-                      items={entry.items}
-                      activeValue={activeItem.value}
-                      collapsed={!drawerOpen}
-                      onNavigate={navigate}
-                      onPrefetch={onPrefetch}
-                    />
-                  </Collapse>
-                </Box>
-              );
-            }
-
-            return (
-              <NavList
-                key={entry.value}
-                items={[entry]}
-                activeValue={activeItem.value}
-                collapsed={!drawerOpen}
-                onNavigate={navigate}
-                onPrefetch={onPrefetch}
-              />
-            );
-          })}
-        </Box>
-
-        {bottomNavItems && bottomNavItems.length > 0 && (
-          <Box style={{ ...navPadding, paddingBottom: 16 }}>
-            <Divider style={{ marginBottom: 12 }} />
-            <NavList
-              items={bottomNavItems}
-              activeValue={activeItem.value}
-              collapsed={!drawerOpen}
-              onNavigate={navigate}
-              onPrefetch={onPrefetch}
-            />
-          </Box>
-        )}
-      </aside>
+      <Sidebar
+        navItems={navItems}
+        bottomNavItems={bottomNavItems}
+        drawerOpen={drawerOpen}
+        activeValue={activeItem?.value ?? ""}
+        onNavigate={navigate}
+        onPrefetch={onPrefetch}
+      />
 
       <Box
         component="main"

--- a/packages/hobom-design-system/src/patterns/AppShell/NavList.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/NavList.tsx
@@ -1,0 +1,143 @@
+import { ExpandLess, ExpandMore } from "../../icons";
+import { Box } from "../../components/Box/Box";
+import { Collapse } from "../../components/Collapse/Collapse";
+import { List } from "../../components/List/List";
+import { Tooltip } from "../../components/Tooltip/Tooltip";
+import { useToggleSet } from "./useToggleSet";
+import type { AppShellNavItem } from "./nav-items.lib";
+
+interface NavListProps {
+  items: AppShellNavItem[];
+  activeValue: string;
+  collapsed: boolean;
+  onNavigate: (path: string) => void;
+  onPrefetch?: (path: string) => void;
+}
+
+export const NavList = ({ items, activeValue, collapsed, onNavigate, onPrefetch }: NavListProps) => {
+  const [openGroups, toggleGroup] = useToggleSet(() => {
+    const initial = new Set<string>();
+
+    for (const item of items) {
+      if (item.children?.some((child) => child.value === activeValue)) {
+        initial.add(item.value);
+      }
+    }
+
+    return initial;
+  });
+
+  return (
+    <List.Root disablePadding>
+      {items.map((item) => {
+        const hasChildren = item.children && item.children.length > 0;
+        const isGroupOpen = openGroups.has(item.value);
+        const isActive = item.value === activeValue;
+        const isChildActive = item.children?.some((c) => c.value === activeValue) ?? false;
+
+        const button = (
+          <List.ItemButton
+            key={item.value}
+            selected={!hasChildren && isActive}
+            aria-current={!hasChildren && isActive ? "page" : undefined}
+            onClick={() => (hasChildren ? toggleGroup(item.value) : onNavigate(item.path))}
+            onMouseEnter={() => !hasChildren && onPrefetch?.(item.path)}
+            style={collapsed ? { justifyContent: "center", paddingInline: 12 } : undefined}
+          >
+            <List.ItemIcon style={collapsed ? { minWidth: 0, justifyContent: "center" } : undefined}>
+              {item.icon}
+            </List.ItemIcon>
+            {!collapsed && (
+              <>
+                <List.ItemText
+                  primary={item.label}
+                  primaryStyle={{
+                    fontSize: "0.875rem",
+                    fontWeight: isActive || isChildActive ? 600 : 400,
+                  }}
+                />
+                {hasChildren &&
+                  (isGroupOpen ? (
+                    <ExpandLess sx={{ fontSize: 18, opacity: 0.5 }} />
+                  ) : (
+                    <ExpandMore sx={{ fontSize: 18, opacity: 0.5 }} />
+                  ))}
+              </>
+            )}
+          </List.ItemButton>
+        );
+
+        const wrappedButton = collapsed ? (
+          <Tooltip key={item.value} title={item.label} placement="right" arrow>
+            {button}
+          </Tooltip>
+        ) : (
+          button
+        );
+
+        if (!hasChildren) return wrappedButton;
+
+        // Collapsed: render children flat under the parent icon with tooltips.
+        if (collapsed) {
+          return (
+            <Box key={item.value}>
+              {wrappedButton}
+              {item.children?.map((child) => {
+                const childActive = child.value === activeValue;
+
+                return (
+                  <Tooltip key={child.value} title={child.label} placement="right" arrow>
+                    <List.ItemButton
+                      selected={childActive}
+                      aria-current={childActive ? "page" : undefined}
+                      onClick={() => onNavigate(child.path)}
+                      onMouseEnter={() => onPrefetch?.(child.path)}
+                      style={{ justifyContent: "center", paddingInline: 12 }}
+                    >
+                      <List.ItemIcon style={{ minWidth: 0, justifyContent: "center" }}>
+                        {child.icon}
+                      </List.ItemIcon>
+                    </List.ItemButton>
+                  </Tooltip>
+                );
+              })}
+            </Box>
+          );
+        }
+
+        return (
+          <Box key={item.value}>
+            {wrappedButton}
+            <Collapse in={isGroupOpen} unmountOnExit>
+              <List.Root disablePadding>
+                {item.children?.map((child) => {
+                  const childActive = child.value === activeValue;
+
+                  return (
+                    <List.ItemButton
+                      key={child.value}
+                      selected={childActive}
+                      aria-current={childActive ? "page" : undefined}
+                      onClick={() => onNavigate(child.path)}
+                      onMouseEnter={() => onPrefetch?.(child.path)}
+                      style={{ paddingLeft: 36 }}
+                    >
+                      <List.ItemIcon style={{ minWidth: 28 }}>{child.icon}</List.ItemIcon>
+                      <List.ItemText
+                        primary={child.label}
+                        primaryStyle={{
+                          fontSize: "0.8125rem",
+                          fontWeight: childActive ? 600 : 400,
+                        }}
+                      />
+                    </List.ItemButton>
+                  );
+                })}
+              </List.Root>
+            </Collapse>
+          </Box>
+        );
+      })}
+    </List.Root>
+  );
+};

--- a/packages/hobom-design-system/src/patterns/AppShell/Sidebar.tsx
+++ b/packages/hobom-design-system/src/patterns/AppShell/Sidebar.tsx
@@ -1,0 +1,193 @@
+import type { CSSProperties, KeyboardEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { ExpandLess, ExpandMore } from "../../icons";
+import { Box } from "../../components/Box/Box";
+import { Collapse } from "../../components/Collapse/Collapse";
+import { Divider } from "../../components/Divider/Divider";
+import { Text } from "../../components/Text/Text";
+import { DRAWER_WIDTH, DRAWER_WIDTH_COLLAPSED, APPBAR_HEIGHT } from "../../foundations/layout";
+import { NavList } from "./NavList";
+import { useToggleSet } from "./useToggleSet";
+import { isSection, type AppShellNavItem, type NavEntry } from "./nav-items.lib";
+
+interface SidebarProps {
+  navItems: NavEntry[];
+  bottomNavItems?: AppShellNavItem[];
+  drawerOpen: boolean;
+  activeValue: string;
+  onNavigate: (path: string) => void;
+  onPrefetch?: (path: string) => void;
+}
+
+const TRANSITION = "width 0.25s cubic-bezier(0.4, 0, 0.2, 1)";
+
+const styles = stylex.create({
+  sectionHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingInline: 8,
+    marginBottom: 4,
+    cursor: "pointer",
+    borderRadius: 8,
+    backgroundColor: { default: "transparent", ":hover": "rgba(0, 0, 0, 0.04)" },
+  },
+});
+
+export const Sidebar = ({
+  navItems,
+  bottomNavItems,
+  drawerOpen,
+  activeValue,
+  onNavigate,
+  onPrefetch,
+}: SidebarProps) => {
+  const [openSections, toggleSection] = useToggleSet(() => {
+    const initial = new Set<string>();
+
+    for (const entry of navItems) {
+      if (isSection(entry)) {
+        initial.add(entry.section);
+      }
+    }
+
+    return initial;
+  });
+
+  const currentWidth = drawerOpen ? DRAWER_WIDTH : DRAWER_WIDTH_COLLAPSED;
+  const navPadding: CSSProperties = { paddingInline: drawerOpen ? 12 : 6 };
+
+  return (
+    <aside
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        height: "100vh",
+        width: currentWidth,
+        zIndex: 1200,
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        overflowX: "hidden",
+        backgroundColor: "var(--hb-color-chrome)",
+        borderRight: "1px solid var(--hb-color-border)",
+        transition: TRANSITION,
+      }}
+    >
+      {/* 로고 영역 */}
+      <Box
+        style={{
+          height: APPBAR_HEIGHT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          paddingInline: drawerOpen ? 20 : 0,
+          flexShrink: 0,
+        }}
+      >
+        <Text
+          variant="h6"
+          style={{
+            fontWeight: 800,
+            fontSize: "1.15rem",
+            color: "var(--hb-color-text-primary)",
+            letterSpacing: "0.02em",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {drawerOpen ? "HoBom" : "H"}
+        </Text>
+      </Box>
+
+      <Divider />
+
+      <Box
+        component="nav"
+        aria-label="메인 네비게이션"
+        style={{ ...navPadding, paddingBlock: 16, flexGrow: 1 }}
+      >
+        {navItems.map((entry, index) => {
+          if (isSection(entry)) {
+            const isSectionOpen = openSections.has(entry.section);
+
+            return (
+              <Box key={entry.section}>
+                {drawerOpen ? (
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={isSectionOpen}
+                    onClick={() => toggleSection(entry.section)}
+                    onKeyDown={(e: KeyboardEvent) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggleSection(entry.section);
+                      }
+                    }}
+                    {...stylex.props(styles.sectionHeader)}
+                    style={{ marginTop: index > 0 ? 16 : 0 }}
+                  >
+                    <Text
+                      variant="caption"
+                      style={{
+                        color: "var(--hb-color-text-secondary)",
+                        fontSize: "0.7125rem",
+                        fontWeight: 600,
+                        letterSpacing: "0.1em",
+                        textTransform: "uppercase",
+                        userSelect: "none",
+                      }}
+                    >
+                      {entry.label}
+                    </Text>
+                    {isSectionOpen ? (
+                      <ExpandLess sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
+                    ) : (
+                      <ExpandMore sx={{ fontSize: 14, color: "var(--hb-color-text-disabled)" }} />
+                    )}
+                  </div>
+                ) : (
+                  index > 0 && <Divider style={{ marginBlock: 8 }} />
+                )}
+                <Collapse in={!drawerOpen || isSectionOpen} unmountOnExit>
+                  <NavList
+                    items={entry.items}
+                    activeValue={activeValue}
+                    collapsed={!drawerOpen}
+                    onNavigate={onNavigate}
+                    onPrefetch={onPrefetch}
+                  />
+                </Collapse>
+              </Box>
+            );
+          }
+
+          return (
+            <NavList
+              key={entry.value}
+              items={[entry]}
+              activeValue={activeValue}
+              collapsed={!drawerOpen}
+              onNavigate={onNavigate}
+              onPrefetch={onPrefetch}
+            />
+          );
+        })}
+      </Box>
+
+      {bottomNavItems && bottomNavItems.length > 0 && (
+        <Box style={{ ...navPadding, paddingBottom: 16 }}>
+          <Divider style={{ marginBottom: 12 }} />
+          <NavList
+            items={bottomNavItems}
+            activeValue={activeValue}
+            collapsed={!drawerOpen}
+            onNavigate={onNavigate}
+            onPrefetch={onPrefetch}
+          />
+        </Box>
+      )}
+    </aside>
+  );
+};

--- a/packages/hobom-design-system/src/patterns/AppShell/index.ts
+++ b/packages/hobom-design-system/src/patterns/AppShell/index.ts
@@ -1,1 +1,2 @@
-export * from "./AppShell";
+export { AppShell } from "./AppShell";
+export type { AppShellNavItem, AppShellNavSection, NavEntry } from "./nav-items.lib";

--- a/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.spec.ts
+++ b/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  flattenNavEntries,
+  flattenNavItems,
+  isSection,
+  resolveActiveItem,
+  type AppShellNavItem,
+  type NavEntry,
+} from "./nav-items.lib";
+
+const item = (value: string, path: string, children?: AppShellNavItem[]): AppShellNavItem => ({
+  value,
+  label: value,
+  path,
+  icon: null,
+  children,
+});
+
+describe("isSection", () => {
+  it("distinguishes a section from a plain item", () => {
+    expect(isSection({ section: "s", label: "S", items: [] })).toBe(true);
+    expect(isSection(item("a", "/a"))).toBe(false);
+  });
+});
+
+describe("flattenNavItems", () => {
+  it("inlines children after their parent", () => {
+    const parent = item("p", "/p", [item("c1", "/p/1"), item("c2", "/p/2")]);
+
+    expect(flattenNavItems([parent, item("q", "/q")]).map((i) => i.value)).toEqual([
+      "p",
+      "c1",
+      "c2",
+      "q",
+    ]);
+  });
+});
+
+describe("flattenNavEntries", () => {
+  it("flattens sections and standalone items alike", () => {
+    const entries: NavEntry[] = [
+      { section: "s", label: "S", items: [item("a", "/a"), item("b", "/b", [item("b1", "/b/1")])] },
+      item("c", "/c"),
+    ];
+
+    expect(flattenNavEntries(entries).map((i) => i.value)).toEqual(["a", "b", "b1", "c"]);
+  });
+});
+
+describe("resolveActiveItem", () => {
+  const entries: NavEntry[] = [
+    { section: "s", label: "S", items: [item("dash", "/"), item("issues", "/issues")] },
+    item("board", "/board", [item("kanban", "/board/kanban")]),
+  ];
+
+  it("picks the longest matching path prefix", () => {
+    expect(resolveActiveItem(entries, undefined, "/board/kanban/123")?.value).toBe("kanban");
+    expect(resolveActiveItem(entries, undefined, "/issues/42")?.value).toBe("issues");
+  });
+
+  it("does not let a shorter prefix shadow a longer one", () => {
+    // "/" matches everything, but "/board" is the longer, more specific match.
+    expect(resolveActiveItem(entries, undefined, "/board")?.value).toBe("board");
+  });
+
+  it("also considers bottom items", () => {
+    const bottom = [item("settings", "/settings")];
+
+    expect(resolveActiveItem(entries, bottom, "/settings")?.value).toBe("settings");
+  });
+
+  it("falls back to the first item when nothing matches", () => {
+    const noRoot: NavEntry[] = [item("board", "/board"), item("issues", "/issues")];
+
+    expect(resolveActiveItem(noRoot, undefined, "/unknown")?.value).toBe("board");
+  });
+
+  it("falls back to the first item inside a leading section", () => {
+    expect(resolveActiveItem(entries, undefined, "/nope")?.value).toBe("dash");
+  });
+});

--- a/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.ts
+++ b/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Bom } from "hobom-utils";
 
 export interface AppShellNavItem {
   /** 네비게이션 아이템의 고유 식별자. 활성 상태 판별에 사용. */
@@ -52,9 +53,10 @@ export const resolveActiveItem = (
   entries: NavEntry[],
   bottomItems: AppShellNavItem[] | undefined,
   pathname: string,
-): AppShellNavItem | undefined => {
-  const allItems = [...flattenNavEntries(entries), ...flattenNavItems(bottomItems ?? [])];
-  const byPathLengthDesc = [...allItems].sort((a, b) => b.path.length - a.path.length);
-
-  return byPathLengthDesc.find((item) => pathname.startsWith(item.path)) ?? firstNavItem(entries);
-};
+): AppShellNavItem | undefined =>
+  Bom.pipe(
+    [...flattenNavEntries(entries), ...flattenNavItems(bottomItems ?? [])],
+    Bom.sortBy((item) => -item.path.length),
+    (items) => items.find((item) => pathname.startsWith(item.path)),
+    Bom.when(Bom.isNullish, () => firstNavItem(entries)),
+  );

--- a/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.ts
+++ b/packages/hobom-design-system/src/patterns/AppShell/nav-items.lib.ts
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+export interface AppShellNavItem {
+  /** 네비게이션 아이템의 고유 식별자. 활성 상태 판별에 사용. */
+  value: string;
+  /** 사이드바에 표시할 텍스트. 접힘 모드에서는 Tooltip으로 표시. */
+  label: string;
+  /** 클릭 시 이동할 경로. `location.pathname.startsWith(path)`로 활성 상태 판별. */
+  path: string;
+  icon: ReactNode;
+  /** 접이식 서브 메뉴 아이템. 부모 아이템 클릭 시 토글. */
+  children?: AppShellNavItem[];
+}
+
+/** 섹션 헤더로 그룹화된 네비게이션 아이템 모음. */
+export interface AppShellNavSection {
+  /** 섹션 고유 키. */
+  section: string;
+  /** 사이드바에 표시할 섹션 헤더 텍스트. */
+  label: string;
+  /** 이 섹션에 속하는 아이템 목록. */
+  items: AppShellNavItem[];
+}
+
+/** 독립 아이템 또는 섹션. navItems prop의 엘리먼트 타입. */
+export type NavEntry = AppShellNavItem | AppShellNavSection;
+
+export const isSection = (entry: NavEntry): entry is AppShellNavSection => "items" in entry;
+
+/** children 포함 전체 아이템을 1차원 배열로 펼친다. */
+export const flattenNavItems = (items: AppShellNavItem[]): AppShellNavItem[] =>
+  items.flatMap((item) => (item.children ? [item, ...item.children] : [item]));
+
+/** NavEntry[]에서 모든 AppShellNavItem을 1차원 배열로 추출한다. */
+export const flattenNavEntries = (entries: NavEntry[]): AppShellNavItem[] =>
+  entries.flatMap((entry) =>
+    isSection(entry) ? flattenNavItems(entry.items) : flattenNavItems([entry]),
+  );
+
+/** navItems의 첫 아이템(섹션이면 그 첫 아이템)을 활성 아이템 fallback으로 쓴다. */
+const firstNavItem = (entries: NavEntry[]): AppShellNavItem | undefined => {
+  const first = entries[0];
+
+  return first && isSection(first) ? first.items[0] : first;
+};
+
+/**
+ * 현재 경로와 가장 긴 prefix로 매칭되는 아이템을 활성 아이템으로 고른다.
+ * 매칭이 없으면 첫 아이템으로 fallback.
+ */
+export const resolveActiveItem = (
+  entries: NavEntry[],
+  bottomItems: AppShellNavItem[] | undefined,
+  pathname: string,
+): AppShellNavItem | undefined => {
+  const allItems = [...flattenNavEntries(entries), ...flattenNavItems(bottomItems ?? [])];
+  const byPathLengthDesc = [...allItems].sort((a, b) => b.path.length - a.path.length);
+
+  return byPathLengthDesc.find((item) => pathname.startsWith(item.path)) ?? firstNavItem(entries);
+};

--- a/packages/hobom-design-system/src/patterns/AppShell/useToggleSet.ts
+++ b/packages/hobom-design-system/src/patterns/AppShell/useToggleSet.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from "react";
+
+/**
+ * A set of "open" string keys with a toggle — backs the collapsible nav
+ * sections and item groups in the sidebar.
+ */
+export const useToggleSet = (
+  init: () => Set<string>,
+): [Set<string>, (key: string) => void] => {
+  const [open, setOpen] = useState(init);
+
+  const toggle = useCallback((key: string) => {
+    setOpen((prev) => {
+      const next = new Set(prev);
+
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+
+      return next;
+    });
+  }, []);
+
+  return [open, toggle];
+};


### PR DESCRIPTION
## What
`AppShell.tsx` was a single 519-line file mixing four concerns. Split it so each piece has one job, following the codebase's "logic in hooks, pure functions in lib with tests, components render only" conventions.

| Unit | Concern |
| --- | --- |
| `nav-items.lib.ts` | `NavEntry` / `AppShellNavItem` / `AppShellNavSection` types + pure `isSection` / `flattenNavItems` / `flattenNavEntries` / `resolveActiveItem` |
| `nav-items.lib.spec.ts` | unit tests for the pure helpers (longest-prefix active match, section/standalone flattening, fallbacks) |
| `useToggleSet.ts` | collapsible open-set state — previously duplicated between the sidebar sections and the nav-list groups |
| `AppBar.tsx` | top bar (drawer toggle, brand, active label, action) |
| `Sidebar.tsx` | logo + sections/nav + bottom nav |
| `NavList.tsx` | the nav item list with group collapse |
| `AppShell.tsx` | composes the above and owns the `drawerOpen` state |

## Notes
- Behavior unchanged — the `resolveActiveItem` logic (longest matching path prefix, fallback to the first item) is preserved and now covered by unit tests.
- Public API is unchanged: `AppShell` and the three nav types are still exported from the pattern (types now re-exported from `nav-items.lib`).

## Verify
- DS + app `tsc -b` clean, eslint clean
- app build ok, 582 app tests pass
- DS Storybook suite 144 tests pass (54 files) — AppShell story a11y checks still pass, plus the new `nav-items.lib` unit tests