### PR TITLE
Validate API responses at the trust boundary

### DIFF
--- a/apps/hobom-system/src/entities/label/api/label.api.ts
+++ b/apps/hobom-system/src/entities/label/api/label.api.ts
@@ -1,13 +1,18 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { labelItemSchema, labelItemsSchema } from "./label.schema";
 import type { LabelItemType, CreateLabelRequest, UpdateLabelRequest } from "./label.type";
 
 export const fetchLabels = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels", { signal });
+  const res = await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels", { signal });
+
+  return { ...res, items: parseResponse(labelItemsSchema, "GET /labels")(res.items) };
 };
 
 export const fetchLabelById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`, { signal });
+
+  return { ...res, items: parseResponse(labelItemSchema, "GET /labels/:id")(res.items) };
 };
 
 export const postCreateLabel = async (data: CreateLabelRequest) => {

--- a/apps/hobom-system/src/entities/label/api/label.schema.ts
+++ b/apps/hobom-system/src/entities/label/api/label.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { LabelItemType } from "./label.type";
+
+/** `LabelItemType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const labelItemSchema: Schema<LabelItemType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  ownerId: HoBomSchema.string(),
+});
+
+export const labelItemsSchema: Schema<LabelItemType[]> = HoBomSchema.array(labelItemSchema);

--- a/apps/hobom-system/src/shared/api/index.ts
+++ b/apps/hobom-system/src/shared/api/index.ts
@@ -7,3 +7,5 @@ export {
 } from "./http.api";
 
 export type { HttpResponseType, PaginatedItems } from "./http-response.type";
+
+export { parseResponse } from "./parse-response.api";

--- a/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { HoBomSchema } from "hobom-schema";
+import { parseResponse } from "./parse-response.api";
+
+const itemSchema = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+});
+
+describe("parseResponse", () => {
+  it("returns the payload when it matches the schema", () => {
+    const payload = { id: "1", title: "hello" };
+
+    expect(parseResponse(itemSchema, "GET /items")(payload)).toEqual(payload);
+  });
+
+  it("throws with the context and issue detail when the shape is wrong", () => {
+    expect(() => parseResponse(itemSchema, "GET /items")({ id: "1" })).toThrow(
+      /Response validation failed \(GET \/items\)/,
+    );
+  });
+
+  it("throws when a field has the wrong type", () => {
+    expect(() =>
+      parseResponse(itemSchema, "GET /items")({ id: 1, title: "hello" }),
+    ).toThrow(/Response validation failed/);
+  });
+
+  it("validates arrays element by element", () => {
+    const listSchema = HoBomSchema.array(itemSchema);
+    const list = [
+      { id: "1", title: "a" },
+      { id: "2", title: "b" },
+    ];
+
+    expect(parseResponse(listSchema, "GET /items")(list)).toEqual(list);
+    expect(() =>
+      parseResponse(listSchema, "GET /items")([{ id: "1", title: "a" }, { id: "2" }]),
+    ).toThrow(/Response validation failed/);
+  });
+});

--- a/apps/hobom-system/src/shared/api/parse-response.api.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.ts
@@ -1,0 +1,24 @@
+import type { Schema } from "hobom-schema";
+
+/**
+ * 응답 페이로드를 스키마로 검증하는 경계 파서.
+ *
+ * 불일치 시 즉시 throw한다 — 서버 계약 위반이 렌더링 깊숙한 곳에서 터지는 대신
+ * 이 경계에서 (쿼리 에러로) 드러나게 한다.
+ *
+ * @param schema  기대하는 페이로드 스키마
+ * @param context 실패 메시지에 붙일 식별자 (예: `"GET /labels"`)
+ */
+export const parseResponse =
+  <T>(schema: Schema<T>, context: string) =>
+  (data: unknown): T => {
+    const result = schema.safeParse(data);
+
+    if (result.success) {
+      return result.data;
+    }
+
+    const detail = result.error.issues.map((issue) => issue.message).join("; ");
+
+    throw new Error(`Response validation failed (${context}): ${detail}`);
+  };


### PR DESCRIPTION
## Why
API responses were typed with TypeScript interfaces but never validated at runtime. A server contract violation (missing field, wrong type, unexpected null) surfaced as a crash deep in rendering instead of at the boundary. `hobom-schema` already existed in the codebase — but only for form input, never wired to the network boundary. This is the cheapest place to catch backend drift.

## What
- **`shared/api/parse-response.api.ts`** — `parseResponse(schema, context)(data)` validates a payload against a schema and **throws on any mismatch**, so the failure surfaces here as a query error (per the chosen fail-fast policy) rather than corrupting downstream state.
- **`entities/label/api/label.schema.ts`** — response schema for `LabelItemType`, annotated `Schema<LabelItemType>` so the schema and the response interface can't silently drift (tsc catches divergence).
- **`label.api.ts`** — `fetchLabels` / `fetchLabelById` validate `res.items` and return the validated envelope. `label` is the first adopter because its payload is all strings — modelable with the current engine, no new primitives.

## Scope / next
This establishes the pattern on one entity. Other entities can adopt it incrementally. Richer payloads (note's `isPinned: boolean`, timestamps) need a `boolean()` (and likely `date`) primitive added to `hobom-schema` first — a natural follow-up.

## Verify
- app `tsc -b` clean, eslint clean, build ok
- 588 app tests pass (582 + 4 new `parseResponse` unit tests)