### PR TITLE
Validate every GET response against a schema (advisory)

### DIFF
--- a/apps/hobom-system/src/entities/admin-user/api/admin-user.api.ts
+++ b/apps/hobom-system/src/entities/admin-user/api/admin-user.api.ts
@@ -1,8 +1,15 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
+import type { HttpResponseType } from "@/shared/api";
+import { pendingUsersSchema } from "./admin-user.schema";
 import type { PendingUserType } from "./admin-user.type";
 
-export const fetchPendingUsers = async (signal?: AbortSignal) =>
-  await httpClient.get<HttpResponseType<PendingUserType[]>>(`/admin/users/pending`, { signal });
+export const fetchPendingUsers = async (signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<PendingUserType[]>>(`/admin/users/pending`, {
+    signal,
+  });
+
+  return { ...res, items: parseResponse(pendingUsersSchema, "GET /admin/users/pending")(res.items) };
+};
 
 export const patchApproveUser = async ({ id }: { id: string }) =>
   await httpClient.patch(`/admin/users/${id}/approve`, {});

--- a/apps/hobom-system/src/entities/admin-user/api/admin-user.schema.ts
+++ b/apps/hobom-system/src/entities/admin-user/api/admin-user.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { PendingUserType } from "./admin-user.type";
+
+export const pendingUserSchema: Schema<PendingUserType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  username: HoBomSchema.string(),
+  nickname: HoBomSchema.string(),
+  email: HoBomSchema.string(),
+});
+
+export const pendingUsersSchema: Schema<PendingUserType[]> = HoBomSchema.array(pendingUserSchema);

--- a/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
@@ -1,5 +1,7 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
+import type { HttpResponseType } from "@/shared/api";
 import type { UserType, AuthSignUpType } from "@/entities/auth/model/auth-login.type.ts";
+import { usersSchema } from "./auth-login.schema";
 
 export const postAuthLogin = async ({
   nickname,
@@ -19,5 +21,8 @@ export const postAuthLogout = async () => {
   await httpClient.post("/auth/logout", {});
 };
 
-export const fetchUsers = async (signal?: AbortSignal) =>
-  await httpClient.get<HttpResponseType<UserType[]>>("/users", { signal });
+export const fetchUsers = async (signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<UserType[]>>("/users", { signal });
+
+  return { ...res, items: parseResponse(usersSchema, "GET /users")(res.items) };
+};

--- a/apps/hobom-system/src/entities/auth/api/auth-login.schema.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth-login.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { UserType } from "@/entities/auth/model/auth-login.type.ts";
+import type { Schema } from "hobom-schema";
+
+export const userSchema: Schema<UserType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  username: HoBomSchema.string(),
+  email: HoBomSchema.string(),
+  nickname: HoBomSchema.string(),
+});
+
+export const usersSchema: Schema<UserType[]> = HoBomSchema.array(userSchema);

--- a/apps/hobom-system/src/entities/board/api/board.api.ts
+++ b/apps/hobom-system/src/entities/board/api/board.api.ts
@@ -1,14 +1,21 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { boardSchema, boardsSchema } from "./board.schema";
 import type { BoardDto, CreateBoardRequest, UpdateBoardRequest } from "./board.type";
 
 export const fetchBoardsByProject = async (
   { projectId }: { projectId: string },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<BoardDto[]>>(`/projects/${projectId}/boards`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<BoardDto[]>>(
+    `/projects/${projectId}/boards`,
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(boardsSchema, "GET /projects/:projectId/boards")(res.items),
+  };
 };
 
 export const fetchBoardById = async (
@@ -21,10 +28,15 @@ export const fetchBoardById = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<BoardDto>>(
+  const res = await httpClient.get<HttpResponseType<BoardDto>>(
     `/projects/${projectId}/boards/${boardId}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(boardSchema, "GET /projects/:projectId/boards/:boardId")(res.items),
+  };
 };
 
 export const postCreateBoard = async ({

--- a/apps/hobom-system/src/entities/board/api/board.schema.ts
+++ b/apps/hobom-system/src/entities/board/api/board.schema.ts
@@ -1,0 +1,22 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { BoardColumn, BoardDto } from "./board.type";
+
+const boardColumnSchema: Schema<BoardColumn> = HoBomSchema.object({
+  statusId: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  wipLimit: HoBomSchema.number().nullable(),
+  order: HoBomSchema.number(),
+});
+
+/** `BoardDto` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const boardSchema: Schema<BoardDto> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  project: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  type: HoBomSchema.enum(["KANBAN", "SCRUM"]),
+  columns: HoBomSchema.array(boardColumnSchema),
+  createdBy: HoBomSchema.string(),
+});
+
+export const boardsSchema: Schema<BoardDto[]> = HoBomSchema.array(boardSchema);

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
@@ -1,8 +1,11 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse, type HttpResponseType } from "@/shared/api";
 import type { CategoryType } from "@/entities/daily-todo";
+import { categoryListSchema } from "./daily-todo-category.schema";
 
 export const fetchDailyTodoCategories = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<CategoryType[]>>(`/categories`, { signal });
+  const res = await httpClient.get<HttpResponseType<CategoryType[]>>(`/categories`, { signal });
+
+  return { ...res, items: parseResponse(categoryListSchema, "GET /categories")(res.items) };
 };
 
 export const postCategory = async ({ title }: { title: string }) => {

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.schema.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { CategoryType } from "./daily-todo-category.type";
+
+/** `CategoryType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const categorySchema: Schema<CategoryType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  ownerId: HoBomSchema.string(),
+});
+
+export const categoryListSchema: Schema<CategoryType[]> = HoBomSchema.array(categorySchema);

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo.api.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo.api.ts
@@ -1,17 +1,26 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { dailyTodoListSchema } from "./daily-todo.schema";
 import type { DailyTodoType, ProgressType } from "./daily-todo.type.ts";
 
 export const fetchDailyTodos = async ({ date }: { date: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos?date=${date}`, {
+  const res = await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos?date=${date}`, {
     signal,
   });
+
+  return { ...res, items: parseResponse(dailyTodoListSchema, "GET /daily-todos")(res.items) };
 };
 
 export const fetchDailyTodosByDate = async ({ date }: { date: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<DailyTodoType[]>>(`/daily-todos/by-date/${date}`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<DailyTodoType[]>>(
+    `/daily-todos/by-date/${date}`,
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(dailyTodoListSchema, "GET /daily-todos/by-date/:date")(res.items),
+  };
 };
 
 export const patchDailyTodoCompleteStatusChange = async ({

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo.schema.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo.schema.ts
@@ -1,0 +1,28 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { DailyTodoType } from "./daily-todo.type";
+
+/** `DailyTodoType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const dailyTodoSchema: Schema<DailyTodoType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  date: HoBomSchema.date(),
+  reaction: HoBomSchema.object({
+    value: HoBomSchema.string(),
+    reactionUserId: HoBomSchema.string(),
+  }).nullable(),
+  progress: HoBomSchema.enum(["COMPLETED", "PROGRESS"]),
+  cycle: HoBomSchema.enum(["EVERYDAY", "EVERY_WEEKDAY", "EVERY_WEEKEND"]),
+  owner: HoBomSchema.object({
+    id: HoBomSchema.string(),
+    username: HoBomSchema.string(),
+    nickname: HoBomSchema.string(),
+  }),
+  category: HoBomSchema.object({
+    id: HoBomSchema.string(),
+    title: HoBomSchema.string(),
+    ownerId: HoBomSchema.string(),
+  }),
+});
+
+export const dailyTodoListSchema: Schema<DailyTodoType[]> = HoBomSchema.array(dailyTodoSchema);

--- a/apps/hobom-system/src/entities/dashboard/api/dashboard.api.ts
+++ b/apps/hobom-system/src/entities/dashboard/api/dashboard.api.ts
@@ -1,5 +1,15 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import {
+  dailyTodoDashboardSchema,
+  noteDashboardSchema,
+  messageDashboardSchema,
+  notificationDashboardSchema,
+  systemDashboardSchema,
+  activityDashboardSchema,
+  projectIssueDashboardSchema,
+  sprintDashboardSchema,
+} from "./dashboard.schema";
 import type {
   PeriodType,
   SystemPeriodType,
@@ -23,10 +33,15 @@ export const fetchDailyTodoDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<DailyTodoDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<DailyTodoDashboardType>>(
     `/dashboard/daily-todos?period=${period}&date=${date}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(dailyTodoDashboardSchema, "GET /dashboard/daily-todos")(res.items),
+  };
 };
 
 export const fetchNoteDashboard = async (
@@ -39,10 +54,12 @@ export const fetchNoteDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<NoteDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<NoteDashboardType>>(
     `/dashboard/notes?period=${period}&date=${date}`,
     { signal },
   );
+
+  return { ...res, items: parseResponse(noteDashboardSchema, "GET /dashboard/notes")(res.items) };
 };
 
 export const fetchMessageDashboard = async (
@@ -55,10 +72,15 @@ export const fetchMessageDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<MessageDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<MessageDashboardType>>(
     `/dashboard/future-messages?period=${period}&date=${date}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(messageDashboardSchema, "GET /dashboard/future-messages")(res.items),
+  };
 };
 
 export const fetchNotificationDashboard = async (
@@ -71,20 +93,27 @@ export const fetchNotificationDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<NotificationDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<NotificationDashboardType>>(
     `/dashboard/notifications?period=${period}&date=${date}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(notificationDashboardSchema, "GET /dashboard/notifications")(res.items),
+  };
 };
 
 export const fetchSystemDashboard = async (
   { period }: { period: SystemPeriodType },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<SystemDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<SystemDashboardType>>(
     `/dashboard/system?period=${period}`,
     { signal },
   );
+
+  return { ...res, items: parseResponse(systemDashboardSchema, "GET /dashboard/system")(res.items) };
 };
 
 export const fetchActivityDashboard = async (
@@ -97,20 +126,32 @@ export const fetchActivityDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<ActivityDashboardType>>(
+  const res = await httpClient.get<HttpResponseType<ActivityDashboardType>>(
     `/dashboard/activity?period=${period}&date=${date}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(activityDashboardSchema, "GET /dashboard/activity")(res.items),
+  };
 };
 
 export const fetchProjectIssueDashboard = async (
   { projectId }: { projectId: string },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<ProjectIssueDashboardDto>>(
+  const res = await httpClient.get<HttpResponseType<ProjectIssueDashboardDto>>(
     `/dashboard/projects/${projectId}/issues`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(projectIssueDashboardSchema, "GET /dashboard/projects/:id/issues")(
+      res.items,
+    ),
+  };
 };
 
 export const fetchSprintDashboard = async (
@@ -123,8 +164,15 @@ export const fetchSprintDashboard = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<SprintDashboardDto>>(
+  const res = await httpClient.get<HttpResponseType<SprintDashboardDto>>(
     `/dashboard/projects/${projectId}/sprints/${sprintId}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(sprintDashboardSchema, "GET /dashboard/projects/:id/sprints/:id")(
+      res.items,
+    ),
+  };
 };

--- a/apps/hobom-system/src/entities/dashboard/api/dashboard.schema.ts
+++ b/apps/hobom-system/src/entities/dashboard/api/dashboard.schema.ts
@@ -1,0 +1,205 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type {
+  DailyTodoDashboardType,
+  NoteDashboardType,
+  MessageDashboardType,
+  NotificationDashboardType,
+  SystemDashboardType,
+  ActivityDashboardType,
+  ProjectIssueDashboardDto,
+  SprintDashboardDto,
+} from "./dashboard.type";
+
+export const dailyTodoDashboardSchema: Schema<DailyTodoDashboardType> = HoBomSchema.object({
+  period: HoBomSchema.enum(["WEEKLY", "MONTHLY"]),
+  startDate: HoBomSchema.date(),
+  endDate: HoBomSchema.date(),
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    completed: HoBomSchema.number(),
+    completionRate: HoBomSchema.number(),
+    reactionsCount: HoBomSchema.number(),
+  }),
+  daily: HoBomSchema.array(
+    HoBomSchema.object({
+      date: HoBomSchema.date(),
+      total: HoBomSchema.number(),
+      completed: HoBomSchema.number(),
+      completionRate: HoBomSchema.number(),
+    }),
+  ),
+  byCategory: HoBomSchema.array(
+    HoBomSchema.object({
+      categoryId: HoBomSchema.string(),
+      categoryTitle: HoBomSchema.string(),
+      total: HoBomSchema.number(),
+      completed: HoBomSchema.number(),
+    }),
+  ),
+  byCycle: HoBomSchema.array(
+    HoBomSchema.object({
+      cycle: HoBomSchema.string(),
+      total: HoBomSchema.number(),
+      completed: HoBomSchema.number(),
+    }),
+  ),
+});
+
+export const noteDashboardSchema: Schema<NoteDashboardType> = HoBomSchema.object({
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    checklistCompletionRate: HoBomSchema.number(),
+  }),
+  byStatus: HoBomSchema.array(
+    HoBomSchema.object({ status: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  byType: HoBomSchema.array(
+    HoBomSchema.object({ type: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  byLabel: HoBomSchema.array(
+    HoBomSchema.object({ labelId: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  dailyCreated: HoBomSchema.array(
+    HoBomSchema.object({ date: HoBomSchema.date(), count: HoBomSchema.number() }),
+  ),
+});
+
+export const messageDashboardSchema: Schema<MessageDashboardType> = HoBomSchema.object({
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    pending: HoBomSchema.number(),
+    sent: HoBomSchema.number(),
+  }),
+  upcoming: HoBomSchema.array(
+    HoBomSchema.object({
+      id: HoBomSchema.string(),
+      title: HoBomSchema.string(),
+      recipientId: HoBomSchema.string(),
+      scheduledAt: HoBomSchema.date(),
+    }),
+  ),
+  monthlyTrend: HoBomSchema.array(
+    HoBomSchema.object({ month: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+});
+
+export const notificationDashboardSchema: Schema<NotificationDashboardType> = HoBomSchema.object({
+  period: HoBomSchema.enum(["WEEKLY", "MONTHLY"]),
+  startDate: HoBomSchema.date(),
+  endDate: HoBomSchema.date(),
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    read: HoBomSchema.number(),
+    unread: HoBomSchema.number(),
+  }),
+  dailyTrend: HoBomSchema.array(
+    HoBomSchema.object({ date: HoBomSchema.date(), count: HoBomSchema.number() }),
+  ),
+  byCategory: HoBomSchema.array(
+    HoBomSchema.object({ category: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  recentUnread: HoBomSchema.array(
+    HoBomSchema.object({
+      id: HoBomSchema.string(),
+      title: HoBomSchema.string(),
+      category: HoBomSchema.string(),
+      createdAt: HoBomSchema.date(),
+    }),
+  ),
+});
+
+export const systemDashboardSchema: Schema<SystemDashboardType> = HoBomSchema.object({
+  period: HoBomSchema.enum(["LAST_24H", "LAST_7D", "LAST_30D"]),
+  startDate: HoBomSchema.date(),
+  endDate: HoBomSchema.date(),
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    sent: HoBomSchema.number(),
+    failed: HoBomSchema.number(),
+    pending: HoBomSchema.number(),
+    successRate: HoBomSchema.number(),
+  }),
+  byEventType: HoBomSchema.array(
+    HoBomSchema.object({ eventType: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  hourlyThroughput: HoBomSchema.array(
+    HoBomSchema.object({ hour: HoBomSchema.number(), count: HoBomSchema.number() }),
+  ),
+  recentFailures: HoBomSchema.array(
+    HoBomSchema.object({
+      eventId: HoBomSchema.string(),
+      eventType: HoBomSchema.string(),
+      lastError: HoBomSchema.string().nullable(),
+      retryCount: HoBomSchema.number(),
+      failedAt: HoBomSchema.date().nullable(),
+    }),
+  ),
+  retryDistribution: HoBomSchema.array(
+    HoBomSchema.object({ retryCount: HoBomSchema.number(), count: HoBomSchema.number() }),
+  ),
+});
+
+export const activityDashboardSchema: Schema<ActivityDashboardType> = HoBomSchema.object({
+  period: HoBomSchema.enum(["WEEKLY", "MONTHLY"]),
+  startDate: HoBomSchema.date(),
+  endDate: HoBomSchema.date(),
+  overview: HoBomSchema.object({
+    activeDays: HoBomSchema.number(),
+    totalDays: HoBomSchema.number(),
+    activityRate: HoBomSchema.number(),
+    currentStreak: HoBomSchema.number(),
+    longestStreak: HoBomSchema.number(),
+  }),
+  heatmap: HoBomSchema.array(
+    HoBomSchema.object({
+      date: HoBomSchema.date(),
+      count: HoBomSchema.number(),
+      level: HoBomSchema.number(),
+    }),
+  ),
+  moduleUsage: HoBomSchema.array(
+    HoBomSchema.object({
+      module: HoBomSchema.string(),
+      count: HoBomSchema.number(),
+      percentage: HoBomSchema.number(),
+    }),
+  ),
+});
+
+export const projectIssueDashboardSchema: Schema<ProjectIssueDashboardDto> = HoBomSchema.object({
+  overview: HoBomSchema.object({
+    total: HoBomSchema.number(),
+    open: HoBomSchema.number(),
+    done: HoBomSchema.number(),
+    completionRate: HoBomSchema.number(),
+    overdueCount: HoBomSchema.number(),
+  }),
+  byStatus: HoBomSchema.array(
+    HoBomSchema.object({ status: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  byPriority: HoBomSchema.array(
+    HoBomSchema.object({ priority: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+  byType: HoBomSchema.array(
+    HoBomSchema.object({ type: HoBomSchema.string(), count: HoBomSchema.number() }),
+  ),
+});
+
+export const sprintDashboardSchema: Schema<SprintDashboardDto> = HoBomSchema.object({
+  sprint: HoBomSchema.object({
+    id: HoBomSchema.string(),
+    name: HoBomSchema.string(),
+    goal: HoBomSchema.string().nullable(),
+    status: HoBomSchema.string(),
+    startDate: HoBomSchema.date(),
+    endDate: HoBomSchema.date(),
+  }),
+  overview: HoBomSchema.object({
+    totalIssues: HoBomSchema.number(),
+    completedIssues: HoBomSchema.number(),
+    completionRate: HoBomSchema.number(),
+    totalStoryPoints: HoBomSchema.number(),
+    completedStoryPoints: HoBomSchema.number(),
+  }),
+});

--- a/apps/hobom-system/src/entities/dlq/api/dlq.api.ts
+++ b/apps/hobom-system/src/entities/dlq/api/dlq.api.ts
@@ -1,10 +1,15 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
+import type { HttpResponseType } from "@/shared/api";
+import { dlqListSchema } from "./dlq.schema";
 import type { DlqListResponse, DlqDetailResponse, DlqRetryResponse } from "./dlq.type";
 
 const BASE = "/dlq";
 
-export const fetchDlqKeys = (signal?: AbortSignal) =>
-  httpClient.get<HttpResponseType<DlqListResponse>>(BASE, { signal });
+export const fetchDlqKeys = async (signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<DlqListResponse>>(BASE, { signal });
+
+  return { ...res, items: parseResponse(dlqListSchema, "GET /dlq")(res.items) };
+};
 
 export const fetchDlqDetail = (key: string, signal?: AbortSignal) =>
   httpClient.get<HttpResponseType<DlqDetailResponse>>(`${BASE}/${encodeURIComponent(key)}`, {

--- a/apps/hobom-system/src/entities/dlq/api/dlq.schema.ts
+++ b/apps/hobom-system/src/entities/dlq/api/dlq.schema.ts
@@ -1,0 +1,7 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { DlqListResponse } from "./dlq.type";
+
+export const dlqListSchema: Schema<DlqListResponse> = HoBomSchema.object({
+  items: HoBomSchema.array(HoBomSchema.string()),
+});

--- a/apps/hobom-system/src/entities/error-event/api/error-event.api.ts
+++ b/apps/hobom-system/src/entities/error-event/api/error-event.api.ts
@@ -1,5 +1,6 @@
-import { spaceHttpClient } from "@/shared/api";
+import { spaceHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
+import { errorEventSchema, errorEventPageSchema } from "./error-event.schema";
 import type { ErrorEventDto, ErrorEventSearchParams } from "./error-event.type";
 
 const BASE = "/api/v1/errors";
@@ -12,11 +13,18 @@ export const fetchErrorEvents = (params: ErrorEventSearchParams, signal?: AbortS
   if (params.page != null) query.set("page", String(params.page));
   if (params.size != null) query.set("size", String(params.size));
 
-  return spaceHttpClient.get<HttpResponseType<PaginatedItems<ErrorEventDto>>>(
-    `${BASE}?${query.toString()}`,
-    { signal },
-  );
+  return spaceHttpClient
+    .get<HttpResponseType<PaginatedItems<ErrorEventDto>>>(`${BASE}?${query.toString()}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(errorEventPageSchema, "GET /api/v1/errors")(res.items),
+    }));
 };
 
 export const fetchErrorEventById = (id: number, signal?: AbortSignal) =>
-  spaceHttpClient.get<HttpResponseType<ErrorEventDto>>(`${BASE}/${id}`, { signal });
+  spaceHttpClient
+    .get<HttpResponseType<ErrorEventDto>>(`${BASE}/${id}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(errorEventSchema, "GET /api/v1/errors/:id")(res.items),
+    }));

--- a/apps/hobom-system/src/entities/error-event/api/error-event.schema.ts
+++ b/apps/hobom-system/src/entities/error-event/api/error-event.schema.ts
@@ -1,0 +1,22 @@
+import { HoBomSchema } from "hobom-schema";
+import type { PaginatedItems } from "@/shared/api";
+import type { Schema } from "hobom-schema";
+import type { ErrorEventDto } from "./error-event.type";
+
+export const errorEventSchema: Schema<ErrorEventDto> = HoBomSchema.object({
+  id: HoBomSchema.number(),
+  message: HoBomSchema.string(),
+  stackTrace: HoBomSchema.string().nullable(),
+  screen: HoBomSchema.string(),
+  errorType: HoBomSchema.enum(["SERVER_RESPONSE", "CLIENT_LOGIC"]),
+  userAgent: HoBomSchema.string().nullable(),
+  nickname: HoBomSchema.string().nullable(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const errorEventPageSchema: Schema<PaginatedItems<ErrorEventDto>> = HoBomSchema.object({
+  items: HoBomSchema.array(errorEventSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});

--- a/apps/hobom-system/src/entities/future-message/api/future-message.api.ts
+++ b/apps/hobom-system/src/entities/future-message/api/future-message.api.ts
@@ -1,4 +1,5 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse, type HttpResponseType } from "@/shared/api";
+import { futureMessagesSchema } from "./future-message.schema";
 import type { FutureMessageSendStatusType } from "../model/future-message-send-status.model";
 import type { FutureMessageType } from "./future-message.type";
 import type { FutureMessageSendSchemaType } from "../model/future-message-send.model";
@@ -10,11 +11,17 @@ export const fetchFutureMessageByStatus = async (
     status: FutureMessageSendStatusType;
   },
   signal?: AbortSignal,
-) =>
-  httpClient.get<HttpResponseType<FutureMessageType[]>>(
+) => {
+  const res = await httpClient.get<HttpResponseType<FutureMessageType[]>>(
     `/future-messages/by-status?status=${status}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(futureMessagesSchema, "GET /future-messages/by-status")(res.items),
+  };
+};
 
 export const postFutureMessage = async (body: FutureMessageSendSchemaType) =>
   httpClient.post("/future-messages", body);

--- a/apps/hobom-system/src/entities/future-message/api/future-message.schema.ts
+++ b/apps/hobom-system/src/entities/future-message/api/future-message.schema.ts
@@ -1,0 +1,16 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { FutureMessageType } from "./future-message.type";
+
+export const futureMessageSchema: Schema<FutureMessageType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  scheduledAt: HoBomSchema.date(),
+  sendStatus: HoBomSchema.enum(["PENDING", "SENT"]),
+  createdAt: HoBomSchema.date(),
+  updatedAt: HoBomSchema.date(),
+});
+
+export const futureMessagesSchema: Schema<FutureMessageType[]> =
+  HoBomSchema.array(futureMessageSchema);

--- a/apps/hobom-system/src/entities/issue-comment/api/issue-comment.api.ts
+++ b/apps/hobom-system/src/entities/issue-comment/api/issue-comment.api.ts
@@ -1,5 +1,6 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { issueCommentsSchema } from "./issue-comment.schema";
 import type {
   IssueCommentType,
   CreateIssueCommentRequest,
@@ -16,10 +17,18 @@ export const fetchIssueComments = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<IssueCommentType[]>>(
+  const res = await httpClient.get<HttpResponseType<IssueCommentType[]>>(
     `/projects/${projectId}/issues/${issueId}/comments`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      issueCommentsSchema,
+      "GET /projects/:projectId/issues/:issueId/comments",
+    )(res.items),
+  };
 };
 
 export const postCreateIssueComment = async ({

--- a/apps/hobom-system/src/entities/issue-comment/api/issue-comment.schema.ts
+++ b/apps/hobom-system/src/entities/issue-comment/api/issue-comment.schema.ts
@@ -1,0 +1,16 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { IssueCommentType } from "./issue-comment.type";
+
+/** `IssueCommentType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const issueCommentSchema: Schema<IssueCommentType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  issue: HoBomSchema.string(),
+  author: HoBomSchema.string(),
+  body: HoBomSchema.string(),
+  editedAt: HoBomSchema.date().nullable(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const issueCommentsSchema: Schema<IssueCommentType[]> =
+  HoBomSchema.array(issueCommentSchema);

--- a/apps/hobom-system/src/entities/issue/api/issue.api.ts
+++ b/apps/hobom-system/src/entities/issue/api/issue.api.ts
@@ -1,5 +1,6 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { issueSchema, issuesSchema } from "./issue.schema";
 import type {
   IssueType,
   CreateIssueRequest,
@@ -12,9 +13,15 @@ export const fetchIssuesByProject = async (
   { projectId }: { projectId: string },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<IssueType[]>>(`/projects/${projectId}/issues`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<IssueType[]>>(
+    `/projects/${projectId}/issues`,
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(issuesSchema, "GET /projects/:projectId/issues")(res.items),
+  };
 };
 
 export const fetchIssueById = async (
@@ -27,10 +34,15 @@ export const fetchIssueById = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<IssueType>>(
+  const res = await httpClient.get<HttpResponseType<IssueType>>(
     `/projects/${projectId}/issues/${issueId}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(issueSchema, "GET /projects/:projectId/issues/:issueId")(res.items),
+  };
 };
 
 export const postCreateIssue = async ({

--- a/apps/hobom-system/src/entities/issue/api/issue.schema.ts
+++ b/apps/hobom-system/src/entities/issue/api/issue.schema.ts
@@ -1,0 +1,27 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { IssueType } from "./issue.type";
+
+/** `IssueType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const issueSchema: Schema<IssueType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  project: HoBomSchema.string(),
+  issueNumber: HoBomSchema.number(),
+  issueKey: HoBomSchema.string(),
+  type: HoBomSchema.enum(["EPIC", "STORY", "TASK", "BUG", "SUBTASK"]),
+  title: HoBomSchema.string(),
+  description: HoBomSchema.string().optional(),
+  status: HoBomSchema.string(),
+  priority: HoBomSchema.enum(["CRITICAL", "HIGH", "MEDIUM", "LOW"]),
+  resolution: HoBomSchema.string().optional(),
+  reporter: HoBomSchema.string(),
+  assignee: HoBomSchema.string().optional(),
+  sprint: HoBomSchema.string().optional(),
+  parent: HoBomSchema.string().optional(),
+  labels: HoBomSchema.array(HoBomSchema.string()),
+  storyPoints: HoBomSchema.number().optional(),
+  dueDate: HoBomSchema.date().optional(),
+  resolvedAt: HoBomSchema.date().optional(),
+});
+
+export const issuesSchema: Schema<IssueType[]> = HoBomSchema.array(issueSchema);

--- a/apps/hobom-system/src/entities/label/api/label.api.ts
+++ b/apps/hobom-system/src/entities/label/api/label.api.ts
@@ -1,13 +1,18 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { labelItemSchema, labelItemsSchema } from "./label.schema";
 import type { LabelItemType, CreateLabelRequest, UpdateLabelRequest } from "./label.type";
 
 export const fetchLabels = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels", { signal });
+  const res = await httpClient.get<HttpResponseType<LabelItemType[]>>("/labels", { signal });
+
+  return { ...res, items: parseResponse(labelItemsSchema, "GET /labels")(res.items) };
 };
 
 export const fetchLabelById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<LabelItemType>>(`/labels/${id}`, { signal });
+
+  return { ...res, items: parseResponse(labelItemSchema, "GET /labels/:id")(res.items) };
 };
 
 export const postCreateLabel = async (data: CreateLabelRequest) => {

--- a/apps/hobom-system/src/entities/label/api/label.schema.ts
+++ b/apps/hobom-system/src/entities/label/api/label.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { LabelItemType } from "./label.type";
+
+/** `LabelItemType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const labelItemSchema: Schema<LabelItemType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  ownerId: HoBomSchema.string(),
+});
+
+export const labelItemsSchema: Schema<LabelItemType[]> = HoBomSchema.array(labelItemSchema);

--- a/apps/hobom-system/src/entities/log/api/log.api.spec.ts
+++ b/apps/hobom-system/src/entities/log/api/log.api.spec.ts
@@ -4,6 +4,7 @@ const mockGet = vi.fn();
 
 vi.mock("@/shared/api", () => ({
   internalHttpClient: { get: (...args: unknown[]) => mockGet(...args) },
+  parseResponse: () => (data: unknown) => data,
 }));
 
 const { fetchLogSearch } = await import("./log.api");

--- a/apps/hobom-system/src/entities/log/api/log.api.ts
+++ b/apps/hobom-system/src/entities/log/api/log.api.ts
@@ -1,5 +1,13 @@
-import { internalHttpClient } from "@/shared/api";
+import { internalHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
+import {
+  logLevelCountsSchema,
+  logServiceCountsSchema,
+  logStatusCountsSchema,
+  logRequestCountsSchema,
+  logEndpointErrorsSchema,
+  logEntryPageSchema,
+} from "./log.schema";
 import type {
   LogLevelCount,
   LogServiceCount,
@@ -13,33 +21,47 @@ import type {
 const BASE = "/logs";
 
 export const fetchLogLevelSummary = (hours: number, signal?: AbortSignal) =>
-  internalHttpClient.get<HttpResponseType<LogLevelCount[]>>(`${BASE}/level-summary?hours=${hours}`, {
-    signal,
-  });
+  internalHttpClient
+    .get<HttpResponseType<LogLevelCount[]>>(`${BASE}/level-summary?hours=${hours}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logLevelCountsSchema, "GET /logs/level-summary")(res.items),
+    }));
 
 export const fetchLogServiceSummary = (hours: number, signal?: AbortSignal) =>
-  internalHttpClient.get<HttpResponseType<LogServiceCount[]>>(
-    `${BASE}/service-summary?hours=${hours}`,
-    { signal },
-  );
+  internalHttpClient
+    .get<HttpResponseType<LogServiceCount[]>>(`${BASE}/service-summary?hours=${hours}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logServiceCountsSchema, "GET /logs/service-summary")(res.items),
+    }));
 
 export const fetchLogStatusSummary = (hours: number, signal?: AbortSignal) =>
-  internalHttpClient.get<HttpResponseType<LogStatusCount[]>>(
-    `${BASE}/status-summary?hours=${hours}`,
-    { signal },
-  );
+  internalHttpClient
+    .get<HttpResponseType<LogStatusCount[]>>(`${BASE}/status-summary?hours=${hours}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logStatusCountsSchema, "GET /logs/status-summary")(res.items),
+    }));
 
 export const fetchLogRequestSummary = (hours: number, signal?: AbortSignal) =>
-  internalHttpClient.get<HttpResponseType<LogRequestCount[]>>(
-    `${BASE}/request-summary?hours=${hours}`,
-    { signal },
-  );
+  internalHttpClient
+    .get<HttpResponseType<LogRequestCount[]>>(`${BASE}/request-summary?hours=${hours}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logRequestCountsSchema, "GET /logs/request-summary")(res.items),
+    }));
 
 export const fetchLogEndpointErrors = (hours: number, limit = 20, signal?: AbortSignal) =>
-  internalHttpClient.get<HttpResponseType<LogEndpointError[]>>(
-    `${BASE}/endpoint-errors?hours=${hours}&limit=${limit}`,
-    { signal },
-  );
+  internalHttpClient
+    .get<HttpResponseType<LogEndpointError[]>>(
+      `${BASE}/endpoint-errors?hours=${hours}&limit=${limit}`,
+      { signal },
+    )
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logEndpointErrorsSchema, "GET /logs/endpoint-errors")(res.items),
+    }));
 
 export const fetchLogSearch = (params: LogSearchParams, signal?: AbortSignal) => {
   const query = new URLSearchParams();
@@ -54,8 +76,10 @@ export const fetchLogSearch = (params: LogSearchParams, signal?: AbortSignal) =>
   if (params.page != null) query.set("page", String(params.page));
   if (params.size != null) query.set("size", String(params.size));
 
-  return internalHttpClient.get<HttpResponseType<PaginatedItems<LogEntry>>>(
-    `${BASE}?${query.toString()}`,
-    { signal },
-  );
+  return internalHttpClient
+    .get<HttpResponseType<PaginatedItems<LogEntry>>>(`${BASE}?${query.toString()}`, { signal })
+    .then((res) => ({
+      ...res,
+      items: parseResponse(logEntryPageSchema, "GET /logs")(res.items),
+    }));
 };

--- a/apps/hobom-system/src/entities/log/api/log.schema.ts
+++ b/apps/hobom-system/src/entities/log/api/log.schema.ts
@@ -1,0 +1,76 @@
+import { HoBomSchema } from "hobom-schema";
+import type { PaginatedItems } from "@/shared/api";
+import type { Schema } from "hobom-schema";
+import type {
+  LogLevelCount,
+  LogServiceCount,
+  LogStatusCount,
+  LogRequestCount,
+  LogEndpointError,
+  LogEntry,
+} from "./log.type";
+
+export const logLevelCountSchema: Schema<LogLevelCount> = HoBomSchema.object({
+  level: HoBomSchema.string(),
+  count: HoBomSchema.number(),
+});
+
+export const logLevelCountsSchema: Schema<LogLevelCount[]> =
+  HoBomSchema.array(logLevelCountSchema);
+
+export const logServiceCountSchema: Schema<LogServiceCount> = HoBomSchema.object({
+  serviceType: HoBomSchema.string(),
+  count: HoBomSchema.number(),
+});
+
+export const logServiceCountsSchema: Schema<LogServiceCount[]> =
+  HoBomSchema.array(logServiceCountSchema);
+
+export const logStatusCountSchema: Schema<LogStatusCount> = HoBomSchema.object({
+  statusCode: HoBomSchema.number(),
+  count: HoBomSchema.number(),
+});
+
+export const logStatusCountsSchema: Schema<LogStatusCount[]> =
+  HoBomSchema.array(logStatusCountSchema);
+
+export const logRequestCountSchema: Schema<LogRequestCount> = HoBomSchema.object({
+  minute: HoBomSchema.string(),
+  totalRequests: HoBomSchema.number(),
+});
+
+export const logRequestCountsSchema: Schema<LogRequestCount[]> =
+  HoBomSchema.array(logRequestCountSchema);
+
+export const logEndpointErrorSchema: Schema<LogEndpointError> = HoBomSchema.object({
+  path: HoBomSchema.string(),
+  httpMethod: HoBomSchema.string(),
+  totalCount: HoBomSchema.number(),
+  errorCount: HoBomSchema.number(),
+  errorRate: HoBomSchema.number(),
+});
+
+export const logEndpointErrorsSchema: Schema<LogEndpointError[]> =
+  HoBomSchema.array(logEndpointErrorSchema);
+
+export const logEntrySchema: Schema<LogEntry> = HoBomSchema.object({
+  id: HoBomSchema.number(),
+  serviceType: HoBomSchema.string(),
+  level: HoBomSchema.string(),
+  traceId: HoBomSchema.string(),
+  message: HoBomSchema.string(),
+  httpMethod: HoBomSchema.string(),
+  path: HoBomSchema.string(),
+  statusCode: HoBomSchema.number(),
+  host: HoBomSchema.string(),
+  userId: HoBomSchema.string(),
+  payload: HoBomSchema.string(),
+  timestamp: HoBomSchema.date(),
+});
+
+export const logEntryPageSchema: Schema<PaginatedItems<LogEntry>> = HoBomSchema.object({
+  items: HoBomSchema.array(logEntrySchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});

--- a/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.api.ts
+++ b/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.api.ts
@@ -1,4 +1,5 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse, type HttpResponseType } from "@/shared/api";
+import { menuRecommendationListSchema, todayRecommendedMenuSchema } from "./menu-recommendation.schema";
 import type {
   MenuRecommendationType,
   SelectedTodayMenuResponse,
@@ -11,9 +12,15 @@ import type {
 } from "../model/menu-recommendation.model";
 
 export const fetchMenuRecommendationList = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<MenuRecommendationType[]>>("/menu-recommendation", {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<MenuRecommendationType[]>>(
+    "/menu-recommendation",
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(menuRecommendationListSchema, "GET /menu-recommendation")(res.items),
+  };
 };
 
 export const postMenuRecommendation = async ({
@@ -45,9 +52,15 @@ export const putMenuRecommendationTodayMenu = async ({
 };
 
 export const fetchTodayRecommendedMenu = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<TodayRecommendedMenuType>>(`/today-menu/${id}`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<TodayRecommendedMenuType>>(
+    `/today-menu/${id}`,
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(todayRecommendedMenuSchema, "GET /today-menu/:id")(res.items),
+  };
 };
 
 export const postSelectTodayMenu = async ({ id }: { id: string }) => {

--- a/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.schema.ts
+++ b/apps/hobom-system/src/entities/menu-recommendation/api/menu-recommendation.schema.ts
@@ -1,0 +1,35 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { MenuRecommendationType, TodayRecommendedMenuType } from "./menu-recommendation.type";
+
+/** `MenuRecommendationType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const menuRecommendationSchema: Schema<MenuRecommendationType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  menuKind: HoBomSchema.enum([
+    "KOREAN",
+    "JAPANESE",
+    "CHINESE",
+    "INDIAN",
+    "MEXICAN",
+    "AMERICAN",
+    "ITALIAN",
+  ]),
+  timeOfMeal: HoBomSchema.enum(["BREAKFAST", "LUNCH", "DINNER"]),
+  foodType: HoBomSchema.enum(["MEAL", "DESERT", "BOTH"]),
+  registerPerson: HoBomSchema.object({
+    id: HoBomSchema.string(),
+    username: HoBomSchema.string(),
+    nickname: HoBomSchema.string(),
+  }),
+});
+
+export const menuRecommendationListSchema: Schema<MenuRecommendationType[]> =
+  HoBomSchema.array(menuRecommendationSchema);
+
+export const todayRecommendedMenuSchema: Schema<TodayRecommendedMenuType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  recommendationDate: HoBomSchema.date(),
+  recommendedMenu: menuRecommendationSchema,
+  candidates: HoBomSchema.array(menuRecommendationSchema),
+});

--- a/apps/hobom-system/src/entities/note/api/note.api.ts
+++ b/apps/hobom-system/src/entities/note/api/note.api.ts
@@ -1,5 +1,6 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { rawNoteItemSchema, rawNoteItemsSchema } from "./note.schema";
 import type {
   RawNoteItemType,
   NoteItemType,
@@ -22,14 +23,16 @@ const normalizeNote = (raw: RawNoteItemType): NoteItemType => ({
 export const fetchNotes = async (status?: NoteStatus, signal?: AbortSignal) => {
   const query = status ? `?status=${status}` : "";
   const res = await httpClient.get<HttpResponseType<RawNoteItemType[]>>(`/notes${query}`, { signal });
+  const rawItems = parseResponse(rawNoteItemsSchema, "GET /notes")(res.items);
 
-  return { ...res, items: res.items.map(normalizeNote) };
+  return { ...res, items: rawItems.map(normalizeNote) };
 };
 
 export const fetchNoteById = async ({ id }: { id: string }, signal?: AbortSignal) => {
   const res = await httpClient.get<HttpResponseType<RawNoteItemType>>(`/notes/${id}`, { signal });
+  const rawItem = parseResponse(rawNoteItemSchema, "GET /notes/:id")(res.items);
 
-  return { ...res, items: normalizeNote(res.items) };
+  return { ...res, items: normalizeNote(rawItem) };
 };
 
 export const postCreateNote = async (data: CreateNoteRequest) => {

--- a/apps/hobom-system/src/entities/note/api/note.schema.ts
+++ b/apps/hobom-system/src/entities/note/api/note.schema.ts
@@ -1,0 +1,34 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { ChecklistItemType, ReminderType, RawNoteItemType } from "./note.type";
+
+const checklistItemSchema: Schema<ChecklistItemType> = HoBomSchema.object({
+  text: HoBomSchema.string(),
+  checked: HoBomSchema.boolean(),
+  order: HoBomSchema.number(),
+});
+
+const reminderSchema: Schema<ReminderType> = HoBomSchema.object({
+  date: HoBomSchema.date(),
+  recurrence: HoBomSchema.enum(["NONE", "DAILY", "WEEKLY", "MONTHLY"]),
+});
+
+/** `RawNoteItemType` (VO 래핑 원본) 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const rawNoteItemSchema: Schema<RawNoteItemType> = HoBomSchema.object({
+  id: HoBomSchema.object({ value: HoBomSchema.string() }),
+  owner: HoBomSchema.object({ value: HoBomSchema.string() }),
+  title: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  type: HoBomSchema.enum(["TEXT", "CHECKLIST"]),
+  checklistItems: HoBomSchema.array(checklistItemSchema),
+  color: HoBomSchema.object({ value: HoBomSchema.string() }),
+  labels: HoBomSchema.array(HoBomSchema.object({ value: HoBomSchema.string() })),
+  reminder: reminderSchema.nullable(),
+  members: HoBomSchema.array(HoBomSchema.object({ value: HoBomSchema.string() })),
+  isPinned: HoBomSchema.boolean(),
+  status: HoBomSchema.enum(["ACTIVE", "ARCHIVED", "TRASHED"]),
+  trashedAt: HoBomSchema.date().nullable(),
+  order: HoBomSchema.number(),
+});
+
+export const rawNoteItemsSchema: Schema<RawNoteItemType[]> = HoBomSchema.array(rawNoteItemSchema);

--- a/apps/hobom-system/src/entities/notification/api/notification.api.ts
+++ b/apps/hobom-system/src/entities/notification/api/notification.api.ts
@@ -1,5 +1,6 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { notificationPageSchema } from "./notification.schema";
 import type { NotificationPageParams, NotificationPageResponse } from "./notification.type";
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -19,7 +20,7 @@ export const fetchNotificationPage = async (
     { signal },
   );
 
-  return res.items;
+  return parseResponse(notificationPageSchema, "GET /notifications/scroll")(res.items);
 };
 
 export const patchNotificationRead = async (id: string) => {

--- a/apps/hobom-system/src/entities/notification/api/notification.schema.ts
+++ b/apps/hobom-system/src/entities/notification/api/notification.schema.ts
@@ -1,0 +1,19 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { NotificationItemType, NotificationPageResponse } from "./notification.type";
+
+export const notificationItemSchema: Schema<NotificationItemType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  category: HoBomSchema.enum(["SYSTEM"]),
+  title: HoBomSchema.string(),
+  body: HoBomSchema.string(),
+  senderId: HoBomSchema.string(),
+  isRead: HoBomSchema.boolean(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const notificationPageSchema: Schema<NotificationPageResponse> = HoBomSchema.object({
+  data: HoBomSchema.array(notificationItemSchema),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});

--- a/apps/hobom-system/src/entities/privacy-law/api/privacy-law.api.ts
+++ b/apps/hobom-system/src/entities/privacy-law/api/privacy-law.api.ts
@@ -1,5 +1,16 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import {
+  lawVersionSchema,
+  lawVersionsSchema,
+  lawDiffSchema,
+  lawDiffsSchema,
+  studyMaterialSchema,
+  studyMaterialsSchema,
+  questionHistoriesSchema,
+  examSetsSchema,
+  examSetDetailSchema,
+} from "./privacy-law.schema";
 import type {
   LawVersion,
   LawDiff,
@@ -16,41 +27,74 @@ const BASE = "/privacy-law";
 // ── Versions ──
 
 export const fetchVersions = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LawVersion[]>>(`${BASE}/versions`, { signal });
+  const res = await httpClient.get<HttpResponseType<LawVersion[]>>(`${BASE}/versions`, { signal });
+
+  return { ...res, items: parseResponse(lawVersionsSchema, "GET /privacy-law/versions")(res.items) };
 };
 
 export const fetchVersionById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LawVersion>>(`${BASE}/versions/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<LawVersion>>(`${BASE}/versions/${id}`, {
+    signal,
+  });
+
+  return {
+    ...res,
+    items: parseResponse(lawVersionSchema, "GET /privacy-law/versions/:id")(res.items),
+  };
 };
 
 // ── Diffs ──
 
 export const fetchDiffs = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LawDiff[]>>(`${BASE}/diffs`, { signal });
+  const res = await httpClient.get<HttpResponseType<LawDiff[]>>(`${BASE}/diffs`, { signal });
+
+  return { ...res, items: parseResponse(lawDiffsSchema, "GET /privacy-law/diffs")(res.items) };
 };
 
 export const fetchDiffById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<LawDiff>>(`${BASE}/diffs/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<LawDiff>>(`${BASE}/diffs/${id}`, { signal });
+
+  return { ...res, items: parseResponse(lawDiffSchema, "GET /privacy-law/diffs/:id")(res.items) };
 };
 
 // ── Study Materials ──
 
 export const fetchStudyMaterials = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<StudyMaterial[]>>(`${BASE}/study-materials`, {
+  const res = await httpClient.get<HttpResponseType<StudyMaterial[]>>(`${BASE}/study-materials`, {
     signal,
   });
+
+  return {
+    ...res,
+    items: parseResponse(studyMaterialsSchema, "GET /privacy-law/study-materials")(res.items),
+  };
 };
 
 export const fetchStudyMaterialById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<StudyMaterial>>(`${BASE}/study-materials/${id}`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<StudyMaterial>>(
+    `${BASE}/study-materials/${id}`,
+    {
+      signal,
+    },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(studyMaterialSchema, "GET /privacy-law/study-materials/:id")(res.items),
+  };
 };
 
 // ── Questions ──
 
 export const fetchQuestionHistory = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<QuestionHistory[]>>(`${BASE}/questions`, { signal });
+  const res = await httpClient.get<HttpResponseType<QuestionHistory[]>>(`${BASE}/questions`, {
+    signal,
+  });
+
+  return {
+    ...res,
+    items: parseResponse(questionHistoriesSchema, "GET /privacy-law/questions")(res.items),
+  };
 };
 
 export const postAskQuestion = async (data: AskQuestionRequest) => {
@@ -60,11 +104,20 @@ export const postAskQuestion = async (data: AskQuestionRequest) => {
 // ── Exams ──
 
 export const fetchExams = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<ExamSet[]>>(`${BASE}/exams`, { signal });
+  const res = await httpClient.get<HttpResponseType<ExamSet[]>>(`${BASE}/exams`, { signal });
+
+  return { ...res, items: parseResponse(examSetsSchema, "GET /privacy-law/exams")(res.items) };
 };
 
 export const fetchExamById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<ExamSetDetail>>(`${BASE}/exams/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<ExamSetDetail>>(`${BASE}/exams/${id}`, {
+    signal,
+  });
+
+  return {
+    ...res,
+    items: parseResponse(examSetDetailSchema, "GET /privacy-law/exams/:id")(res.items),
+  };
 };
 
 export const postGenerateExam = async () => {

--- a/apps/hobom-system/src/entities/privacy-law/api/privacy-law.schema.ts
+++ b/apps/hobom-system/src/entities/privacy-law/api/privacy-law.schema.ts
@@ -1,0 +1,133 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type {
+  LawParagraph,
+  LawArticle,
+  LawVersion,
+  ArticleChange,
+  LawDiff,
+  Quiz,
+  StudyMaterial,
+  QuestionHistory,
+  ExamQuestion,
+  ExamSet,
+  ExamSetDetail,
+} from "./privacy-law.type";
+
+// ── Versions ──
+
+const paragraphSubItemSchema = HoBomSchema.object({
+  no: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+});
+
+const lawParagraphSchema: Schema<LawParagraph> = HoBomSchema.object({
+  no: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  subItems: HoBomSchema.array(paragraphSubItemSchema),
+});
+
+const lawArticleSchema: Schema<LawArticle> = HoBomSchema.object({
+  articleNo: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  paragraphs: HoBomSchema.array(lawParagraphSchema),
+});
+
+export const lawVersionSchema: Schema<LawVersion> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  lawId: HoBomSchema.string(),
+  lawName: HoBomSchema.string(),
+  proclamationDate: HoBomSchema.date(),
+  enforcementDate: HoBomSchema.date(),
+  articles: HoBomSchema.array(lawArticleSchema),
+  rawXml: HoBomSchema.string().optional(),
+  fetchedAt: HoBomSchema.date(),
+});
+
+export const lawVersionsSchema: Schema<LawVersion[]> = HoBomSchema.array(lawVersionSchema);
+
+// ── Diffs ──
+
+const articleChangeSchema: Schema<ArticleChange> = HoBomSchema.object({
+  articleNo: HoBomSchema.string(),
+  changeType: HoBomSchema.enum(["ADDED", "MODIFIED", "DELETED"]),
+  before: HoBomSchema.string().optional(),
+  after: HoBomSchema.string().optional(),
+});
+
+export const lawDiffSchema: Schema<LawDiff> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  fromVersionId: HoBomSchema.string(),
+  toVersionId: HoBomSchema.string(),
+  fromProclamationDate: HoBomSchema.date(),
+  toProclamationDate: HoBomSchema.date(),
+  changes: HoBomSchema.array(articleChangeSchema),
+});
+
+export const lawDiffsSchema: Schema<LawDiff[]> = HoBomSchema.array(lawDiffSchema);
+
+// ── Study Materials ──
+
+const quizSchema: Schema<Quiz> = HoBomSchema.object({
+  type: HoBomSchema.string(),
+  question: HoBomSchema.string(),
+  choices: HoBomSchema.array(HoBomSchema.string()),
+  answer: HoBomSchema.string(),
+  explanation: HoBomSchema.string(),
+});
+
+export const studyMaterialSchema: Schema<StudyMaterial> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  diffId: HoBomSchema.string(),
+  summary: HoBomSchema.string(),
+  keyPoints: HoBomSchema.array(HoBomSchema.string()),
+  quizzes: HoBomSchema.array(quizSchema),
+});
+
+export const studyMaterialsSchema: Schema<StudyMaterial[]> =
+  HoBomSchema.array(studyMaterialSchema);
+
+// ── Questions ──
+
+export const questionHistorySchema: Schema<QuestionHistory> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  question: HoBomSchema.string(),
+  answer: HoBomSchema.string(),
+  referencedArticles: HoBomSchema.array(HoBomSchema.string()),
+  createdAt: HoBomSchema.date(),
+});
+
+export const questionHistoriesSchema: Schema<QuestionHistory[]> =
+  HoBomSchema.array(questionHistorySchema);
+
+// ── Exams ──
+
+const examQuestionSchema: Schema<ExamQuestion> = HoBomSchema.object({
+  no: HoBomSchema.number(),
+  subject: HoBomSchema.string(),
+  type: HoBomSchema.string(),
+  question: HoBomSchema.string(),
+  choices: HoBomSchema.array(HoBomSchema.string()),
+  answer: HoBomSchema.string(),
+  explanation: HoBomSchema.string(),
+});
+
+export const examSetSchema: Schema<ExamSet> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  version: HoBomSchema.number(),
+  totalQuestions: HoBomSchema.number(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const examSetsSchema: Schema<ExamSet[]> = HoBomSchema.array(examSetSchema);
+
+export const examSetDetailSchema: Schema<ExamSetDetail> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  version: HoBomSchema.number(),
+  totalQuestions: HoBomSchema.number(),
+  createdAt: HoBomSchema.date(),
+  questions: HoBomSchema.array(examQuestionSchema),
+});

--- a/apps/hobom-system/src/entities/project-label/api/project-label.api.ts
+++ b/apps/hobom-system/src/entities/project-label/api/project-label.api.ts
@@ -1,5 +1,6 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { projectLabelsSchema } from "./project-label.schema";
 import type {
   ProjectLabelType,
   CreateProjectLabelRequest,
@@ -10,10 +11,15 @@ export const fetchProjectLabels = async (
   { projectId }: { projectId: string },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<ProjectLabelType[]>>(
+  const res = await httpClient.get<HttpResponseType<ProjectLabelType[]>>(
     `/projects/${projectId}/labels`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(projectLabelsSchema, "GET /projects/:projectId/labels")(res.items),
+  };
 };
 
 export const postCreateProjectLabel = async ({

--- a/apps/hobom-system/src/entities/project-label/api/project-label.schema.ts
+++ b/apps/hobom-system/src/entities/project-label/api/project-label.schema.ts
@@ -1,0 +1,12 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { ProjectLabelType } from "./project-label.type";
+
+/** `ProjectLabelType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const projectLabelSchema: Schema<ProjectLabelType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  color: HoBomSchema.string(),
+});
+
+export const projectLabelsSchema: Schema<ProjectLabelType[]> = HoBomSchema.array(projectLabelSchema);

--- a/apps/hobom-system/src/entities/project/api/project.api.ts
+++ b/apps/hobom-system/src/entities/project/api/project.api.ts
@@ -1,13 +1,18 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { projectSchema, projectsSchema } from "./project.schema";
 import type { ProjectType, CreateProjectRequest, UpdateProjectRequest } from "./project.type";
 
 export const fetchProjects = async (signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<ProjectType[]>>("/projects/me", { signal });
+  const res = await httpClient.get<HttpResponseType<ProjectType[]>>("/projects/me", { signal });
+
+  return { ...res, items: parseResponse(projectsSchema, "GET /projects/me")(res.items) };
 };
 
 export const fetchProjectById = async ({ id }: { id: string }, signal?: AbortSignal) => {
-  return await httpClient.get<HttpResponseType<ProjectType>>(`/projects/${id}`, { signal });
+  const res = await httpClient.get<HttpResponseType<ProjectType>>(`/projects/${id}`, { signal });
+
+  return { ...res, items: parseResponse(projectSchema, "GET /projects/:id")(res.items) };
 };
 
 export const postCreateProject = async (data: CreateProjectRequest) => {

--- a/apps/hobom-system/src/entities/project/api/project.schema.ts
+++ b/apps/hobom-system/src/entities/project/api/project.schema.ts
@@ -1,0 +1,42 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { ProjectMemberType, ProjectWorkflow, ProjectType } from "./project.type";
+import type { WorkflowStatus, WorkflowTransition } from "./workflow.type";
+
+const workflowStatusSchema: Schema<WorkflowStatus> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  isDone: HoBomSchema.boolean(),
+  order: HoBomSchema.number(),
+});
+
+const workflowTransitionSchema: Schema<WorkflowTransition> = HoBomSchema.object({
+  from: HoBomSchema.string(),
+  to: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+});
+
+const projectWorkflowSchema: Schema<ProjectWorkflow> = HoBomSchema.object({
+  statuses: HoBomSchema.array(workflowStatusSchema),
+  transitions: HoBomSchema.array(workflowTransitionSchema),
+});
+
+const projectMemberSchema: Schema<ProjectMemberType> = HoBomSchema.object({
+  userId: HoBomSchema.string(),
+  role: HoBomSchema.string(),
+  joinedAt: HoBomSchema.date(),
+});
+
+/** `ProjectType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const projectSchema: Schema<ProjectType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  key: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  description: HoBomSchema.string().optional(),
+  owner: HoBomSchema.string(),
+  members: HoBomSchema.array(projectMemberSchema),
+  issueSequence: HoBomSchema.number(),
+  workflow: projectWorkflowSchema.nullable(),
+});
+
+export const projectsSchema: Schema<ProjectType[]> = HoBomSchema.array(projectSchema);

--- a/apps/hobom-system/src/entities/sprint/api/sprint.api.ts
+++ b/apps/hobom-system/src/entities/sprint/api/sprint.api.ts
@@ -1,14 +1,21 @@
-import { httpClient } from "@/shared/api";
+import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { sprintsSchema } from "./sprint.schema";
 import type { SprintType, CreateSprintRequest, UpdateSprintRequest } from "./sprint.type";
 
 export const fetchSprintsByProject = async (
   { projectId }: { projectId: string },
   signal?: AbortSignal,
 ) => {
-  return await httpClient.get<HttpResponseType<SprintType[]>>(`/projects/${projectId}/sprints`, {
-    signal,
-  });
+  const res = await httpClient.get<HttpResponseType<SprintType[]>>(
+    `/projects/${projectId}/sprints`,
+    { signal },
+  );
+
+  return {
+    ...res,
+    items: parseResponse(sprintsSchema, "GET /projects/:projectId/sprints")(res.items),
+  };
 };
 
 export const postCreateSprint = async ({

--- a/apps/hobom-system/src/entities/sprint/api/sprint.schema.ts
+++ b/apps/hobom-system/src/entities/sprint/api/sprint.schema.ts
@@ -1,0 +1,18 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { SprintType } from "./sprint.type";
+
+/** `SprintType` 응답 스키마. shape이 타입과 어긋나면 tsc가 잡는다. */
+export const sprintSchema: Schema<SprintType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  project: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  goal: HoBomSchema.string().optional(),
+  status: HoBomSchema.enum(["PLANNING", "ACTIVE", "COMPLETED"]),
+  startDate: HoBomSchema.date(),
+  endDate: HoBomSchema.date(),
+  completedAt: HoBomSchema.date().optional(),
+  createdBy: HoBomSchema.string(),
+});
+
+export const sprintsSchema: Schema<SprintType[]> = HoBomSchema.array(sprintSchema);

--- a/apps/hobom-system/src/entities/user/api/user.api.ts
+++ b/apps/hobom-system/src/entities/user/api/user.api.ts
@@ -1,14 +1,21 @@
-import { httpClient, type HttpResponseType } from "@/shared/api";
+import { httpClient, parseResponse, type HttpResponseType } from "@/shared/api";
+import { userSchema, usersSchema } from "./user.schema";
 import type { UserType } from "./user.type";
 
 export const fetchMe = async (signal?: AbortSignal) => {
   const res = await httpClient.get<HttpResponseType<UserType>>(`/auth/me`, { signal });
 
-  return res.items;
+  return parseResponse(userSchema, "GET /auth/me")(res.items);
 };
 
-export const fetchUsers = async (signal?: AbortSignal) =>
-  await httpClient.get<HttpResponseType<UserType[]>>(`/users`, { signal });
+export const fetchUsers = async (signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<UserType[]>>(`/users`, { signal });
 
-export const fetchUserById = async ({ id }: { id: string }, signal?: AbortSignal) =>
-  await httpClient.get<HttpResponseType<UserType>>(`/users/${id}`, { signal });
+  return { ...res, items: parseResponse(usersSchema, "GET /users")(res.items) };
+};
+
+export const fetchUserById = async ({ id }: { id: string }, signal?: AbortSignal) => {
+  const res = await httpClient.get<HttpResponseType<UserType>>(`/users/${id}`, { signal });
+
+  return { ...res, items: parseResponse(userSchema, "GET /users/:id")(res.items) };
+};

--- a/apps/hobom-system/src/entities/user/api/user.schema.ts
+++ b/apps/hobom-system/src/entities/user/api/user.schema.ts
@@ -1,0 +1,13 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { UserType } from "./user.type";
+
+export const userSchema: Schema<UserType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  username: HoBomSchema.string(),
+  nickname: HoBomSchema.string(),
+  email: HoBomSchema.string(),
+  friends: HoBomSchema.array(HoBomSchema.string()),
+});
+
+export const usersSchema: Schema<UserType[]> = HoBomSchema.array(userSchema);

--- a/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.api.ts
+++ b/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.api.ts
@@ -1,5 +1,6 @@
-import { spaceHttpClient } from "@/shared/api";
+import { spaceHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
+import { commentsPageSchema } from "./wiki-comment.schema";
 import type { CommentType, CreateCommentRequest, UpdateCommentRequest } from "./wiki-comment.type";
 
 export const fetchComments = async (
@@ -16,10 +17,18 @@ export const fetchComments = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<PaginatedItems<CommentType>>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PaginatedItems<CommentType>>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/comments?offset=${offset}&limit=${limit}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      commentsPageSchema,
+      "GET /api/v1/spaces/:spaceKey/pages/:pageId/comments",
+    )(res.items),
+  };
 };
 
 export const postCreateComment = async ({

--- a/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.schema.ts
+++ b/apps/hobom-system/src/entities/wiki-comment/api/wiki-comment.schema.ts
@@ -1,0 +1,21 @@
+import { HoBomSchema } from "hobom-schema";
+import type { PaginatedItems } from "@/shared/api";
+import type { Schema } from "hobom-schema";
+import type { CommentType } from "./wiki-comment.type";
+
+export const commentSchema: Schema<CommentType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  pageId: HoBomSchema.string(),
+  parentCommentId: HoBomSchema.string().nullable(),
+  content: HoBomSchema.string(),
+  author: HoBomSchema.string().nullable(),
+  createdAt: HoBomSchema.date(),
+  updatedAt: HoBomSchema.date(),
+});
+
+export const commentsPageSchema: Schema<PaginatedItems<CommentType>> = HoBomSchema.object({
+  items: HoBomSchema.array(commentSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});

--- a/apps/hobom-system/src/entities/wiki-label/api/wiki-label.api.ts
+++ b/apps/hobom-system/src/entities/wiki-label/api/wiki-label.api.ts
@@ -1,5 +1,6 @@
-import { spaceHttpClient } from "@/shared/api";
+import { spaceHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
+import { labelsSchema, labelPagesSchema } from "./wiki-label.schema";
 import type {
   LabelType,
   LabelPageType,
@@ -11,10 +12,15 @@ import type {
 // ── Space Labels ──
 
 export const fetchLabels = async ({ spaceKey }: { spaceKey: string }, signal?: AbortSignal) => {
-  return await spaceHttpClient.get<HttpResponseType<LabelType[]>>(
+  const res = await spaceHttpClient.get<HttpResponseType<LabelType[]>>(
     `/api/v1/spaces/${spaceKey}/labels`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(labelsSchema, "GET /api/v1/spaces/:spaceKey/labels")(res.items),
+  };
 };
 
 export const postCreateLabel = async ({
@@ -83,8 +89,16 @@ export const fetchPagesByLabel = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<LabelPageType[]>>(
+  const res = await spaceHttpClient.get<HttpResponseType<LabelPageType[]>>(
     `/api/v1/spaces/${spaceKey}/labels/${labelId}/pages`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      labelPagesSchema,
+      "GET /api/v1/spaces/:spaceKey/labels/:labelId/pages",
+    )(res.items),
+  };
 };

--- a/apps/hobom-system/src/entities/wiki-label/api/wiki-label.schema.ts
+++ b/apps/hobom-system/src/entities/wiki-label/api/wiki-label.schema.ts
@@ -1,0 +1,22 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { LabelType, LabelPageType } from "./wiki-label.type";
+
+export const labelSchema: Schema<LabelType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  spaceId: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  color: HoBomSchema.string(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const labelsSchema: Schema<LabelType[]> = HoBomSchema.array(labelSchema);
+
+export const labelPageSchema: Schema<LabelPageType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  spaceId: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  updatedAt: HoBomSchema.date(),
+});
+
+export const labelPagesSchema: Schema<LabelPageType[]> = HoBomSchema.array(labelPageSchema);

--- a/apps/hobom-system/src/entities/wiki-page/api/wiki-page.api.ts
+++ b/apps/hobom-system/src/entities/wiki-page/api/wiki-page.api.ts
@@ -1,5 +1,14 @@
-import { spaceHttpClient } from "@/shared/api";
+import { spaceHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
+import {
+  pageSchema,
+  pageTreeSchema,
+  pageVersionSchema,
+  pageVersionsPageSchema,
+  diffEntriesSchema,
+  trashPagesPageSchema,
+  searchResultsPageSchema,
+} from "./wiki-page.schema";
 import type {
   PageType,
   PageTreeNode,
@@ -16,20 +25,30 @@ import type {
 // ── Pages ──
 
 export const fetchPageTree = async ({ spaceKey }: { spaceKey: string }, signal?: AbortSignal) => {
-  return await spaceHttpClient.get<HttpResponseType<PageTreeNode[]>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PageTreeNode[]>>(
     `/api/v1/spaces/${spaceKey}/pages`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(pageTreeSchema, "GET /api/v1/spaces/:spaceKey/pages")(res.items),
+  };
 };
 
 export const fetchPageById = async (
   { spaceKey, pageId }: { spaceKey: string; pageId: string },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<PageType>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PageType>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(pageSchema, "GET /api/v1/spaces/:spaceKey/pages/:pageId")(res.items),
+  };
 };
 
 export const postCreatePage = async ({
@@ -75,10 +94,18 @@ export const fetchPageVersions = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<PaginatedItems<PageVersionType>>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PaginatedItems<PageVersionType>>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions?offset=${offset}&limit=${limit}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      pageVersionsPageSchema,
+      "GET /api/v1/spaces/:spaceKey/pages/:pageId/versions",
+    )(res.items),
+  };
 };
 
 export const fetchPageVersion = async (
@@ -93,10 +120,18 @@ export const fetchPageVersion = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<PageVersionType>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PageVersionType>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions/${version}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      pageVersionSchema,
+      "GET /api/v1/spaces/:spaceKey/pages/:pageId/versions/:version",
+    )(res.items),
+  };
 };
 
 export const postRestorePageVersion = async ({
@@ -154,10 +189,18 @@ export const fetchVersionDiff = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<DiffEntryType[]>>(
+  const res = await spaceHttpClient.get<HttpResponseType<DiffEntryType[]>>(
     `/api/v1/spaces/${spaceKey}/pages/${pageId}/versions/diff?from=${fromVersion}&to=${toVersion}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(
+      diffEntriesSchema,
+      "GET /api/v1/spaces/:spaceKey/pages/:pageId/versions/diff",
+    )(res.items),
+  };
 };
 
 // ── Trash ──
@@ -174,10 +217,15 @@ export const fetchTrashPages = async (
   },
   signal?: AbortSignal,
 ) => {
-  return await spaceHttpClient.get<HttpResponseType<PaginatedItems<TrashPageType>>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PaginatedItems<TrashPageType>>>(
     `/api/v1/spaces/${spaceKey}/trash?offset=${offset}&limit=${limit}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(trashPagesPageSchema, "GET /api/v1/spaces/:spaceKey/trash")(res.items),
+  };
 };
 
 export const postRestoreTrashPage = async ({
@@ -223,8 +271,13 @@ export const searchPages = async (
 ) => {
   const base = spaceKey ? `/api/v1/search/spaces/${spaceKey}` : "/api/v1/search";
 
-  return await spaceHttpClient.get<HttpResponseType<PaginatedItems<SearchResultType>>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PaginatedItems<SearchResultType>>>(
     `${base}?q=${encodeURIComponent(q)}&offset=${offset}&limit=${limit}`,
     { signal },
   );
+
+  return {
+    ...res,
+    items: parseResponse(searchResultsPageSchema, "GET /api/v1/search")(res.items),
+  };
 };

--- a/apps/hobom-system/src/entities/wiki-page/api/wiki-page.schema.ts
+++ b/apps/hobom-system/src/entities/wiki-page/api/wiki-page.schema.ts
@@ -1,0 +1,98 @@
+import { HoBomSchema } from "hobom-schema";
+import type { PaginatedItems } from "@/shared/api";
+import type { Schema } from "hobom-schema";
+import type {
+  PageLabelType,
+  PageType,
+  PageTreeNode,
+  PageVersionType,
+  SearchResultType,
+  DiffEntryType,
+  TrashPageType,
+} from "./wiki-page.type";
+
+const pageLabelSchema: Schema<PageLabelType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  color: HoBomSchema.string(),
+});
+
+export const pageSchema: Schema<PageType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  spaceId: HoBomSchema.string(),
+  parentPageId: HoBomSchema.string().nullable(),
+  title: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  position: HoBomSchema.number(),
+  createdAt: HoBomSchema.date(),
+  updatedAt: HoBomSchema.date(),
+  labels: HoBomSchema.array(pageLabelSchema),
+});
+
+export const pageTreeNodeSchema: Schema<PageTreeNode> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  position: HoBomSchema.number(),
+  get children() {
+    return HoBomSchema.array(pageTreeNodeSchema);
+  },
+});
+
+export const pageTreeSchema: Schema<PageTreeNode[]> = HoBomSchema.array(pageTreeNodeSchema);
+
+export const pageVersionSchema: Schema<PageVersionType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  pageId: HoBomSchema.string(),
+  version: HoBomSchema.number(),
+  title: HoBomSchema.string(),
+  content: HoBomSchema.string(),
+  editedBy: HoBomSchema.string().nullable(),
+  createdAt: HoBomSchema.date(),
+});
+
+export const pageVersionsPageSchema: Schema<PaginatedItems<PageVersionType>> = HoBomSchema.object({
+  items: HoBomSchema.array(pageVersionSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});
+
+export const diffEntrySchema: Schema<DiffEntryType> = HoBomSchema.object({
+  lineNumber: HoBomSchema.number(),
+  type: HoBomSchema.enum(["ADDED", "REMOVED", "UNCHANGED"]),
+  content: HoBomSchema.string(),
+});
+
+export const diffEntriesSchema: Schema<DiffEntryType[]> = HoBomSchema.array(diffEntrySchema);
+
+export const trashPageSchema: Schema<TrashPageType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  spaceId: HoBomSchema.string(),
+  parentPageId: HoBomSchema.string().nullable(),
+  title: HoBomSchema.string(),
+  position: HoBomSchema.number(),
+  createdAt: HoBomSchema.date(),
+  deletedAt: HoBomSchema.date().nullable(),
+  deletedBy: HoBomSchema.string().nullable(),
+});
+
+export const trashPagesPageSchema: Schema<PaginatedItems<TrashPageType>> = HoBomSchema.object({
+  items: HoBomSchema.array(trashPageSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});
+
+export const searchResultSchema: Schema<SearchResultType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  spaceId: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  updatedAt: HoBomSchema.date(),
+});
+
+export const searchResultsPageSchema: Schema<PaginatedItems<SearchResultType>> = HoBomSchema.object({
+  items: HoBomSchema.array(searchResultSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});

--- a/apps/hobom-system/src/entities/wiki-space/api/wiki-space.api.ts
+++ b/apps/hobom-system/src/entities/wiki-space/api/wiki-space.api.ts
@@ -1,5 +1,6 @@
-import { spaceHttpClient } from "@/shared/api";
+import { spaceHttpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType, PaginatedItems } from "@/shared/api";
+import { spaceSchema, spacesPageSchema } from "./wiki-space.schema";
 import type { SpaceType, CreateSpaceRequest, UpdateSpaceRequest } from "./wiki-space.type";
 
 export const fetchSpaces = async (
@@ -9,14 +10,20 @@ export const fetchSpaces = async (
   const offset = params?.offset ?? 0;
   const limit = params?.limit ?? 20;
 
-  return await spaceHttpClient.get<HttpResponseType<PaginatedItems<SpaceType>>>(
+  const res = await spaceHttpClient.get<HttpResponseType<PaginatedItems<SpaceType>>>(
     `/api/v1/spaces?offset=${offset}&limit=${limit}`,
     { signal },
   );
+
+  return { ...res, items: parseResponse(spacesPageSchema, "GET /api/v1/spaces")(res.items) };
 };
 
 export const fetchSpaceByKey = async ({ key }: { key: string }, signal?: AbortSignal) => {
-  return await spaceHttpClient.get<HttpResponseType<SpaceType>>(`/api/v1/spaces/${key}`, { signal });
+  const res = await spaceHttpClient.get<HttpResponseType<SpaceType>>(`/api/v1/spaces/${key}`, {
+    signal,
+  });
+
+  return { ...res, items: parseResponse(spaceSchema, "GET /api/v1/spaces/:key")(res.items) };
 };
 
 export const postCreateSpace = async (data: CreateSpaceRequest) => {

--- a/apps/hobom-system/src/entities/wiki-space/api/wiki-space.schema.ts
+++ b/apps/hobom-system/src/entities/wiki-space/api/wiki-space.schema.ts
@@ -1,0 +1,20 @@
+import { HoBomSchema } from "hobom-schema";
+import type { PaginatedItems } from "@/shared/api";
+import type { Schema } from "hobom-schema";
+import type { SpaceType } from "./wiki-space.type";
+
+export const spaceSchema: Schema<SpaceType> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  key: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  description: HoBomSchema.string().nullable(),
+  createdAt: HoBomSchema.date(),
+  updatedAt: HoBomSchema.date(),
+});
+
+export const spacesPageSchema: Schema<PaginatedItems<SpaceType>> = HoBomSchema.object({
+  items: HoBomSchema.array(spaceSchema),
+  totalCount: HoBomSchema.number(),
+  offset: HoBomSchema.number(),
+  limit: HoBomSchema.number(),
+});

--- a/apps/hobom-system/src/shared/api/index.ts
+++ b/apps/hobom-system/src/shared/api/index.ts
@@ -7,3 +7,5 @@ export {
 } from "./http.api";
 
 export type { HttpResponseType, PaginatedItems } from "./http-response.type";
+
+export { parseResponse } from "./parse-response.api";

--- a/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { HoBomSchema } from "hobom-schema";
+import { parseResponse } from "./parse-response.api";
+
+const itemSchema = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+});
+
+describe("parseResponse", () => {
+  it("returns the payload when it matches the schema", () => {
+    const payload = { id: "1", title: "hello" };
+
+    expect(parseResponse(itemSchema, "GET /items")(payload)).toEqual(payload);
+  });
+
+  it("throws with the context and issue detail when the shape is wrong", () => {
+    expect(() => parseResponse(itemSchema, "GET /items")({ id: "1" })).toThrow(
+      /Response validation failed \(GET \/items\)/,
+    );
+  });
+
+  it("throws when a field has the wrong type", () => {
+    expect(() =>
+      parseResponse(itemSchema, "GET /items")({ id: 1, title: "hello" }),
+    ).toThrow(/Response validation failed/);
+  });
+
+  it("validates arrays element by element", () => {
+    const listSchema = HoBomSchema.array(itemSchema);
+    const list = [
+      { id: "1", title: "a" },
+      { id: "2", title: "b" },
+    ];
+
+    expect(parseResponse(listSchema, "GET /items")(list)).toEqual(list);
+    expect(() =>
+      parseResponse(listSchema, "GET /items")([{ id: "1", title: "a" }, { id: "2" }]),
+    ).toThrow(/Response validation failed/);
+  });
+});

--- a/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
@@ -1,41 +1,62 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HoBomSchema } from "hobom-schema";
 import { parseResponse } from "./parse-response.api";
+
+const reportError = vi.fn();
+
+vi.mock("@/shared/lib/report-error.lib", () => ({
+  reportError: (error: Error) => reportError(error),
+}));
 
 const itemSchema = HoBomSchema.object({
   id: HoBomSchema.string(),
   title: HoBomSchema.string(),
 });
 
+beforeEach(() => {
+  reportError.mockReset();
+});
+
 describe("parseResponse", () => {
-  it("returns the payload when it matches the schema", () => {
+  it("returns the payload and reports nothing when it matches", () => {
     const payload = { id: "1", title: "hello" };
 
     expect(parseResponse(itemSchema, "GET /items")(payload)).toEqual(payload);
+    expect(reportError).not.toHaveBeenCalled();
   });
 
-  it("throws with the context and issue detail when the shape is wrong", () => {
-    expect(() => parseResponse(itemSchema, "GET /items")({ id: "1" })).toThrow(
-      /Response validation failed \(GET \/items\)/,
+  it("passes the raw payload through and reports the mismatch (advisory, non-fatal)", () => {
+    const wrong = { id: "1" };
+
+    // Never throws — the unvalidated payload flows through unchanged.
+    expect(parseResponse(itemSchema, "GET /items")(wrong)).toBe(wrong);
+
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError.mock.calls[0][0].message).toMatch(
+      /Response validation mismatch \(GET \/items\)/,
     );
   });
 
-  it("throws when a field has the wrong type", () => {
-    expect(() =>
-      parseResponse(itemSchema, "GET /items")({ id: 1, title: "hello" }),
-    ).toThrow(/Response validation failed/);
+  it("reports a wrong field type but still returns the data", () => {
+    const wrong = { id: 1, title: "hello" };
+
+    expect(parseResponse(itemSchema, "GET /items")(wrong)).toBe(wrong);
+    expect(reportError).toHaveBeenCalledOnce();
   });
 
-  it("validates arrays element by element", () => {
+  it("validates arrays and reports element mismatches without throwing", () => {
     const listSchema = HoBomSchema.array(itemSchema);
-    const list = [
+    const good = [
       { id: "1", title: "a" },
       { id: "2", title: "b" },
     ];
 
-    expect(parseResponse(listSchema, "GET /items")(list)).toEqual(list);
-    expect(() =>
-      parseResponse(listSchema, "GET /items")([{ id: "1", title: "a" }, { id: "2" }]),
-    ).toThrow(/Response validation failed/);
+    expect(parseResponse(listSchema, "GET /items")(good)).toEqual(good);
+    expect(reportError).not.toHaveBeenCalled();
+
+    const bad = [{ id: "1", title: "a" }, { id: "2" }];
+
+    expect(parseResponse(listSchema, "GET /items")(bad)).toBe(bad);
+    expect(reportError).toHaveBeenCalledOnce();
   });
 });

--- a/apps/hobom-system/src/shared/api/parse-response.api.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.ts
@@ -1,13 +1,15 @@
+import { reportError } from "@/shared/lib/report-error.lib";
 import type { Schema } from "hobom-schema";
 
 /**
  * 응답 페이로드를 스키마로 검증하는 경계 파서.
  *
- * 불일치 시 즉시 throw한다 — 서버 계약 위반이 렌더링 깊숙한 곳에서 터지는 대신
- * 이 경계에서 (쿼리 에러로) 드러나게 한다.
+ * 불일치해도 throw하지 않는다 — `reportError`로 계약 위반을 보고하고 원본 데이터를
+ * 그대로 통과시켜, 백엔드 드리프트가 화면을 깨뜨리지 않게 한다. 로깅된 불일치를
+ * 근거로 스키마/타입을 점진적으로 실제 계약에 맞춰간다 (advisory validation).
  *
  * @param schema  기대하는 페이로드 스키마
- * @param context 실패 메시지에 붙일 식별자 (예: `"GET /labels"`)
+ * @param context 보고 메시지에 붙일 식별자 (예: `"GET /labels"`)
  */
 export const parseResponse =
   <T>(schema: Schema<T>, context: string) =>
@@ -20,5 +22,9 @@ export const parseResponse =
 
     const detail = result.error.issues.map((issue) => issue.message).join("; ");
 
-    throw new Error(`Response validation failed (${context}): ${detail}`);
+    reportError(new Error(`Response validation mismatch (${context}): ${detail}`));
+
+    // Advisory only: pass the unvalidated payload through so a schema/wire
+    // mismatch is reported, not fatal.
+    return data as T;
   };

--- a/apps/hobom-system/src/shared/api/parse-response.api.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.ts
@@ -1,0 +1,24 @@
+import type { Schema } from "hobom-schema";
+
+/**
+ * 응답 페이로드를 스키마로 검증하는 경계 파서.
+ *
+ * 불일치 시 즉시 throw한다 — 서버 계약 위반이 렌더링 깊숙한 곳에서 터지는 대신
+ * 이 경계에서 (쿼리 에러로) 드러나게 한다.
+ *
+ * @param schema  기대하는 페이로드 스키마
+ * @param context 실패 메시지에 붙일 식별자 (예: `"GET /labels"`)
+ */
+export const parseResponse =
+  <T>(schema: Schema<T>, context: string) =>
+  (data: unknown): T => {
+    const result = schema.safeParse(data);
+
+    if (result.success) {
+      return result.data;
+    }
+
+    const detail = result.error.issues.map((issue) => issue.message).join("; ");
+
+    throw new Error(`Response validation failed (${context}): ${detail}`);
+  };

--- a/packages/hobom-schema/src/index.ts
+++ b/packages/hobom-schema/src/index.ts
@@ -1,5 +1,7 @@
 import { StringSchema } from "./schemas/string-schema";
 import { NumberSchema } from "./schemas/number-schema";
+import { BooleanSchema } from "./schemas/boolean-schema";
+import { DateSchema } from "./schemas/date-schema";
 import { EnumSchema } from "./schemas/enum-schema";
 import { ObjectSchema } from "./schemas/object-schema";
 import { ArraySchema } from "./schemas/array-schema";
@@ -8,6 +10,8 @@ import type { Schema } from "./schemas/schema";
 export const HoBomSchema = {
   string: (): StringSchema => new StringSchema(),
   number: (): NumberSchema => new NumberSchema(),
+  boolean: (): BooleanSchema => new BooleanSchema(),
+  date: (): DateSchema => new DateSchema(),
   enum: <T extends string>(values: readonly T[]): EnumSchema<T> => new EnumSchema(values),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   object: <T extends Record<string, Schema<any>>>(shape: T): ObjectSchema<T> =>

--- a/packages/hobom-schema/src/schema.spec.ts
+++ b/packages/hobom-schema/src/schema.spec.ts
@@ -119,6 +119,40 @@ describe("number", () => {
   });
 });
 
+describe("boolean", () => {
+  const schema = HoBomSchema.boolean();
+
+  it("parses true and false", () => {
+    expect(schema.safeParse(true)).toEqual({ success: true, data: true });
+    expect(schema.safeParse(false)).toEqual({ success: true, data: false });
+  });
+
+  it("fails on non-boolean (including truthy/falsy values)", () => {
+    expect(schema.safeParse(1).success).toBe(false);
+    expect(schema.safeParse(0).success).toBe(false);
+    expect(schema.safeParse("true").success).toBe(false);
+    expect(schema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe("date", () => {
+  const schema = HoBomSchema.date();
+
+  it("parses a valid date string and keeps it as a string", () => {
+    expect(schema.safeParse("2026-07-10T00:00:00.000Z")).toEqual({
+      success: true,
+      data: "2026-07-10T00:00:00.000Z",
+    });
+    expect(schema.safeParse("2026-07-10").success).toBe(true);
+  });
+
+  it("fails on non-string or unparseable date", () => {
+    expect(schema.safeParse("not a date").success).toBe(false);
+    expect(schema.safeParse(1720000000000).success).toBe(false);
+    expect(schema.safeParse(null).success).toBe(false);
+  });
+});
+
 describe("enum", () => {
   const schema = HoBomSchema.enum(["A", "B", "C"]);
 

--- a/packages/hobom-schema/src/schemas/boolean-schema.ts
+++ b/packages/hobom-schema/src/schemas/boolean-schema.ts
@@ -1,0 +1,13 @@
+import { Schema } from "./schema";
+import { fail } from "./types";
+import type { Fail } from "./types";
+
+export class BooleanSchema extends Schema<boolean> {
+  _parse(input: unknown): boolean | Fail {
+    if (typeof input !== "boolean") {
+      return fail([{ message: "Expected boolean" }]);
+    }
+
+    return input;
+  }
+}

--- a/packages/hobom-schema/src/schemas/date-schema.ts
+++ b/packages/hobom-schema/src/schemas/date-schema.ts
@@ -1,0 +1,17 @@
+import { Schema } from "./schema";
+import { fail } from "./types";
+import type { Fail } from "./types";
+
+/**
+ * Validates an ISO-ish date string (anything `Date.parse` accepts) and keeps it
+ * as a string, matching how the API carries dates over the wire.
+ */
+export class DateSchema extends Schema<string> {
+  _parse(input: unknown): string | Fail {
+    if (typeof input !== "string" || Number.isNaN(Date.parse(input))) {
+      return fail([{ message: "Expected a date string" }]);
+    }
+
+    return input;
+  }
+}


### PR DESCRIPTION
Supersedes #168 — folds in the label proof plus the boolean/date primitives and the full rollout.

## Story
#168 wired `hobom-schema` into the label reads with a **throwing** validator. Rolling that out revealed the app's TypeScript response types don't match the wire — fields the types call `string` arrive VO-wrapped (`{ value }`), nullability is under-declared, etc. A schema derived from those types **rejects valid data**, so strict throwing took screens down (`GET /daily-todos`, wiki page tree, …).

## Policy: advisory (log-only)
`parseResponse` now **reports the mismatch via `reportError` and passes the raw payload through** instead of throwing. Validation runs everywhere and surfaces the real contract gaps in logs, without a mismatch ever breaking a screen. Schemas and the response types get tightened from those reports over time.

## Engine
Added `HoBomSchema.boolean()` and `HoBomSchema.date()` (validates a parseable date string, keeps it a string to match the wire) — needed to model real payloads.

## Rollout
A response schema is wired into **every GET read** across all entities (notes, todos, menu, project/board/issue/sprint/labels, the wiki family, admin/ops/dlq/log/dashboard/error-event, future-message/notification/privacy-law/user). Each schema is annotated `Schema<ResponseType>` so the schema shape and the type stay in lockstep at compile time. Infinite/paginated wrappers and the recursive page tree are modeled explicitly.

**Skipped:** DLQ detail — its `payload: Record<string, unknown>` has no schema primitive.

## Verify
- app `tsc -b` clean (every `Schema<X>` annotation compiles), eslint clean, build ok
- 588 app tests pass; `parse-response.api.spec.ts` covers the advisory behavior (passthrough + report, never throws)
- hobom-schema: 54 tests (incl. new boolean/date)

## Follow-up
The mismatch logs are the worklist: fix each response **type** (and its schema) to match the wire, then a future PR can flip specific endpoints back to strict throwing once verified.