### PR TITLE
Extend the FSD boundary rule to re-exports and dynamic imports

### DIFF
--- a/apps/hobom-system/eslint-rules/fsd-boundaries.d.ts
+++ b/apps/hobom-system/eslint-rules/fsd-boundaries.d.ts
@@ -1,0 +1,3 @@
+import type { Rule } from "eslint";
+
+export const rule: Rule.RuleModule;

--- a/apps/hobom-system/eslint-rules/fsd-boundaries.js
+++ b/apps/hobom-system/eslint-rules/fsd-boundaries.js
@@ -75,23 +75,40 @@ export const rule = {
     const current = parseLocation(context.filename);
     if (!current) return {};
 
+    const checkSource = (node, importPath) => {
+      if (typeof importPath !== "string") return;
+
+      if (importPath.startsWith("@/")) {
+        const [importedLayer, importedSlice] = importPath.slice(2).split("/");
+        checkImport(context, node, importedLayer, importedSlice ?? null, current);
+
+        return;
+      }
+
+      if (importPath.startsWith(".")) {
+        const resolved = path.resolve(path.dirname(context.filename), importPath);
+        const imported = parseLocation(resolved);
+        if (!imported) return;
+        checkImport(context, node, imported.layer, imported.slice, current);
+      }
+    };
+
+    // `node.source` carries the `from "..."` specifier. It is present on static
+    // imports and on re-exports (`export … from`), and absent on a bare
+    // `export { x }`, so the guard skips those.
+    const checkStatement = (node) => {
+      if (node.source) checkSource(node, node.source.value);
+    };
+
     return {
-      ImportDeclaration(node) {
-        const importPath = node.source.value;
-        if (typeof importPath !== "string") return;
-
-        if (importPath.startsWith("@/")) {
-          const [importedLayer, importedSlice] = importPath.slice(2).split("/");
-          checkImport(context, node, importedLayer, importedSlice ?? null, current);
-
-          return;
-        }
-
-        if (importPath.startsWith(".")) {
-          const resolved = path.resolve(path.dirname(context.filename), importPath);
-          const imported = parseLocation(resolved);
-          if (!imported) return;
-          checkImport(context, node, imported.layer, imported.slice, current);
+      ImportDeclaration: checkStatement,
+      // Re-exports bypass ImportDeclaration but cross boundaries all the same.
+      ExportNamedDeclaration: checkStatement,
+      ExportAllDeclaration: checkStatement,
+      // Dynamic `import("…")` (e.g. lazy-loaded pages) — only literal targets.
+      ImportExpression(node) {
+        if (node.source.type === "Literal") {
+          checkSource(node, node.source.value);
         }
       },
     };

--- a/apps/hobom-system/src/test/fsd-boundaries.rule.spec.ts
+++ b/apps/hobom-system/src/test/fsd-boundaries.rule.spec.ts
@@ -1,0 +1,50 @@
+import { RuleTester } from "eslint";
+import { rule } from "../../eslint-rules/fsd-boundaries.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+});
+
+const file = (layer: string, slice: string) =>
+  `/repo/apps/hobom-system/src/${layer}/${slice}/thing.ts`;
+
+ruleTester.run("fsd-boundaries", rule, {
+  valid: [
+    // entities may import shared
+    { code: `import { x } from "@/shared/y";`, filename: file("entities", "note") },
+    // re-export within the allowed direction
+    { code: `export { x } from "@/shared/y";`, filename: file("features", "auth") },
+    // apps may lazy-load pages
+    { code: `const p = import("@/pages/home");`, filename: file("apps", "app-router") },
+    // same-slice relative import is fine
+    { code: `import { x } from "@/entities/note";`, filename: file("entities", "note") },
+    // non-literal dynamic import is ignored
+    { code: `const p = import(dynamicPath);`, filename: file("entities", "note") },
+  ],
+  invalid: [
+    // entities cannot import features (static)
+    {
+      code: `import { x } from "@/features/auth";`,
+      filename: file("entities", "note"),
+      errors: [{ messageId: "crossLayer" }],
+    },
+    // …nor via a re-export
+    {
+      code: `export * from "@/features/auth";`,
+      filename: file("entities", "note"),
+      errors: [{ messageId: "crossLayer" }],
+    },
+    // …nor via a dynamic import
+    {
+      code: `const p = import("@/features/auth");`,
+      filename: file("entities", "note"),
+      errors: [{ messageId: "crossLayer" }],
+    },
+    // cross-slice import within the same layer
+    {
+      code: `import { x } from "@/features/billing";`,
+      filename: file("features", "auth"),
+      errors: [{ messageId: "crossSlice" }],
+    },
+  ],
+});


### PR DESCRIPTION
## What
The custom `fsd-boundaries` ESLint rule only inspected `ImportDeclaration`, so two ways of pulling in a module crossed layer/slice boundaries unchecked:
- **re-exports** — `export … from "@/features/x"` (barrels)
- **dynamic imports** — `import("@/features/x")` (e.g. the router's ~40 lazy page loads)

Zero violations exist today, but only because the rule didn't look — the gap was latent.

## Change
Route all four node types through one shared source check:
- `ImportDeclaration`
- `ExportNamedDeclaration` / `ExportAllDeclaration` (only when a `from` source is present — a bare `export { x }` is skipped)
- `ImportExpression` (literal targets only; `import(variable)` is ignored)

## Tests
Adds a `RuleTester` spec (`src/test/fsd-boundaries.rule.spec.ts`) — previously the rule had none — covering valid cases and cross-layer / cross-slice violations via static import, re-export, and dynamic import. A co-located `fsd-boundaries.d.ts` lets the `.js` rule be imported from the TypeScript test without an `any` cast.

## Verify
- app `tsc -b` clean, eslint clean (0 new boundary violations across `src`)
- build ok, 597 app tests pass (588 + 9 rule cases)