### PR TITLE
Harden CI gate and drop dead Vite config

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - develop
+      - main
 
 jobs:
   pr-checks:
@@ -13,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/apps/hobom-system/package.json
+++ b/apps/hobom-system/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc -b",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "format": "prettier . --write",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/hobom-system/vite.config.ts
+++ b/apps/hobom-system/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     react(),
   ],
   optimizeDeps: {
-    include: ["date-fns", "zod", "react-hook-form"],
+    include: ["date-fns", "react-hook-form"],
   },
   resolve: {
     alias: {
@@ -34,12 +34,6 @@ export default defineConfig({
             id.includes("/node_modules/scheduler/")
           ) {
             return "framework";
-          }
-          if (
-            (id.includes("/node_modules/@mui/") && !id.includes("/node_modules/@mui/x-")) ||
-            id.includes("/node_modules/@emotion/")
-          ) {
-            return "mui";
           }
         },
       },

--- a/packages/hobom-data/package.json
+++ b/packages/hobom-data/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage"
   },

--- a/packages/hobom-design-system/package.json
+++ b/packages/hobom-design-system/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",

--- a/packages/hobom-schema/package.json
+++ b/packages/hobom-schema/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage"
   }

--- a/packages/hobom-utils/package.json
+++ b/packages/hobom-utils/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage"
   },


### PR DESCRIPTION
## CI (`pr-check.yml`)
- **Gate `main` PRs too** — the check only ran for PRs into `develop`; added `main` to the trigger. (Takes effect for `main` PRs once this workflow reaches `main` via the normal develop→main promotion — GitHub reads the branch filter from the base.)
- **`--max-warnings=0`** — each package's `lint` script now runs `eslint --max-warnings=0`, so a warning fails CI instead of piling up. All five packages are at zero warnings today, so this is safe to turn on now.
- **Off the deprecated Node 20 action runtime** — `actions/checkout@v5`, `actions/setup-node@v5`, and Node `22`.

## Vite (`vite.config.ts`)
- Removed the `manualChunks` branch that grouped `@mui/*` + `@emotion/*` into a `mui` chunk — both are gone, so it never matched.
- Dropped `zod` from `optimizeDeps.include` — it isn't a dependency and isn't imported anywhere (the app uses `hobom-schema`).

## Verify
- `pnpm lint` exits 0 with `--max-warnings=0`
- app build ok (framework chunk intact)
- CI on this PR exercises the Node 22 / v5 actions