### PR TITLE
Enable noUncheckedIndexedAccess and fix the fallout

### DIFF
--- a/apps/hobom-system/src/entities/board/model/board.model.spec.ts
+++ b/apps/hobom-system/src/entities/board/model/board.model.spec.ts
@@ -34,9 +34,9 @@ describe("getStatusConfig", () => {
 describe("DEFAULT_BOARD_COLUMNS", () => {
   it("3개의 기본 컬럼이 올바른 순서로 존재한다", () => {
     expect(DEFAULT_BOARD_COLUMNS).toHaveLength(3);
-    expect(DEFAULT_BOARD_COLUMNS[0].statusId).toBe("todo");
-    expect(DEFAULT_BOARD_COLUMNS[1].statusId).toBe("in-progress");
-    expect(DEFAULT_BOARD_COLUMNS[2].statusId).toBe("done");
+    expect(DEFAULT_BOARD_COLUMNS[0]?.statusId).toBe("todo");
+    expect(DEFAULT_BOARD_COLUMNS[1]?.statusId).toBe("in-progress");
+    expect(DEFAULT_BOARD_COLUMNS[2]?.statusId).toBe("done");
   });
 
   it("order 값이 0, 1, 2 순서이다", () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.spec.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.spec.ts
@@ -29,8 +29,8 @@ describe("createTodosWithCategory", () => {
     const result = createTodosWithCategory([category], todos);
 
     expect(result).toHaveLength(1);
-    expect(result[0].categoryId).toBe("cat-1");
-    expect(result[0].todoItems).toHaveLength(2);
+    expect(result[0]?.categoryId).toBe("cat-1");
+    expect(result[0]?.todoItems).toHaveLength(2);
   });
 
   it("여러 카테고리에 각각 올바른 할일을 분류한다", () => {
@@ -55,10 +55,10 @@ describe("createTodosWithCategory", () => {
     const result = createTodosWithCategory([cat1, cat2], todos);
 
     expect(result).toHaveLength(2);
-    expect(result[0].categoryId).toBe("cat-1");
-    expect(result[0].todoItems).toHaveLength(2);
-    expect(result[1].categoryId).toBe("cat-2");
-    expect(result[1].todoItems).toHaveLength(1);
+    expect(result[0]?.categoryId).toBe("cat-1");
+    expect(result[0]?.todoItems).toHaveLength(2);
+    expect(result[1]?.categoryId).toBe("cat-2");
+    expect(result[1]?.todoItems).toHaveLength(1);
   });
 
   it("매칭되는 할일이 없으면 todoItems가 빈 배열이다", () => {
@@ -68,7 +68,7 @@ describe("createTodosWithCategory", () => {
     const result = createTodosWithCategory([category], todos);
 
     expect(result).toHaveLength(1);
-    expect(result[0].todoItems).toHaveLength(0);
+    expect(result[0]?.todoItems).toHaveLength(0);
   });
 
   it("할일 배열이 비어있으면 모든 카테고리의 todoItems가 빈 배열이다", () => {
@@ -77,7 +77,7 @@ describe("createTodosWithCategory", () => {
     const result = createTodosWithCategory(categories, []);
 
     expect(result).toHaveLength(2);
-    expect(result[0].todoItems).toHaveLength(0);
-    expect(result[1].todoItems).toHaveLength(0);
+    expect(result[0]?.todoItems).toHaveLength(0);
+    expect(result[1]?.todoItems).toHaveLength(0);
   });
 });

--- a/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
@@ -105,7 +105,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
       getQueryDataMock.mockReturnValue(previous);
       cancelQueriesMock.mockResolvedValue(undefined);
 
-      const ctx = await opts.onMutate({ status: "DONE" });
+      const ctx = await opts.onMutate?.({ status: "DONE" });
 
       expect(cancelQueriesMock).toHaveBeenCalled();
       expect(ctx).toEqual({ previousData: previous });
@@ -121,9 +121,9 @@ describe("useChangeDailyTodoCompleteStatus", () => {
         items: [makeTodo({ id: "todo-1", progress: "PROGRESS" })],
       });
 
-      await opts.onMutate({ status: "DONE" });
+      await opts.onMutate?.({ status: "DONE" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
       const updated = updater({
         items: [makeTodo({ id: "todo-1", progress: "PROGRESS" })],
       });
@@ -139,9 +139,9 @@ describe("useChangeDailyTodoCompleteStatus", () => {
       cancelQueriesMock.mockResolvedValue(undefined);
       getQueryDataMock.mockReturnValue(null);
 
-      await opts.onMutate({ status: "DONE" });
+      await opts.onMutate?.({ status: "DONE" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
 
       expect(updater(null)).toBeUndefined();
     });
@@ -154,7 +154,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
       const opts = optsOf(result.current);
       const previousData = { items: [makeTodo()] };
 
-      opts.onError(new Error("fail"), {}, { previousData });
+      opts.onError?.(new Error("fail"), {}, { previousData });
 
       expect(setQueryDataMock).toHaveBeenCalled();
       expect(openErrorToastMock).toHaveBeenCalledWith({
@@ -169,7 +169,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
       const opts = optsOf(result.current);
 
-      opts.onSuccess();
+      opts.onSuccess?.();
 
       expect(openSuccessToastMock).toHaveBeenCalledWith({
         message: "상태를 변경했어요.",
@@ -183,7 +183,7 @@ describe("useChangeDailyTodoCompleteStatus", () => {
       const { result } = renderHook(() => useChangeDailyTodoCompleteStatus(todo));
       const opts = optsOf(result.current);
 
-      await opts.onSettled();
+      await opts.onSettled?.();
 
       expect(invalidateQueriesMock).toHaveBeenCalled();
     });

--- a/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
+++ b/apps/hobom-system/src/entities/document/lib/document-tree.lib.ts
@@ -152,6 +152,10 @@ export const reorderChildren = (
     const next = nodes.slice();
     const [moved] = next.splice(from, 1);
 
+    if (moved === undefined) {
+      return next;
+    }
+
     next.splice(to, 0, moved);
 
     return next;

--- a/apps/hobom-system/src/entities/document/model/document.model.spec.ts
+++ b/apps/hobom-system/src/entities/document/model/document.model.spec.ts
@@ -34,6 +34,8 @@ describe("createSampleDocument", () => {
 
     const [root] = doc.children;
 
+    if (!root) throw new Error("expected root node");
+
     expect(isComponentNode(root) && root.type).toBe("Hb.Stack");
 
     const types: string[] = [];

--- a/apps/hobom-system/src/entities/issue/lib/issue-tree.lib.spec.ts
+++ b/apps/hobom-system/src/entities/issue/lib/issue-tree.lib.spec.ts
@@ -40,7 +40,7 @@ describe("buildIssueTree", () => {
     const { roots, childrenMap, parentMap } = buildIssueTree(issues);
 
     expect(roots).toHaveLength(1);
-    expect(roots[0].id).toBe("epic-1");
+    expect(roots[0]?.id).toBe("epic-1");
     expect(childrenMap.get("epic-1")).toHaveLength(2);
     expect(parentMap.get("task-1")?.id).toBe("epic-1");
     expect(parentMap.get("task-2")?.id).toBe("epic-1");
@@ -51,7 +51,7 @@ describe("buildIssueTree", () => {
     const { roots } = buildIssueTree(issues);
 
     expect(roots).toHaveLength(1);
-    expect(roots[0].id).toBe("1");
+    expect(roots[0]?.id).toBe("1");
   });
 
   it("빈 배열이면 빈 트리를 반환한다", () => {
@@ -101,8 +101,8 @@ describe("flattenIssueTree", () => {
     const flat = flattenIssueTree(issues, new Set(["epic"]));
 
     expect(flat).toHaveLength(1);
-    expect(flat[0].issue.id).toBe("epic");
-    expect(flat[0].childCount).toBe(2);
+    expect(flat[0]?.issue.id).toBe("epic");
+    expect(flat[0]?.childCount).toBe(2);
   });
 
   it("빈 배열이면 빈 배열을 반환한다", () => {

--- a/apps/hobom-system/src/entities/issue/model/useAssignIssue.spec.ts
+++ b/apps/hobom-system/src/entities/issue/model/useAssignIssue.spec.ts
@@ -126,7 +126,7 @@ describe("useAssignIssue", () => {
 
       await opts.onMutate({ issueId: "issue-1", assignee: "user-2" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
       const updated = updater(original);
 
       expect(updated.items[0].assignee).toBe("user-2");
@@ -143,7 +143,7 @@ describe("useAssignIssue", () => {
 
       await opts.onMutate({ issueId: "issue-1", assignee: undefined });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
       const updated = updater(original);
 
       expect(updated.items[0].assignee).toBeUndefined();
@@ -158,7 +158,7 @@ describe("useAssignIssue", () => {
 
       await opts.onMutate({ issueId: "issue-1", assignee: "user-2" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
 
       expect(updater(undefined)).toBeUndefined();
     });
@@ -177,7 +177,7 @@ describe("useAssignIssue", () => {
 
       await opts.onMutate({ issueId: "issue-1", assignee: "user-2" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
       const updated = updater(original);
 
       expect(updated.items[0].assignee).toBe("user-2");

--- a/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
+++ b/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
@@ -99,7 +99,7 @@ describe("useTransitionIssue", () => {
       getQueryDataMock.mockReturnValue(previous);
       cancelQueriesMock.mockResolvedValue(undefined);
 
-      const ctx = await opts.onMutate({
+      const ctx = await opts.onMutate?.({
         issueId: "issue-1",
         statusId: "in-progress",
       });
@@ -121,9 +121,9 @@ describe("useTransitionIssue", () => {
       getQueryDataMock.mockReturnValue(original);
       cancelQueriesMock.mockResolvedValue(undefined);
 
-      await opts.onMutate({ issueId: "issue-1", statusId: "in-progress" });
+      await opts.onMutate?.({ issueId: "issue-1", statusId: "in-progress" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
       const updated = updater(original);
 
       expect(updated.items[0].status).toBe("in-progress");
@@ -136,9 +136,9 @@ describe("useTransitionIssue", () => {
       getQueryDataMock.mockReturnValue(undefined);
       cancelQueriesMock.mockResolvedValue(undefined);
 
-      await opts.onMutate({ issueId: "issue-1", statusId: "done" });
+      await opts.onMutate?.({ issueId: "issue-1", statusId: "done" });
 
-      const updater = setQueryDataMock.mock.calls[0][1];
+      const updater = setQueryDataMock.mock.calls[0]?.[1];
 
       expect(updater(undefined)).toBeUndefined();
     });
@@ -150,7 +150,7 @@ describe("useTransitionIssue", () => {
       const opts = optsOf(result.current);
       const previous = { items: [makeIssue()] };
 
-      opts.onError(new Error("fail"), {}, { previous });
+      opts.onError?.(new Error("fail"), {}, { previous });
 
       expect(setQueryDataMock).toHaveBeenCalledWith(["issues", "list", "proj-1"], previous);
       expect(openErrorToastMock).toHaveBeenCalledWith({
@@ -162,7 +162,7 @@ describe("useTransitionIssue", () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
       const opts = optsOf(result.current);
 
-      opts.onError(new Error("fail"), {}, undefined);
+      opts.onError?.(new Error("fail"), {}, undefined);
 
       expect(setQueryDataMock).not.toHaveBeenCalled();
       expect(openErrorToastMock).toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe("useTransitionIssue", () => {
       const { result } = renderHook(() => useTransitionIssue("proj-1"));
       const opts = optsOf(result.current);
 
-      await opts.onSettled();
+      await opts.onSettled?.();
 
       expect(invalidateQueriesMock).toHaveBeenCalledWith({
         queryKey: ["issues"],

--- a/apps/hobom-system/src/entities/log/api/log.api.spec.ts
+++ b/apps/hobom-system/src/entities/log/api/log.api.spec.ts
@@ -28,7 +28,7 @@ describe("fetchLogSearch", () => {
 
     fetchLogSearch(params);
 
-    const url = mockGet.mock.calls[0][0] as string;
+    const url = mockGet.mock.calls[0]?.[0] as string;
 
     expect(url).toContain("serviceType=HOBOM_BACKEND");
     expect(url).toContain("httpMethod=GET");
@@ -44,7 +44,7 @@ describe("fetchLogSearch", () => {
 
     fetchLogSearch(params);
 
-    const url = mockGet.mock.calls[0][0] as string;
+    const url = mockGet.mock.calls[0]?.[0] as string;
 
     expect(url).not.toContain("serviceType");
     expect(url).not.toContain("httpMethod");
@@ -63,7 +63,7 @@ describe("fetchLogSearch", () => {
 
     fetchLogSearch(params);
 
-    const url = mockGet.mock.calls[0][0] as string;
+    const url = mockGet.mock.calls[0]?.[0] as string;
 
     expect(url).not.toContain("serviceType");
     expect(url).not.toContain("httpMethod");
@@ -72,7 +72,7 @@ describe("fetchLogSearch", () => {
   it("uses /logs base path", () => {
     fetchLogSearch({ page: 0, size: 10 });
 
-    const url = mockGet.mock.calls[0][0] as string;
+    const url = mockGet.mock.calls[0]?.[0] as string;
 
     expect(url).toMatch(/^\/logs\?/);
   });

--- a/apps/hobom-system/src/entities/notification/lib/group-notifications-by-date.lib.spec.ts
+++ b/apps/hobom-system/src/entities/notification/lib/group-notifications-by-date.lib.spec.ts
@@ -21,8 +21,8 @@ describe("groupNotificationsByDate", () => {
     const groups = groupNotificationsByDate(items, NOW);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe("오늘");
-    expect(groups[0].items).toHaveLength(1);
+    expect(groups[0]?.label).toBe("오늘");
+    expect(groups[0]?.items).toHaveLength(1);
   });
 
   it("어제 알림을 '어제' 그룹에 분류한다", () => {
@@ -30,7 +30,7 @@ describe("groupNotificationsByDate", () => {
     const groups = groupNotificationsByDate(items, NOW);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe("어제");
+    expect(groups[0]?.label).toBe("어제");
   });
 
   it("2~7일 전 알림을 '이번 주' 그룹에 분류한다", () => {
@@ -38,7 +38,7 @@ describe("groupNotificationsByDate", () => {
     const groups = groupNotificationsByDate(items, NOW);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe("이번 주");
+    expect(groups[0]?.label).toBe("이번 주");
   });
 
   it("7일 이상 전 알림을 '이전' 그룹에 분류한다", () => {
@@ -46,7 +46,7 @@ describe("groupNotificationsByDate", () => {
     const groups = groupNotificationsByDate(items, NOW);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe("이전");
+    expect(groups[0]?.label).toBe("이전");
   });
 
   it("빈 배열은 빈 결과를 반환한다", () => {
@@ -87,6 +87,6 @@ describe("groupNotificationsByDate", () => {
     const groups = groupNotificationsByDate(items, NOW);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].items).toHaveLength(3);
+    expect(groups[0]?.items).toHaveLength(3);
   });
 });

--- a/apps/hobom-system/src/entities/notification/lib/group-notifications-by-date.lib.ts
+++ b/apps/hobom-system/src/entities/notification/lib/group-notifications-by-date.lib.ts
@@ -41,6 +41,6 @@ export const groupNotificationsByDate = (
   return Bom.pipe(
     [...DATE_LABELS],
     Bom.filter((label) => (grouped[label]?.length ?? 0) > 0),
-    Bom.map((label) => ({ label, items: grouped[label] })),
+    Bom.map((label) => ({ label, items: grouped[label] ?? [] })),
   );
 };

--- a/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
+++ b/apps/hobom-system/src/entities/project-label/ui/ProjectLabelPicker.tsx
@@ -39,7 +39,7 @@ export const ProjectLabelPicker = ({
 
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
-  const [newColor, setNewColor] = useState(LABEL_COLORS[5]);
+  const [newColor, setNewColor] = useState(LABEL_COLORS[5] ?? "#3b82f6");
 
   const handleCreate = () => {
     const trimmed = newName.trim();

--- a/apps/hobom-system/src/entities/project/lib/workflow.lib.spec.ts
+++ b/apps/hobom-system/src/entities/project/lib/workflow.lib.spec.ts
@@ -46,14 +46,14 @@ describe("buildStatusesFromColumns", () => {
 
     const result = buildStatusesFromColumns(columns);
 
-    expect(result[0].isDone).toBe(false);
-    expect(result[1].isDone).toBe(true);
+    expect(result[0]?.isDone).toBe(false);
+    expect(result[1]?.isDone).toBe(true);
   });
 
   it("단일 컬럼이면 isDone이 true다", () => {
     const result = buildStatusesFromColumns([{ statusId: "only", name: "Only", order: 0 }]);
 
-    expect(result[0].isDone).toBe(true);
+    expect(result[0]?.isDone).toBe(true);
   });
 
   it("빈 배열이면 빈 배열을 반환한다", () => {

--- a/apps/hobom-system/src/features/backlog-board/lib/backlog-group.lib.spec.ts
+++ b/apps/hobom-system/src/features/backlog-board/lib/backlog-group.lib.spec.ts
@@ -22,8 +22,8 @@ describe("groupIssuesBySprint", () => {
 
     const result = groupIssuesBySprint(issues, sprints);
 
-    expect(result.sprintGroups[0].issues).toHaveLength(2);
-    expect(result.sprintGroups[1].issues).toHaveLength(1);
+    expect(result.sprintGroups[0]?.issues).toHaveLength(2);
+    expect(result.sprintGroups[1]?.issues).toHaveLength(1);
     expect(result.backlogIssues).toHaveLength(0);
   });
 
@@ -34,7 +34,7 @@ describe("groupIssuesBySprint", () => {
     const result = groupIssuesBySprint(issues, sprints);
 
     expect(result.backlogIssues).toHaveLength(1);
-    expect(result.backlogIssues[0].id).toBe("i1");
+    expect(result.backlogIssues[0]?.id).toBe("i1");
   });
 
   it("존재하지 않는 스프린트를 참조하는 이슈는 백로그로 분류한다", () => {
@@ -44,7 +44,7 @@ describe("groupIssuesBySprint", () => {
     const result = groupIssuesBySprint(issues, sprints);
 
     expect(result.backlogIssues).toHaveLength(1);
-    expect(result.sprintGroups[0].issues).toHaveLength(0);
+    expect(result.sprintGroups[0]?.issues).toHaveLength(0);
   });
 
   it("이슈와 스프린트가 모두 비어있으면 빈 결과를 반환한다", () => {
@@ -60,8 +60,8 @@ describe("groupIssuesBySprint", () => {
 
     const result = groupIssuesBySprint(issues, sprints);
 
-    expect(result.sprintGroups[0].sprint.id).toBe("s2");
-    expect(result.sprintGroups[1].sprint.id).toBe("s1");
-    expect(result.sprintGroups[1].issues).toHaveLength(1);
+    expect(result.sprintGroups[0]?.sprint.id).toBe("s2");
+    expect(result.sprintGroups[1]?.sprint.id).toBe("s1");
+    expect(result.sprintGroups[1]?.issues).toHaveLength(1);
   });
 });

--- a/apps/hobom-system/src/features/backlog-board/model/useCollapsibleTree.spec.ts
+++ b/apps/hobom-system/src/features/backlog-board/model/useCollapsibleTree.spec.ts
@@ -106,7 +106,7 @@ describe("useCollapsibleTree", () => {
 
       const lastCall = flattenIssueTreeMock.mock.calls[flattenIssueTreeMock.mock.calls.length - 1];
 
-      expect(lastCall[1].has("root")).toBe(true);
+      expect(lastCall?.[1].has("root")).toBe(true);
     });
   });
 });

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorHeaderCell.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorHeaderCell.tsx
@@ -9,6 +9,8 @@ interface EndpointErrorHeaderCellProps {
 
 export const EndpointErrorHeaderCell = ({ cell, colResize }: EndpointErrorHeaderCellProps) => {
   const col = COLUMNS[cell.colIndex];
+
+  if (!col) return null;
   const isRight = col.key === "total" || col.key === "errors";
 
   return (

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorTable.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorTable.tsx
@@ -47,7 +47,7 @@ export const EndpointErrorTable = ({ data }: EndpointErrorTableProps) => {
     const widths: Record<number, number> = {};
 
     COLUMNS.forEach((_, i) => {
-      widths[i] = Math.floor(containerWidth * COL_WIDTH_RATIOS[i]);
+      widths[i] = Math.floor(containerWidth * (COL_WIDTH_RATIOS[i] ?? 0));
     });
 
     return widths;
@@ -63,11 +63,12 @@ export const EndpointErrorTable = ({ data }: EndpointErrorTableProps) => {
       }
       const bodyIndex = cell.rowIndex - HEADER_ROW_COUNT;
       const row = rowModel.getRow(bodyIndex);
+      const col = COLUMNS[cell.colIndex];
 
-      if (!row) return null;
+      if (!row || !col) return null;
       const bg = bodyIndex % 2 === 0 ? ROW_EVEN : ROW_ODD;
 
-      return <EndpointErrorBodyCell colKey={COLUMNS[cell.colIndex].key} row={row} bg={bg} />;
+      return <EndpointErrorBodyCell colKey={col.key} row={row} bg={bg} />;
     },
     [rowModel, colResize],
   );

--- a/apps/hobom-system/src/features/dashboard-log/ui/RequestVolumeChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/RequestVolumeChart.tsx
@@ -18,7 +18,7 @@ interface ChartTooltipProps {
 
 const CustomTooltip = ({ active, payload, label }: ChartTooltipProps) => {
   if (!active || !payload?.length) return null;
-  const value = payload[0].value ?? 0;
+  const value = payload[0]?.value ?? 0;
 
   return (
     <div

--- a/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
@@ -19,7 +19,9 @@ interface ChartTooltipProps {
 
 const CustomTooltip = ({ active, payload }: ChartTooltipProps) => {
   if (!active || !payload?.length) return null;
-  const item = payload[0].payload;
+  const item = payload[0]?.payload;
+
+  if (!item) return null;
   const color = getStatusColor(item.statusCode);
 
   return (

--- a/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
@@ -24,6 +24,9 @@ export const HeaderCell = ({
   colResize,
 }: HeaderCellProps) => {
   const col = COLUMNS[cell.colIndex];
+
+  if (!col) return null;
+
   const isSorted = sortKey === col.key;
 
   const renderSortIcon = () => {

--- a/apps/hobom-system/src/features/issue-list-table/ui/IssueGrid.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/IssueGrid.tsx
@@ -53,7 +53,10 @@ export const IssueGrid = ({
 
     if (!el) return;
     const observer = new ResizeObserver((entries) => {
-      setContainerWidth(entries[0].contentRect.width);
+      const entry = entries[0];
+
+      if (!entry) return;
+      setContainerWidth(entry.contentRect.width);
     });
 
     observer.observe(el);
@@ -74,7 +77,7 @@ export const IssueGrid = ({
     const widths: Record<number, number> = {};
 
     COLUMNS.forEach((_, i) => {
-      widths[i] = Math.floor(containerWidth * COL_WIDTH_RATIOS[i]);
+      widths[i] = Math.floor(containerWidth * (COL_WIDTH_RATIOS[i] ?? 0));
     });
 
     return widths;
@@ -104,7 +107,11 @@ export const IssueGrid = ({
 
       if (!row) return null;
 
-      const colKey = COLUMNS[cell.colIndex].key;
+      const col = COLUMNS[cell.colIndex];
+
+      if (!col) return null;
+
+      const colKey = col.key;
       const bg = bodyIndex % 2 === 0 ? ROW_EVEN : ROW_ODD;
 
       return (

--- a/apps/hobom-system/src/features/kanban-board/lib/kanban-filter.lib.spec.ts
+++ b/apps/hobom-system/src/features/kanban-board/lib/kanban-filter.lib.spec.ts
@@ -31,7 +31,7 @@ describe("filterColumnsByEpic", () => {
     const result = filterColumnsByEpic(columns, "epic1", parentMap);
 
     expect(result.TODO).toHaveLength(2);
-    expect(result.TODO.map((i) => i.id)).toEqual(["epic1", "child1"]);
+    expect(result.TODO?.map((i) => i.id)).toEqual(["epic1", "child1"]);
   });
 
   it("매칭되는 이슈가 없으면 빈 배열을 반환한다", () => {
@@ -63,8 +63,8 @@ describe("buildSwimlaneGroups", () => {
     const result = buildSwimlaneGroups([epic, task], issueTree, new Set<string>());
 
     expect(result).toHaveLength(1);
-    expect(result[0].epicId).toBe("epic1");
-    expect(result[0].epicTitle).toBe("My Epic");
+    expect(result[0]?.epicId).toBe("epic1");
+    expect(result[0]?.epicTitle).toBe("My Epic");
   });
 
   it("에픽이 없는 이슈는 '에픽 없음' 그룹으로 분류한다", () => {
@@ -79,8 +79,8 @@ describe("buildSwimlaneGroups", () => {
     const result = buildSwimlaneGroups([task], issueTree, new Set<string>());
 
     expect(result).toHaveLength(1);
-    expect(result[0].epicId).toBeNull();
-    expect(result[0].epicTitle).toBe("에픽 없음");
+    expect(result[0]?.epicId).toBeNull();
+    expect(result[0]?.epicTitle).toBe("에픽 없음");
   });
 
   it("에픽 없음 그룹은 항상 마지막에 정렬된다", () => {
@@ -99,7 +99,7 @@ describe("buildSwimlaneGroups", () => {
 
     const result = buildSwimlaneGroups([orphan, epic], issueTree, new Set<string>());
 
-    expect(result[result.length - 1].epicId).toBeNull();
+    expect(result[result.length - 1]?.epicId).toBeNull();
   });
 
   it("이슈가 없으면 빈 배열을 반환한다", () => {

--- a/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.spec.ts
+++ b/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.spec.ts
@@ -9,6 +9,8 @@ vi.mock("@/shared/ui", () => ({
     const next = arr.slice();
     const [item] = next.splice(from, 1);
 
+    if (item === undefined) return next;
+
     next.splice(to, 0, item);
 
     return next;
@@ -117,8 +119,8 @@ describe("useKanbanDnd", () => {
         } as never);
       });
 
-      expect(result.current.columns["todo"].length).toBe(1);
-      expect(result.current.columns["in-progress"].some((i) => i.id === "i1")).toBe(true);
+      expect(result.current.columns["todo"]?.length).toBe(1);
+      expect(result.current.columns["in-progress"]?.some((i) => i.id === "i1")).toBe(true);
     });
 
     it("over가 없으면 아무것도 하지 않는다", () => {
@@ -139,7 +141,7 @@ describe("useKanbanDnd", () => {
         } as never);
       });
 
-      expect(result.current.columns["todo"].length).toBe(before["todo"].length);
+      expect(result.current.columns["todo"]?.length).toBe(before["todo"]?.length);
     });
   });
 
@@ -212,7 +214,7 @@ describe("useKanbanDnd", () => {
         } as never);
       });
 
-      expect(result.current.columns["todo"].length).toBe(2);
+      expect(result.current.columns["todo"]?.length).toBe(2);
       expect(result.current.activeIssue).toBeNull();
     });
   });
@@ -241,7 +243,7 @@ describe("useKanbanDnd", () => {
       });
 
       expect(result.current.activeIssue).toBeNull();
-      expect(result.current.columns["todo"].length).toBe(2);
+      expect(result.current.columns["todo"]?.length).toBe(2);
     });
   });
 });

--- a/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.ts
+++ b/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.ts
@@ -75,6 +75,9 @@ export const useKanbanDnd = ({
         if (fromIdx === -1) return prev;
 
         const [item] = fromItems.splice(fromIdx, 1);
+
+        if (!item) return prev;
+
         const overItemIdx = toItems.findIndex((i) => i.id === oId);
         const insertIdx = overItemIdx >= 0 ? overItemIdx : toItems.length;
 

--- a/apps/hobom-system/src/features/note/model/useNoteGrid.spec.ts
+++ b/apps/hobom-system/src/features/note/model/useNoteGrid.spec.ts
@@ -8,7 +8,7 @@ vi.mock("@/shared/ui", () => ({
     const next = arr.slice();
     const [item] = next.splice(from, 1);
 
-    next.splice(to, 0, item);
+    if (item !== undefined) next.splice(to, 0, item);
 
     return next;
   },

--- a/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
   const [tab, setTab] = useState(0);
-  const filter = TAB_FILTERS[tab];
+  const filter = TAB_FILTERS[tab] ?? "all";
 
   const { notifications, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
     useNotificationList(filter);

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageGrid.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageGrid.tsx
@@ -107,10 +107,13 @@ const GridInner = ({
 
         const bodyIndex = cell.rowIndex - HEADER_ROW_COUNT;
         const row = rowModel.getRow(bodyIndex);
+        const col = COLUMNS[cell.colIndex];
+
+        if (!row || !col) return null;
 
         return (
           <GridBodyCell
-            colKey={COLUMNS[cell.colIndex].key}
+            colKey={col.key}
             row={row}
             bodyIndex={bodyIndex}
             onEdit={onEdit}

--- a/apps/hobom-system/src/features/send-future-message/ui/GridHeaderCell.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/GridHeaderCell.tsx
@@ -8,6 +8,8 @@ interface Props {
 export const GridHeaderCell = ({ colIndex, onStartResize }: Props) => {
   const col = COLUMNS[colIndex];
 
+  if (!col) return null;
+
   return (
     <div
       style={{

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/CreateLabelDialog.tsx
@@ -45,7 +45,7 @@ export const CreateLabelDialog = ({
   onSubmit,
   loading = false,
   initialName = "",
-  initialColor = LABEL_COLORS[0].hex,
+  initialColor = LABEL_COLORS[0]?.hex ?? "#4680ff",
   title = "라벨 생성",
 }: CreateLabelDialogProps) => {
   const [name, setName] = useState(initialName);

--- a/apps/hobom-system/src/features/wiki-page-comments/lib/build-comment-tree.lib.spec.ts
+++ b/apps/hobom-system/src/features/wiki-page-comments/lib/build-comment-tree.lib.spec.ts
@@ -25,9 +25,9 @@ describe("buildCommentTree", () => {
     const tree = buildCommentTree(comments);
 
     expect(tree).toHaveLength(2);
-    expect(tree[0].id).toBe("1");
-    expect(tree[1].id).toBe("2");
-    expect(tree[0].children).toEqual([]);
+    expect(tree[0]?.id).toBe("1");
+    expect(tree[1]?.id).toBe("2");
+    expect(tree[0]?.children).toEqual([]);
   });
 
   it("nests child comments under parent", () => {
@@ -40,9 +40,9 @@ describe("buildCommentTree", () => {
     const tree = buildCommentTree(comments);
 
     expect(tree).toHaveLength(1);
-    expect(tree[0].children).toHaveLength(2);
-    expect(tree[0].children[0].id).toBe("2");
-    expect(tree[0].children[1].id).toBe("3");
+    expect(tree[0]?.children).toHaveLength(2);
+    expect(tree[0]?.children[0]?.id).toBe("2");
+    expect(tree[0]?.children[1]?.id).toBe("3");
   });
 
   it("supports multi-level nesting", () => {
@@ -55,7 +55,7 @@ describe("buildCommentTree", () => {
     const tree = buildCommentTree(comments);
 
     expect(tree).toHaveLength(1);
-    expect(tree[0].children[0].children[0].id).toBe("3");
+    expect(tree[0]?.children[0]?.children[0]?.id).toBe("3");
   });
 
   it("treats orphan comments (missing parent) as roots", () => {
@@ -67,8 +67,8 @@ describe("buildCommentTree", () => {
     const tree = buildCommentTree(comments);
 
     expect(tree).toHaveLength(2);
-    expect(tree[0].id).toBe("1");
-    expect(tree[1].id).toBe("2");
+    expect(tree[0]?.id).toBe("1");
+    expect(tree[1]?.id).toBe("2");
   });
 
   it("preserves comment data in tree nodes", () => {
@@ -76,8 +76,8 @@ describe("buildCommentTree", () => {
 
     const tree = buildCommentTree(comments);
 
-    expect(tree[0].content).toBe("hello");
-    expect(tree[0].author).toBe("Alice");
-    expect(tree[0].children).toEqual([]);
+    expect(tree[0]?.content).toBe("hello");
+    expect(tree[0]?.author).toBe("Alice");
+    expect(tree[0]?.children).toEqual([]);
   });
 });

--- a/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
+++ b/apps/hobom-system/src/features/workspace/lib/workspace-ops.lib.spec.ts
@@ -51,11 +51,11 @@ describe("workspace-ops", () => {
   });
 
   it("renameFolder는 폴더 이름을 바꾼다", () => {
-    expect(renameFolder(doc(), "f1", "기획").folders[0].name).toBe("기획");
+    expect(renameFolder(doc(), "f1", "기획").folders[0]?.name).toBe("기획");
   });
 
   it("renameItem은 아이템 이름을 바꾼다", () => {
-    expect(renameItem(doc(), "i1", "메인 폼").items[0].name).toBe("메인 폼");
+    expect(renameItem(doc(), "i1", "메인 폼").items[0]?.name).toBe("메인 폼");
   });
 
   it("removeDesign은 아이템과 문서를 제거한다", () => {
@@ -83,7 +83,7 @@ describe("workspace-ops", () => {
   it("renameFavorite은 라벨을 바꾼다", () => {
     const withFav = addFavorite(doc(), { id: "fav1", designId: "i1", label: "샘플" });
 
-    expect(renameFavorite(withFav, "fav1", "즐겨").favorites[0].label).toBe("즐겨");
+    expect(renameFavorite(withFav, "fav1", "즐겨").favorites[0]?.label).toBe("즐겨");
   });
 
   it("디자인 삭제 시 그 즐겨찾기도 제거된다", () => {

--- a/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
@@ -53,7 +53,11 @@ const PrivacyLawLayoutPage = () => {
       </Hb.Stack>
       <Hb.Tabs.Root
         value={currentTab === -1 ? 0 : currentTab}
-        onChange={(_, idx) => navigate(TABS[idx].path)}
+        onChange={(_, idx) => {
+          const target = TABS[idx];
+
+          if (target) navigate(target.path);
+        }}
         style={{
           borderBottom: 1,
           borderColor: "var(--hb-color-border)",

--- a/apps/hobom-system/src/shared/api/auth.middleware.spec.ts
+++ b/apps/hobom-system/src/shared/api/auth.middleware.spec.ts
@@ -67,9 +67,9 @@ describe("authMiddleware.onResponse", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
     // 첫 번째 호출: refresh
-    expect(mockFetch.mock.calls[0][0]).toContain("/auth/refresh");
+    expect(mockFetch.mock.calls[0]?.[0]).toContain("/auth/refresh");
     // 두 번째 호출: 원래 요청 retry
-    expect(mockFetch.mock.calls[1][0]).toBe("https://api.test/some-path");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://api.test/some-path");
     expect(ctx.response?.status).toBe(200);
   });
 
@@ -132,7 +132,7 @@ describe("authMiddleware.onResponse", () => {
 
     // refresh 1번 + retry 2번 = 3번
     expect(mockFetch).toHaveBeenCalledTimes(3);
-    expect(mockFetch.mock.calls[0][0]).toContain("/auth/refresh");
+    expect(mockFetch.mock.calls[0]?.[0]).toContain("/auth/refresh");
   });
 
   it("retry 요청에 CSRF 헤더를 재적용한다", async () => {
@@ -144,7 +144,7 @@ describe("authMiddleware.onResponse", () => {
 
     await onResponse(ctx);
 
-    const retryInit = mockFetch.mock.calls[1][1] as RequestInit;
+    const retryInit = mockFetch.mock.calls[1]?.[1] as RequestInit;
     const headers = retryInit.headers as Record<string, string>;
 
     expect(headers["X-XSRF-TOKEN"]).toBe("mock-csrf");

--- a/apps/hobom-system/src/shared/api/csrf.middleware.ts
+++ b/apps/hobom-system/src/shared/api/csrf.middleware.ts
@@ -8,7 +8,7 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const getCsrfToken = (): string | null => {
   const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${CSRF_COOKIE}=([^;]*)`));
 
-  return match ? decodeURIComponent(match[1]) : null;
+  return match?.[1] != null ? decodeURIComponent(match[1]) : null;
 };
 
 export const applyCsrfHeader = (headers: Record<string, string>): Record<string, string> => {

--- a/apps/hobom-system/src/shared/api/http-client.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/http-client.api.spec.ts
@@ -32,7 +32,7 @@ describe("createHttpClient", () => {
 
     expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledOnce();
-    const [url, init] = mockFetch.mock.calls[0];
+    const [url, init] = mockFetch.mock.calls[0] ?? [];
 
     expect(url).toBe("https://api.test/users");
     expect(init.method).toBe("GET");
@@ -44,7 +44,7 @@ describe("createHttpClient", () => {
 
     await client.post("/users", { name: "test" });
 
-    const [, init] = mockFetch.mock.calls[0];
+    const [, init] = mockFetch.mock.calls[0] ?? [];
 
     expect(init.method).toBe("POST");
     expect(init.body).toBe(JSON.stringify({ name: "test" }));
@@ -154,8 +154,8 @@ describe("createHttpClient", () => {
     await client.get("/test");
 
     expect(onRequest).toHaveBeenCalledOnce();
-    expect(onRequest.mock.calls[0][0]).toHaveProperty("input");
-    expect(onRequest.mock.calls[0][0]).toHaveProperty("init");
+    expect(onRequest.mock.calls[0]?.[0]).toHaveProperty("input");
+    expect(onRequest.mock.calls[0]?.[0]).toHaveProperty("init");
   });
 
   it("미들웨어 onResponse가 응답 후에 호출된다", async () => {
@@ -168,6 +168,6 @@ describe("createHttpClient", () => {
     await client.get("/test");
 
     expect(onResponse).toHaveBeenCalledOnce();
-    expect(onResponse.mock.calls[0][0]).toHaveProperty("response");
+    expect(onResponse.mock.calls[0]?.[0]).toHaveProperty("response");
   });
 });

--- a/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
+++ b/apps/hobom-system/src/shared/api/parse-response.api.spec.ts
@@ -32,7 +32,7 @@ describe("parseResponse", () => {
     expect(parseResponse(itemSchema, "GET /items")(wrong)).toBe(wrong);
 
     expect(reportError).toHaveBeenCalledOnce();
-    expect(reportError.mock.calls[0][0].message).toMatch(
+    expect(reportError.mock.calls[0]?.[0].message).toMatch(
       /Response validation mismatch \(GET \/items\)/,
     );
   });

--- a/apps/hobom-system/src/shared/model/useContainerWidth.ts
+++ b/apps/hobom-system/src/shared/model/useContainerWidth.ts
@@ -8,8 +8,8 @@ export const useContainerWidth = () => {
     const el = ref.current;
 
     if (!el) return;
-    const observer = new ResizeObserver((entries) => {
-      setWidth(entries[0].contentRect.width);
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry) setWidth(entry.contentRect.width);
     });
 
     observer.observe(el);

--- a/apps/hobom-system/src/shared/model/useFunnel.tsx
+++ b/apps/hobom-system/src/shared/model/useFunnel.tsx
@@ -80,10 +80,11 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
 
           const currentStep = qsValue ?? options?.initialStep;
 
-          assertCondition(
-            currentStep != null,
-            `Cannot expression current step. Please check the current step value ${currentStep} again !`,
-          );
+          if (currentStep == null) {
+            throw new Error(
+              `Assertion failed: Cannot expression current step. Please check the current step value ${currentStep} again !`,
+            );
+          }
 
           return <Funnel<Steps> steps={steps} step={currentStep} {...props} />;
         },

--- a/apps/hobom-system/src/shared/model/useVirtualList.ts
+++ b/apps/hobom-system/src/shared/model/useVirtualList.ts
@@ -35,7 +35,7 @@ export const useVirtualList = <T>({ items, itemHeight, overscan = 5 }: UseVirtua
     if (!el) return;
 
     const observer = new ResizeObserver(([entry]) => {
-      setContainerHeight(entry.contentRect.height);
+      if (entry) setContainerHeight(entry.contentRect.height);
     });
 
     observer.observe(el);
@@ -72,8 +72,11 @@ export const useVirtualList = <T>({ items, itemHeight, overscan = 5 }: UseVirtua
     const result: VirtualItem<T>[] = [];
 
     for (let i = startIndex; i <= endIndex; i++) {
+      const item = items[i];
+
+      if (item === undefined) continue;
       result.push({
-        item: items[i],
+        item,
         index: i,
         offsetTop: i * itemHeight,
       });

--- a/apps/hobom-system/src/test/integration/useAssignIssue.integration.spec.ts
+++ b/apps/hobom-system/src/test/integration/useAssignIssue.integration.spec.ts
@@ -101,7 +101,7 @@ describe("useAssignIssue (integration)", () => {
         PROJECT_ID,
       ]);
 
-      expect(cached?.items[0].assignee).toBeUndefined();
+      expect(cached?.items[0]?.assignee).toBeUndefined();
     });
   });
 
@@ -137,7 +137,7 @@ describe("useAssignIssue (integration)", () => {
       PROJECT_ID,
     ]);
 
-    expect(cached?.items[0].assignee).toBe("user-1");
+    expect(cached?.items[0]?.assignee).toBe("user-1");
   });
 
   it("네트워크 에러 시 캐시를 롤백하고 에러 토스트를 표시한다", async () => {
@@ -172,6 +172,6 @@ describe("useAssignIssue (integration)", () => {
       PROJECT_ID,
     ]);
 
-    expect(cached?.items[0].assignee).toBe("user-1");
+    expect(cached?.items[0]?.assignee).toBe("user-1");
   });
 });

--- a/apps/hobom-system/src/test/integration/useTransitionIssue.integration.spec.ts
+++ b/apps/hobom-system/src/test/integration/useTransitionIssue.integration.spec.ts
@@ -135,7 +135,7 @@ describe("useTransitionIssue (integration)", () => {
       PROJECT_ID,
     ]);
 
-    expect(cached?.items[0].status).toBe("todo");
+    expect(cached?.items[0]?.status).toBe("todo");
   });
 
   it("네트워크 에러 시 캐시를 롤백하고 에러 토스트를 표시한다", async () => {
@@ -170,6 +170,6 @@ describe("useTransitionIssue (integration)", () => {
       PROJECT_ID,
     ]);
 
-    expect(cached?.items[0].status).toBe("todo");
+    expect(cached?.items[0]?.status).toBe("todo");
   });
 });

--- a/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
+++ b/apps/hobom-system/src/widgets/code-panel/lib/generate-jsx.lib.ts
@@ -85,7 +85,7 @@ const serializeNode = (node: DocumentNode, indent: string): string => {
 
   const [onlyChild] = node.children;
 
-  if (node.children.length === 1 && isTextNode(onlyChild)) {
+  if (node.children.length === 1 && onlyChild && isTextNode(onlyChild)) {
     return `${indent}<${tag}${attrString}>${onlyChild.value}</${tag}>`;
   }
 
@@ -106,7 +106,7 @@ const collectImports = (doc: StudioDocument): string[] => {
     const manifest = getManifest(node.type);
 
     if (manifest) {
-      const binding = manifest.import.access.split(".")[0];
+      const binding = manifest.import.access.split(".")[0] ?? manifest.import.access;
       const bindings = bindingsBySource.get(manifest.import.source) ?? new Set<string>();
 
       bindings.add(binding);

--- a/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
+++ b/apps/hobom-system/src/widgets/notification-center/ui/NotificationCenter.tsx
@@ -74,7 +74,7 @@ export const NotificationCenter = () => {
               fontSize: "0.875rem",
             }}
           >
-            {EMPTY_MESSAGES[filter]}
+            {filter ? EMPTY_MESSAGES[filter] : null}
           </Hb.Text>
         </Hb.Box>
       );

--- a/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.spec.ts
+++ b/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.spec.ts
@@ -125,7 +125,7 @@ describe("useProjectLayout", () => {
     const { result } = renderHook(() => useProjectLayout());
 
     expect(result.current.projectCtx.statuses.length).toBe(2);
-    expect(result.current.projectCtx.statuses[0].id).toBe("todo");
+    expect(result.current.projectCtx.statuses[0]?.id).toBe("todo");
   });
 
   it("board, backlog, issues 탭에서 showIssueButton이 true이다", () => {

--- a/packages/hobom-data/src/react/infinite-query-observer.ts
+++ b/packages/hobom-data/src/react/infinite-query-observer.ts
@@ -97,6 +97,9 @@ export class InfiniteQueryObserver<TData = unknown, TPageParam = unknown> extend
     if (!currentData) return;
 
     const lastPage = currentData.pages[currentData.pages.length - 1];
+
+    if (lastPage === undefined) return;
+
     const nextPageParam = this.options.getNextPageParam(lastPage, currentData.pages);
 
     if (nextPageParam === undefined) return;

--- a/packages/hobom-data/src/react/integration.spec.tsx
+++ b/packages/hobom-data/src/react/integration.spec.tsx
@@ -189,8 +189,8 @@ describe("useSuspenseQueries", () => {
 
     await waitFor(() => {
       expect(result.current).toHaveLength(2);
-      expect(result.current[0].data).toBe("data-1");
-      expect(result.current[1].data).toBe("data-2");
+      expect(result.current[0]?.data).toBe("data-1");
+      expect(result.current[1]?.data).toBe("data-2");
     });
   });
 });
@@ -220,16 +220,16 @@ describe("useSuspenseQueries dynamic", () => {
 
     await waitFor(() => {
       expect(result.current).toHaveLength(2);
-      expect(result.current[0].data).toBe("data-1");
-      expect(result.current[1].data).toBe("data-2");
+      expect(result.current[0]?.data).toBe("data-1");
+      expect(result.current[1]?.data).toBe("data-2");
     });
 
     rerender({ ids: ["1", "3"] });
 
     await waitFor(() => {
       expect(result.current).toHaveLength(2);
-      expect(result.current[0].data).toBe("data-1");
-      expect(result.current[1].data).toBe("data-3");
+      expect(result.current[0]?.data).toBe("data-1");
+      expect(result.current[1]?.data).toBe("data-3");
     });
   });
 });

--- a/packages/hobom-design-system/src/components/Dialog/Dialog.tsx
+++ b/packages/hobom-design-system/src/components/Dialog/Dialog.tsx
@@ -140,10 +140,10 @@ const Root = ({ open, onClose, size = "sm", className, style, children }: RootPr
 
     if (event.shiftKey && document.activeElement === first) {
       event.preventDefault();
-      last.focus();
+      last?.focus();
     } else if (!event.shiftKey && document.activeElement === last) {
       event.preventDefault();
-      first.focus();
+      first?.focus();
     }
   };
 

--- a/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.ts
+++ b/packages/hobom-design-system/src/components/Pagination/pagination-range.lib.ts
@@ -43,9 +43,10 @@ export const paginationRange = ({
     Math.min(page - siblingCount, count - boundaryCount - siblingCount * 2 - 1),
     boundaryCount + 2,
   );
+  const firstEndPage = endPages[0];
   const siblingsEnd = Math.min(
     Math.max(page + siblingCount, boundaryCount + siblingCount * 2 + 2),
-    endPages.length > 0 ? endPages[0] - 2 : count - 1,
+    firstEndPage !== undefined ? firstEndPage - 2 : count - 1,
   );
 
   const startGap = gapMarker(

--- a/packages/hobom-design-system/src/patterns/Sortable/Sortable.tsx
+++ b/packages/hobom-design-system/src/patterns/Sortable/Sortable.tsx
@@ -25,6 +25,8 @@ export function arrayMove<T>(array: T[], from: number, to: number): T[] {
   const next = array.slice();
   const [item] = next.splice(from, 1);
 
+  if (item === undefined) return next;
+
   next.splice(to, 0, item);
 
   return next;

--- a/packages/hobom-schema/src/schema.spec.ts
+++ b/packages/hobom-schema/src/schema.spec.ts
@@ -30,7 +30,7 @@ describe("string", () => {
     expect(result.success).toBe(false);
 
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe("required");
+      expect(result.error.issues[0]?.message).toBe("required");
     }
   });
 
@@ -48,7 +48,7 @@ describe("string", () => {
     expect(result.success).toBe(false);
 
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe("too long");
+      expect(result.error.issues[0]?.message).toBe("too long");
     }
   });
 
@@ -263,7 +263,7 @@ describe("array", () => {
     expect(result.success).toBe(false);
 
     if (!result.success) {
-      expect(result.error.issues[0].message).toContain("[0]");
+      expect(result.error.issues[0]?.message).toContain("[0]");
     }
   });
 });
@@ -353,7 +353,7 @@ describe("parse (throwing)", () => {
       const err = e as InstanceType<typeof SchemaError>;
 
       expect(err.issues.length).toBeGreaterThanOrEqual(2);
-      expect(err.issues[0].message).toContain("name");
+      expect(err.issues[0]?.message).toContain("name");
     }
   });
 });

--- a/packages/hobom-schema/src/schemas/object-schema.ts
+++ b/packages/hobom-schema/src/schemas/object-schema.ts
@@ -25,8 +25,8 @@ export class ObjectSchema<T extends Record<string, Schema<any>>> extends Schema<
     const result = Object.create(null) as Record<string, unknown>;
     const issues: ValidationIssue[] = [];
 
-    for (const key of Object.keys(this.#shape)) {
-      const parsed = this.#shape[key]._parse(record[key]);
+    for (const [key, schema] of Object.entries(this.#shape)) {
+      const parsed = schema._parse(record[key]);
 
       if (isFail(parsed)) {
         for (const issue of parsed.issues) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## What
Turns on `noUncheckedIndexedAccess` in `tsconfig.base.json`. Indexed access (`arr[i]`, `obj[key]`) is now typed `T | undefined`, so the compiler flags exactly the "assumed present, actually maybe undefined" accesses — the same class of bug behind the recent response-shape crashes.

## Fixes
Every resulting error (~140 unique sites across the app + 15 in the packages) is fixed **behavior-preservingly**, with **no `!` and no `as`**:
- early-return / `continue` guards
- optional chaining (`x?.y`)
- nullish defaults (`arr[i] ?? fallback`)
- `Object.entries(o)` instead of `Object.keys(o)` + `o[key]`
- destructuring-with-default

In production paths the added guards are no-ops for data that's valid today (e.g. grid `renderCell` returns `null` for a nonexistent column, exactly as its sibling row-guard already does). In tests, `?.` on the assertion target keeps the assertion meaningful.

Notable production fixes: focus-trap first/last (Dialog), `arrayMove` splice result (Sortable), infinite-query `lastPage`, `ObjectSchema` loop via `Object.entries`, funnel `currentStep` narrowing (kept `assertCondition`'s exact throw + `!= null` semantics so `""` stays valid), the grid header/cell components, and the various chart/tooltip payload accesses.

## Verify
- tsc clean in all 5 packages
- app 597 tests, hobom-data 86, hobom-schema 54, DS 144 — all pass
- app build ok, eslint clean (`--max-warnings=0`)
- diff audited: no non-null assertions or type casts introduced (the one `as RequestInit` in the diff is a pre-existing line that only gained `?.`)

## Follow-up
`recommendedTypeChecked` (the typescript-eslint type-aware ruleset — the other half of the original item) is deferred to its own PR; it has a separate, larger blast radius.