### PR TITLE
Gate PR checks on develop only

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - develop
-      - main
 
 jobs:
   pr-checks:


### PR DESCRIPTION
Follow-up to #171. `main` doesn't exist on the remote — `develop` is the integration base — so the `main` entry in the `pull_request` branch filter never matched. Drop it; the check keeps gating `develop` PRs.