### PR TITLE
Enforce slice public-API and self-barrel import boundaries

### DIFF
--- a/apps/hobom-system/eslint-rules/fsd-boundaries.js
+++ b/apps/hobom-system/eslint-rules/fsd-boundaries.js
@@ -67,6 +67,10 @@ export const rule = {
     messages: {
       crossLayer: "'{{currentLayer}}' layer cannot import from '{{importedLayer}}'.",
       crossSlice: "Cross-slice import in '{{layer}}': '{{from}}' cannot import from '{{to}}'.",
+      ownSliceAlias:
+        "Import within the same slice ('{{layer}}/{{slice}}') must be relative, not via the '@/' alias — importing your own slice's barrel risks a circular dependency.",
+      deepImport:
+        "Deep import into '{{layer}}/{{slice}}' internals. Import from its public entry: '@/{{layer}}/{{slice}}' or '@/{{layer}}/{{slice}}/ui'.",
     },
     schema: [],
   },
@@ -79,7 +83,42 @@ export const rule = {
       if (typeof importPath !== "string") return;
 
       if (importPath.startsWith("@/")) {
-        const [importedLayer, importedSlice] = importPath.slice(2).split("/");
+        const [importedLayer, importedSlice, ...rest] = importPath.slice(2).split("/");
+
+        // Own-slice imports via the `@/` alias must be relative instead — pulling
+        // your own slice's barrel (or a sibling through it) risks a circular
+        // dependency, and a plain relative path keeps intra-slice wiring local.
+        if (
+          !SLICELESS_LAYERS.has(current.layer) &&
+          importedLayer === current.layer &&
+          importedSlice === current.slice
+        ) {
+          context.report({
+            node,
+            messageId: "ownSliceAlias",
+            data: { layer: current.layer, slice: current.slice },
+          });
+
+          return;
+        }
+
+        // Cross-slice imports may reach only a slice's public entries: the root
+        // barrel (`@/layer/slice`) or the UI barrel (`@/layer/slice/ui`). Deeper
+        // paths reach into internals. Sliceless layers (shared, apps) are
+        // addressed by segment, so they're exempt.
+        if (
+          importedSlice &&
+          !SLICELESS_LAYERS.has(importedLayer) &&
+          rest.length > 0 &&
+          !(rest.length === 1 && rest[0] === "ui")
+        ) {
+          context.report({
+            node,
+            messageId: "deepImport",
+            data: { layer: importedLayer, slice: importedSlice },
+          });
+        }
+
         checkImport(context, node, importedLayer, importedSlice ?? null, current);
 
         return;

--- a/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth-login.api.ts
@@ -1,7 +1,7 @@
 import { httpClient, parseResponse } from "@/shared/api";
 import type { HttpResponseType } from "@/shared/api";
-import type { UserType, AuthSignUpType } from "@/entities/auth/model/auth-login.type.ts";
 import { usersSchema } from "./auth-login.schema";
+import type { UserType, AuthSignUpType } from "../model/auth-login.type";
 
 export const postAuthLogin = async ({
   nickname,

--- a/apps/hobom-system/src/entities/auth/api/auth-login.schema.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth-login.schema.ts
@@ -1,5 +1,5 @@
 import { HoBomSchema } from "hobom-schema";
-import type { UserType } from "@/entities/auth/model/auth-login.type.ts";
+import type { UserType } from "../model/auth-login.type";
 import type { Schema } from "hobom-schema";
 
 export const userSchema: Schema<UserType> = HoBomSchema.object({

--- a/apps/hobom-system/src/entities/auth/api/auth.queries.ts
+++ b/apps/hobom-system/src/entities/auth/api/auth.queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "hobom-data";
-import { fetchUsers } from "@/entities/auth/api/auth-login.api";
+import { fetchUsers } from "./auth-login.api";
 
 export const authQueries = {
   auth: () => ["auth"],

--- a/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
+++ b/apps/hobom-system/src/entities/daily-todo/api/daily-todo-category.api.ts
@@ -1,6 +1,6 @@
 import { httpClient, parseResponse, type HttpResponseType } from "@/shared/api";
-import type { CategoryType } from "@/entities/daily-todo";
 import { categoryListSchema } from "./daily-todo-category.schema";
+import type { CategoryType } from "./daily-todo-category.type";
 
 export const fetchDailyTodoCategories = async (signal?: AbortSignal) => {
   const res = await httpClient.get<HttpResponseType<CategoryType[]>>(`/categories`, { signal });

--- a/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.spec.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { CategoryType, DailyTodoType } from "@/entities/daily-todo";
 import { createTodosWithCategory } from "./create-todo-with-category.model";
+import type { CategoryType } from "../api/daily-todo-category.type";
+import type { DailyTodoType } from "../api/daily-todo.type";
 
 const makeCategory = (overrides: Partial<CategoryType> = {}): CategoryType => ({
   id: "cat-1",

--- a/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/create-todo-with-category.model.ts
@@ -1,5 +1,6 @@
 import { Bom } from "hobom-utils";
-import type { CategoryType, DailyTodoType, DailyTodoWithCategoryType } from "@/entities/daily-todo";
+import type { CategoryType } from "../api/daily-todo-category.type";
+import type { DailyTodoType, DailyTodoWithCategoryType } from "../api/daily-todo.type";
 
 const toDailyTodoWithCategory = (
   category: CategoryType,

--- a/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.spec.ts
@@ -44,12 +44,15 @@ vi.mock("hobom-utils", () => {
   return { Bom: { pipe, prop, isNullish } };
 });
 
-vi.mock("@/entities/daily-todo", () => ({
+vi.mock("../api/daily-todo.queries", () => ({
   todoQueries: {
     byDate: (date: string) => ({
       queryKey: ["todos", "by-date", date],
     }),
   },
+}));
+
+vi.mock("../lib/calendar-date.lib", () => ({
   normalizeTodoDateToUtcMidnight: (d: string) => d,
   formatDate: (d: string) => d,
 }));

--- a/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useChangeDailyTodoCompleteStatus.ts
@@ -2,13 +2,10 @@ import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast } from "@/shared/model";
 import type { HttpResponseType } from "@/shared/api";
-import {
-  type DailyTodoType,
-  todoQueries,
-  normalizeTodoDateToUtcMidnight,
-  formatDate,
-} from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { normalizeTodoDateToUtcMidnight, formatDate } from "../lib/calendar-date.lib";
 import { todoMutations } from "../api/daily-todo.mutations";
+import type { DailyTodoType } from "../api/daily-todo.type";
 
 /**
  * Update item's complete status by optimistic update

--- a/apps/hobom-system/src/entities/daily-todo/model/useCreateCategory.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useCreateCategory.ts
@@ -1,6 +1,6 @@
 import { useMutation, useDataLot } from "hobom-data";
 import { useToast } from "@/shared/model";
-import { todoQueries } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
 import { categoryMutations } from "../api/daily-todo-category.mutations";
 
 export const useCreateCategory = () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/useCreateDailyTodo.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useCreateDailyTodo.ts
@@ -1,7 +1,8 @@
 import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast, useRouterQuery } from "@/shared/model";
-import { todoQueries, formatDate, getNow, getSelectedDate } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
 import { todoMutations } from "../api/daily-todo.mutations";
 
 export const useCreateDailyTodo = () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/useDeleteCategory.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useDeleteCategory.ts
@@ -1,7 +1,8 @@
 import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast, useRouterQuery } from "@/shared/model";
-import { todoQueries, formatDate, getNow, getSelectedDate } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
 import { categoryMutations } from "../api/daily-todo-category.mutations";
 
 export const useDeleteCategory = () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/useDeleteDailyTodo.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useDeleteDailyTodo.ts
@@ -3,14 +3,10 @@ import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast, useRouterQuery } from "@/shared/model";
 import type { HttpResponseType } from "@/shared/api";
-import {
-  type DailyTodoType,
-  todoQueries,
-  formatDate,
-  getNow,
-  getSelectedDate,
-} from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
 import { todoMutations } from "../api/daily-todo.mutations";
+import type { DailyTodoType } from "../api/daily-todo.type";
 
 const UNDO_DELAY = 5_000;
 

--- a/apps/hobom-system/src/entities/daily-todo/model/useUpdateCategory.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useUpdateCategory.ts
@@ -1,6 +1,6 @@
 import { useMutation, useDataLot } from "hobom-data";
 import { useToast } from "@/shared/model";
-import { todoQueries } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
 import { categoryMutations } from "../api/daily-todo-category.mutations";
 
 export const useUpdateCategory = () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/useUpdateDailyTodo.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useUpdateDailyTodo.ts
@@ -1,7 +1,8 @@
 import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast, useRouterQuery } from "@/shared/model";
-import { todoQueries, formatDate, getNow, getSelectedDate } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
 import { todoMutations } from "../api/daily-todo.mutations";
 
 export const useUpdateDailyTodo = () => {

--- a/apps/hobom-system/src/entities/daily-todo/model/useUpdateDailyTodoReaction.ts
+++ b/apps/hobom-system/src/entities/daily-todo/model/useUpdateDailyTodoReaction.ts
@@ -2,14 +2,10 @@ import { useMutation, useDataLot } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { useToast, useRouterQuery } from "@/shared/model";
 import type { HttpResponseType } from "@/shared/api";
-import {
-  type DailyTodoType,
-  todoQueries,
-  formatDate,
-  getNow,
-  getSelectedDate,
-} from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
 import { todoMutations } from "../api/daily-todo.mutations";
+import type { DailyTodoType } from "../api/daily-todo.type";
 
 export const useUpdateDailyTodoReaction = () => {
   const { query } = useRouterQuery();

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoAddButton.tsx
@@ -2,17 +2,11 @@ import { useForm, useWatch } from "react-hook-form";
 import { AddCircle } from "hobom-design-system/icons";
 import { Bom } from "hobom-utils";
 import { Hb } from "@/shared/ui";
-import {
-  type DailyTodoWithCategoryType,
-  type CycleType,
-  DailyTodoCycleModel,
-  CYCLE_LABELS,
-  formatDate,
-  getNow,
-  getSelectedDate,
-  useCreateDailyTodo,
-} from "@/entities/daily-todo";
 import { useOverlay, useRouterQuery, useToast } from "@/shared/model";
+import { DailyTodoCycleModel, CYCLE_LABELS } from "../model/daily-todo-cycle.model";
+import { formatDate, getNow, getSelectedDate } from "../lib/calendar-date.lib";
+import { useCreateDailyTodo } from "../model/useCreateDailyTodo";
+import type { DailyTodoWithCategoryType, CycleType } from "../api/daily-todo.type";
 
 interface Props {
   item: DailyTodoWithCategoryType;

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoEditDialog.tsx
@@ -3,7 +3,9 @@ import { useForm } from "react-hook-form";
 import { useQuery } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { Hb } from "@/shared/ui";
-import { todoQueries, useUpdateDailyTodo, type DailyTodoType } from "@/entities/daily-todo";
+import { todoQueries } from "../api/daily-todo.queries";
+import { useUpdateDailyTodo } from "../model/useUpdateDailyTodo";
+import type { DailyTodoType } from "../api/daily-todo.type";
 
 interface Props {
   item: DailyTodoType;

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -2,22 +2,16 @@ import { useState, memo } from "react";
 import { MoreVert } from "hobom-design-system/icons";
 import { Bom } from "hobom-utils";
 import { Hb } from "@/shared/ui";
-import {
-  formatDate,
-  normalizeTodoDateToUtcMidnight,
-  changeCompleteStatus,
-  isCompleteStatus,
-  useChangeDailyTodoCompleteStatus,
-  useDeleteDailyTodo,
-  useUpdateDailyTodoReaction,
-  CYCLE_LABELS,
-  type DailyTodoType,
-  type ProgressType,
-  type CycleType,
-} from "@/entities/daily-todo";
 import { useBottomSheetCTA } from "@/shared/model";
+import { formatDate, normalizeTodoDateToUtcMidnight } from "../lib/calendar-date.lib";
+import { changeCompleteStatus, isCompleteStatus } from "../model/daily-todo-complete-status.model";
+import { useChangeDailyTodoCompleteStatus } from "../model/useChangeDailyTodoCompleteStatus";
+import { useDeleteDailyTodo } from "../model/useDeleteDailyTodo";
+import { useUpdateDailyTodoReaction } from "../model/useUpdateDailyTodoReaction";
+import { CYCLE_LABELS } from "../model/daily-todo-cycle.model";
 import { DailyTodoReactionPopover } from "./DailyTodoReactionPopover";
 import { DailyTodoEditDialog } from "./DailyTodoEditDialog";
+import type { DailyTodoType, ProgressType, CycleType } from "../api/daily-todo.type";
 
 interface Props {
   item: DailyTodoType;

--- a/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
+++ b/apps/hobom-system/src/entities/menu-recommendation/ui/MenuRecommendationListItem.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactNode } from "react";
 import { Hb } from "@/shared/ui";
-import type { MenuRecommendationType } from "@/entities/menu-recommendation";
+import type { MenuRecommendationType } from "../api/menu-recommendation.type";
 
 const MENU_KIND_LABEL: Record<string, string> = {
   KOREAN: "한식",

--- a/apps/hobom-system/src/features/pick-menu/ui/PickMenuFunnel.tsx
+++ b/apps/hobom-system/src/features/pick-menu/ui/PickMenuFunnel.tsx
@@ -1,6 +1,8 @@
-import { PickMenuContent, PickMenuHeader, SelectedMenuContent } from "@/features/pick-menu";
 import { useFunnel } from "@/shared/model";
 import { Hb } from "@/shared/ui";
+import { PickMenuContent } from "./PickMenuContent";
+import { PickMenuHeader } from "./PickMenuHeader";
+import { SelectedMenuContent } from "./SelectedMenuContent";
 
 const FUNNEL_STEPS = ["select-menu", "pick"] as const;
 

--- a/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
+++ b/apps/hobom-system/src/features/select-menu-tab/ui/MenuRecommendationTab.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useState } from "react";
-import { MenuRecommendationContent } from "@/features/select-menu-tab/ui/MenuRecommendationContent";
-import { MenuRecommendationList } from "@/features/select-menu-tab/ui/MenuRecommendationList";
-import { MenuRecommendationSpeedDial } from "@/features/select-menu-tab/ui/MenuRecommendationSpeedDial";
 import { Hb } from "@/shared/ui";
+import { MenuRecommendationContent } from "./MenuRecommendationContent";
+import { MenuRecommendationList } from "./MenuRecommendationList";
+import { MenuRecommendationSpeedDial } from "./MenuRecommendationSpeedDial";
 
 const TAB_VALUES = ["recommendation", "list"] as const;
 

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContent.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageContent.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode, Suspense } from "react";
 import { useSuspenseQuery } from "hobom-data";
-import { FutureMessageGrid } from "@/features/send-future-message/ui/FutureMessageGrid";
 import { futureMessageQueries, type FutureMessageSendStatusType } from "@/entities/future-message";
 import { useRouterQuery } from "@/shared/model";
 import { Hb, HoBomSkeleton } from "@/shared/ui";
+import { FutureMessageGrid } from "./FutureMessageGrid";
 
 export const FutureMessageContent = () => {
   const { query } = useRouterQuery();

--- a/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
@@ -2,12 +2,13 @@ import { useState } from "react";
 import { type FieldValues, FormProvider, useForm } from "react-hook-form";
 import { useNavigate, Link as RouterLink } from "react-router-dom";
 import { useMutation, useDataLot } from "hobom-data";
-import { NicknameField, PasswordField } from "@/features/submit-auth-login";
 import { useToast } from "@/shared/model";
 import { RoutesConfig } from "@/shared/config";
 import { resetUnauthorizedState } from "@/shared/api";
 import { postAuthLogin, type AuthLoginType } from "@/entities/auth";
 import { Hb } from "@/shared/ui";
+import { NicknameField } from "./NicknameField";
+import { PasswordField } from "./PasswordField";
 import { LoginTransitionOverlay } from "./LoginTransitionOverlay";
 
 export const AuthLoginForm = () => {

--- a/apps/hobom-system/src/test/fsd-boundaries.rule.spec.ts
+++ b/apps/hobom-system/src/test/fsd-boundaries.rule.spec.ts
@@ -16,10 +16,14 @@ ruleTester.run("fsd-boundaries", rule, {
     { code: `export { x } from "@/shared/y";`, filename: file("features", "auth") },
     // apps may lazy-load pages
     { code: `const p = import("@/pages/home");`, filename: file("apps", "app-router") },
-    // same-slice relative import is fine
-    { code: `import { x } from "@/entities/note";`, filename: file("entities", "note") },
+    // same-slice import via a relative path is fine
+    { code: `import { x } from "./api/note.queries";`, filename: file("entities", "note") },
+    // a slice's UI barrel is a sanctioned second public entry (cross-slice)
+    { code: `import { Card } from "@/entities/note/ui";`, filename: file("features", "board") },
     // non-literal dynamic import is ignored
     { code: `const p = import(dynamicPath);`, filename: file("entities", "note") },
+    // deep import into a sliceless layer's segment is fine
+    { code: `import { httpClient } from "@/shared/api";`, filename: file("entities", "note") },
   ],
   invalid: [
     // entities cannot import features (static)
@@ -45,6 +49,24 @@ ruleTester.run("fsd-boundaries", rule, {
       code: `import { x } from "@/features/billing";`,
       filename: file("features", "auth"),
       errors: [{ messageId: "crossSlice" }],
+    },
+    // importing your own slice via the @/ alias (self-barrel) must be relative
+    {
+      code: `import { x } from "@/entities/note";`,
+      filename: file("entities", "note"),
+      errors: [{ messageId: "ownSliceAlias" }],
+    },
+    // …including a deeper own-slice path
+    {
+      code: `import { x } from "@/entities/note/api/note.queries";`,
+      filename: file("entities", "note"),
+      errors: [{ messageId: "ownSliceAlias" }],
+    },
+    // deep import into another slice's internals (past root and /ui)
+    {
+      code: `import { x } from "@/entities/note/model/note.model";`,
+      filename: file("features", "board"),
+      errors: [{ messageId: "deepImport" }],
     },
   ],
 });

--- a/docs/adr/0002-slice-public-api-and-import-boundaries.md
+++ b/docs/adr/0002-slice-public-api-and-import-boundaries.md
@@ -1,0 +1,67 @@
+# 2. Slice public API and import boundaries
+
+- Status: Accepted
+- Date: 2026-07-11
+- Deciders: HoBom frontend
+
+## Context
+
+Two import conventions had spread through the app without being written down or
+enforced, so they were eroding at the edges:
+
+- **Deep imports** into another slice's internals (`@/entities/x/model/foo`,
+  `@/features/y/ui/Component`) instead of going through the slice's public entry.
+  A slice ends up with more than one de-facto public surface, and refactors
+  inside it silently break distant callers.
+- **Self-barrel imports** — a file importing its own slice's root barrel
+  (`@/entities/daily-todo` from inside `entities/daily-todo/**`). The barrel
+  re-exports the very file that imports it, so this is a circular dependency.
+  The bundler tolerates it today, but a single change to export order can turn
+  it into an `undefined`-at-evaluation bug.
+
+The design system already, deliberately, keeps UI out of a slice's root barrel:
+the root barrel is the model/logic API, and each slice exposes its components
+through a separate `ui` barrel. That is a good split (it stops a feature that
+only needs another slice's hooks from pulling in its whole component tree), but
+it was never stated, so "two public entries" read as "deep imports are fine
+anywhere".
+
+## Decision
+
+**A slice exposes at most two public entries, and nothing else is imported
+across a slice boundary:**
+
+1. `@/<layer>/<slice>` — the root barrel (`index.ts`): logic, models, queries,
+   types.
+2. `@/<layer>/<slice>/ui` — the UI barrel: the slice's components.
+
+**Within a slice, imports are always relative** (`./`, `../`) — never the
+`@/<own-slice>` alias, at any depth. This removes the self-barrel cycle and
+keeps intra-slice wiring local and obvious.
+
+**Sliceless layers (`shared`, `apps`) are addressed by segment** — `@/shared/ui`,
+`@/shared/lib`, `@/shared/model`, etc. — since they have no slices and no single
+barrel. Deep imports into their segments are expected and allowed.
+
+## Enforcement
+
+The custom `eslint-rules/fsd-boundaries.js` rule enforces this alongside the
+existing layer/slice checks, on static imports, `export … from` re-exports, and
+dynamic `import()`:
+
+- `ownSliceAlias` — a file importing its own slice via `@/` (root or deeper).
+- `deepImport` — a cross-slice import that reaches past the root barrel and the
+  `ui` barrel into a slice's internals.
+
+Both are covered by `src/test/fsd-boundaries.rule.spec.ts`.
+
+## Consequences
+
+- Each slice has a small, explicit contract; internal files can move freely
+  behind the two barrels.
+- The self-barrel circular-dependency class is gone and can't come back.
+- Cost: adding a new cross-slice-visible symbol means exporting it from the
+  slice's root or `ui` barrel — a deliberate, visible step, which is the point.
+- If a slice genuinely needs a third public surface, that is a signal the slice
+  is doing too much and should be split, not that the rule should gain an
+  exception.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@ the moment it was made.
 | # | Decision | Status |
 | --- | --- | --- |
 | [0001](./0001-in-house-data-and-schema-libraries.md) | In-house data-fetching and schema libraries | Accepted |
+| [0002](./0002-slice-public-api-and-import-boundaries.md) | Slice public API and import boundaries | Accepted |
 
 New ADRs are numbered sequentially and never edited once accepted — supersede
 them with a new record instead.


### PR DESCRIPTION
## What
Two undocumented import conventions were eroding the FSD boundaries:
- **Deep imports** into another slice's internals (`@/entities/x/model/foo`, `@/features/y/ui/Component`), bypassing the slice's public barrel.
- **Self-barrel imports** — a file importing its own slice's root barrel (`@/entities/daily-todo` from inside `entities/daily-todo/**`). The barrel re-exports the importing file, i.e. a circular dependency the bundler only tolerated by luck (one export-order change → `undefined`-at-eval).

## Policy (ADR 0002)
A slice exposes **at most two public entries**: the root barrel `@/<layer>/<slice>` (logic/model/types) and the UI barrel `@/<layer>/<slice>/ui` (components). Cross-slice imports use only these. **Intra-slice imports are always relative** (never the `@/own-slice` alias). Sliceless layers (`shared`, `apps`) are addressed by segment.

## Enforcement
Extends `eslint-rules/fsd-boundaries.js` with two checks (applied to imports, `export … from`, and dynamic `import()`):
- `ownSliceAlias` — importing your own slice via `@/` (root or deeper) must be relative.
- `deepImport` — a cross-slice import past the root and `/ui` barrels into internals.

Both covered by `fsd-boundaries.rule.spec.ts` (RuleTester).

## Fixes
- Converted the **22 offending files** to relative / public-entry imports (13 in `daily-todo`, plus `auth`, `menu-recommendation`, `pick-menu`, `select-menu-tab`, `send-future-message`, `submit-auth-login`).
- Retargeted two specs that mocked a now-relative module (`useChangeDailyTodoCompleteStatus.spec` → mocks `../api/daily-todo.queries` + `../lib/calendar-date.lib`; updated the rule spec's own cases).
- The 31 cross-slice `@/…/ui` barrel imports are **sanctioned** by the policy and need no change.

## Verify
- app `tsc -b` clean, eslint clean (`--max-warnings=0`), build ok
- 602 app tests pass (incl. 14 rule cases)