### PR TITLE
Enable type-aware ESLint for the app (scoped)

### DIFF
--- a/apps/hobom-system/eslint.config.js
+++ b/apps/hobom-system/eslint.config.js
@@ -7,10 +7,20 @@ import * as fsdBoundariesRule from "./eslint-rules/fsd-boundaries.js";
 
 export default tseslint.config(baseIgnores, {
   ...baseConfig,
+  // Type-aware linting (app only for now — the packages follow separately).
+  extends: [...(baseConfig.extends ?? []), ...tseslint.configs.recommendedTypeChecked],
   files: ["**/*.{ts,tsx}"],
   languageOptions: {
     ecmaVersion: 2020,
     globals: globals.browser,
+    parserOptions: {
+      // Config/declaration files outside the TS build project lint under an
+      // inferred default project so type-aware rules don't choke on them.
+      projectService: {
+        allowDefaultProject: ["vitest.config.ts", "eslint-rules/fsd-boundaries.d.ts"],
+      },
+      tsconfigRootDir: import.meta.dirname,
+    },
   },
   plugins: {
     ...baseConfig.plugins,
@@ -24,6 +34,24 @@ export default tseslint.config(baseIgnores, {
   },
   rules: {
     ...baseConfig.rules,
+
+    // ── Type-checked: `any`-leak family deferred ──
+    // These need the source of each `any` typed; tracked as a follow-up so the
+    // high-signal async/assertion rules can land now. See ADR / PR notes.
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+
+    // Async JSX event handlers (`onClick={async …}`) are idiomatic React and
+    // safe — React discards the returned promise. Keep the rule for the risky
+    // cases (a promise passed to a void callback like `forEach`, or used in a
+    // condition), but allow it on attributes.
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      { checksVoidReturn: { attributes: false } },
+    ],
 
     // ── React ──
     ...reactHooks.configs.recommended.rules,

--- a/apps/hobom-system/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-system/src/apps/ui/AppRouter.tsx
@@ -123,7 +123,9 @@ const PREFETCH_MAP: Record<string, (() => Promise<unknown>)[]> = {
 };
 
 const prefetchRoute = (path: string) => {
-  PREFETCH_MAP[path]?.forEach((fn) => fn());
+  PREFETCH_MAP[path]?.forEach((fn) => {
+    void fn();
+  });
 };
 
 const Shell = ({ children }: { children: React.ReactNode }) => {
@@ -134,12 +136,21 @@ const Shell = ({ children }: { children: React.ReactNode }) => {
     (path: string) => {
       prefetchRoute(path);
       const queryPrefetchMap: Record<string, () => void> = {
-        [RoutesConfig.MAIN.DAILY_TODO]: () => dataLot.prefetchQuery(todoQueries.categories()),
-        [RoutesConfig.MENU.RECOMMENDATION]: () =>
-          dataLot.prefetchQuery(menuQueries.recommendationList()),
-        [RoutesConfig.NOTES.LIST]: () => dataLot.prefetchQuery(noteQueries.list()),
-        [RoutesConfig.PROJECTS.LIST]: () => dataLot.prefetchQuery(projectQueries.list()),
-        [RoutesConfig.WIKI.SPACES]: () => dataLot.prefetchQuery(wikiSpaceQueries.list()),
+        [RoutesConfig.MAIN.DAILY_TODO]: () => {
+          void dataLot.prefetchQuery(todoQueries.categories());
+        },
+        [RoutesConfig.MENU.RECOMMENDATION]: () => {
+          void dataLot.prefetchQuery(menuQueries.recommendationList());
+        },
+        [RoutesConfig.NOTES.LIST]: () => {
+          void dataLot.prefetchQuery(noteQueries.list());
+        },
+        [RoutesConfig.PROJECTS.LIST]: () => {
+          void dataLot.prefetchQuery(projectQueries.list());
+        },
+        [RoutesConfig.WIKI.SPACES]: () => {
+          void dataLot.prefetchQuery(wikiSpaceQueries.list());
+        },
       };
 
       queryPrefetchMap[path]?.();
@@ -172,7 +183,7 @@ export const AppRouter = () => {
       openWarnToast({
         message: "인증이 필요해요. 로그인 페이지로 이동합니다.",
       });
-      navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
+      void navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
     };
 
     window.addEventListener(UNAUTHORIZED_EVENT, handler);
@@ -183,7 +194,9 @@ export const AppRouter = () => {
   // 유휴 시간에 모든 페이지 청크 백그라운드 프리페치
   useEffect(() => {
     const id = requestIdleCallback(() => {
-      Object.values(pageImports).forEach((fn) => fn());
+      Object.values(pageImports).forEach((fn) => {
+        void fn();
+      });
     });
 
     return () => cancelIdleCallback(id);

--- a/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
+++ b/apps/hobom-system/src/apps/ui/UserProfileMenu.tsx
@@ -45,7 +45,7 @@ export const UserProfileMenu = () => {
       setIsLoggingOut(false);
       setAnchorEl(null);
       dataLot.clear();
-      navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
+      void navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
     }
   };
 

--- a/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
+++ b/apps/hobom-system/src/entities/daily-todo/ui/DailyTodoListItem.tsx
@@ -101,7 +101,7 @@ export const DailyTodoListItem = memo(function DailyTodoListItem({ item }: Props
                         <Hb.Chip
                           color="secondary"
                           variant="outlined"
-                          label={CYCLE_LABELS[item.cycle as CycleType] ?? item.cycle}
+                          label={CYCLE_LABELS[item.cycle] ?? item.cycle}
                           size="small"
                         />
                       </Hb.Stack>

--- a/apps/hobom-system/src/entities/issue/model/useAssignIssue.spec.ts
+++ b/apps/hobom-system/src/entities/issue/model/useAssignIssue.spec.ts
@@ -72,7 +72,7 @@ const makeIssue = (overrides: Partial<IssueType> = {}): IssueType =>
     reporter: "user-1",
     labels: [],
     ...overrides,
-  }) as IssueType;
+  });
 
 describe("useAssignIssue", () => {
   beforeEach(() => {

--- a/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
+++ b/apps/hobom-system/src/entities/issue/model/useTransitionIssue.spec.ts
@@ -66,7 +66,7 @@ const makeIssue = (overrides: Partial<IssueType> = {}): IssueType =>
     reporter: "user-1",
     labels: [],
     ...overrides,
-  }) as IssueType;
+  });
 
 describe("useTransitionIssue", () => {
   beforeEach(() => {

--- a/apps/hobom-system/src/entities/log/api/log.api.spec.ts
+++ b/apps/hobom-system/src/entities/log/api/log.api.spec.ts
@@ -26,7 +26,7 @@ describe("fetchLogSearch", () => {
       size: 20,
     };
 
-    fetchLogSearch(params);
+    void fetchLogSearch(params);
 
     const url = mockGet.mock.calls[0]?.[0] as string;
 
@@ -42,7 +42,7 @@ describe("fetchLogSearch", () => {
   it("omits undefined optional params", () => {
     const params: LogSearchParams = { page: 0, size: 10 };
 
-    fetchLogSearch(params);
+    void fetchLogSearch(params);
 
     const url = mockGet.mock.calls[0]?.[0] as string;
 
@@ -61,7 +61,7 @@ describe("fetchLogSearch", () => {
       size: 10,
     };
 
-    fetchLogSearch(params);
+    void fetchLogSearch(params);
 
     const url = mockGet.mock.calls[0]?.[0] as string;
 
@@ -70,7 +70,7 @@ describe("fetchLogSearch", () => {
   });
 
   it("uses /logs base path", () => {
-    fetchLogSearch({ page: 0, size: 10 });
+    void fetchLogSearch({ page: 0, size: 10 });
 
     const url = mockGet.mock.calls[0]?.[0] as string;
 

--- a/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
+++ b/apps/hobom-system/src/entities/manifest/model/manifest.model.ts
@@ -16,8 +16,8 @@ export type PropSpec =
   | { kind: "boolean"; default: boolean }
   | { kind: "slot"; accepts: readonly NodeKind[] };
 
-/** Document 노드가 가질 수 있는 종류. 컴포넌트 키이거나 원시 텍스트. */
-type NodeKind = ComponentKey | "text";
+/** Document 노드가 가질 수 있는 종류. 컴포넌트 키이거나 원시 텍스트(`"text"`). */
+type NodeKind = ComponentKey;
 
 /** 매니페스트가 식별하는 컴포넌트 키. 예: `"Hb.Button"`. */
 export type ComponentKey = string;

--- a/apps/hobom-system/src/entities/project/model/useAddMember.ts
+++ b/apps/hobom-system/src/entities/project/model/useAddMember.ts
@@ -10,7 +10,7 @@ export const useAddMember = () => {
   return useMutation({
     ...projectMutations.addMember(),
     onSuccess: (_, variables) => {
-      dataLot.invalidateQueries(projectQueries.detail(variables.projectId));
+      void dataLot.invalidateQueries(projectQueries.detail(variables.projectId));
       openSuccessToast({ message: "멤버를 추가했어요" });
     },
   });

--- a/apps/hobom-system/src/entities/project/model/useRemoveMember.ts
+++ b/apps/hobom-system/src/entities/project/model/useRemoveMember.ts
@@ -10,7 +10,7 @@ export const useRemoveMember = () => {
   return useMutation({
     ...projectMutations.removeMember(),
     onSuccess: (_, variables) => {
-      dataLot.invalidateQueries(projectQueries.detail(variables.projectId));
+      void dataLot.invalidateQueries(projectQueries.detail(variables.projectId));
       openSuccessToast({ message: "멤버를 제거했어요" });
     },
   });

--- a/apps/hobom-system/src/features/backlog-board/model/useBacklogBoard.spec.ts
+++ b/apps/hobom-system/src/features/backlog-board/model/useBacklogBoard.spec.ts
@@ -45,7 +45,7 @@ const makeIssue = (id: string, sprint?: string): IssueType =>
     reporter: "user-1",
     labels: [],
     sprint,
-  }) as IssueType;
+  });
 
 const makeSprint = (id: string) => ({
   id,

--- a/apps/hobom-system/src/features/backlog-board/model/useCollapsibleTree.spec.ts
+++ b/apps/hobom-system/src/features/backlog-board/model/useCollapsibleTree.spec.ts
@@ -26,7 +26,7 @@ const makeIssue = (id: string, parent?: string): IssueType =>
     reporter: "user-1",
     labels: [],
     parent,
-  }) as IssueType;
+  });
 
 const makeTree = (): IssueTreeResult => ({
   roots: [makeIssue("root")],

--- a/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorHeaderCell.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/EndpointErrorHeaderCell.tsx
@@ -47,10 +47,10 @@ export const EndpointErrorHeaderCell = ({ cell, colResize }: EndpointErrorHeader
           transition: "background-color 0.15s",
         }}
         onPointerEnter={(e) => {
-          (e.currentTarget as HTMLDivElement).style.backgroundColor = RESIZE_HANDLE;
+          (e.currentTarget).style.backgroundColor = RESIZE_HANDLE;
         }}
         onPointerLeave={(e) => {
-          (e.currentTarget as HTMLDivElement).style.backgroundColor = "transparent";
+          (e.currentTarget).style.backgroundColor = "transparent";
         }}
         onPointerDown={(e) => {
           e.stopPropagation();

--- a/apps/hobom-system/src/features/dlq-management/model/useRetryDlq.ts
+++ b/apps/hobom-system/src/features/dlq-management/model/useRetryDlq.ts
@@ -12,7 +12,7 @@ export const useRetryDlq = () => {
       openSuccessToast({
         message: data.items.message || "재시도 요청이 완료되었습니다.",
       });
-      dataLot.invalidateQueries({ queryKey: dlqQueries.all() });
+      void dataLot.invalidateQueries({ queryKey: dlqQueries.all() });
     },
     onError: () => {
       openErrorToast({ message: "재시도 요청에 실패했습니다." });

--- a/apps/hobom-system/src/features/issue-detail/model/useIssueDetailState.spec.ts
+++ b/apps/hobom-system/src/features/issue-detail/model/useIssueDetailState.spec.ts
@@ -64,7 +64,7 @@ const makeIssue = (overrides: Partial<IssueType> = {}): IssueType =>
     reporter: "user-1",
     labels: [],
     ...overrides,
-  }) as IssueType;
+  });
 
 describe("useIssueDetailState", () => {
   beforeEach(() => {

--- a/apps/hobom-system/src/features/issue-list-table/model/useIssueListFilters.ts
+++ b/apps/hobom-system/src/features/issue-list-table/model/useIssueListFilters.ts
@@ -25,8 +25,8 @@ export const useIssueListFilters = () => {
       sortKey
         ? [
             {
-              key: sortKey as keyof IssueType,
-              direction: sortDir as "asc" | "desc",
+              key: sortKey,
+              direction: sortDir,
             },
           ]
         : [],

--- a/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
+++ b/apps/hobom-system/src/features/issue-list-table/ui/HeaderCell.tsx
@@ -86,10 +86,10 @@ export const HeaderCell = ({
           transition: "background-color 0.15s",
         }}
         onPointerEnter={(e) => {
-          (e.currentTarget as HTMLDivElement).style.backgroundColor = "var(--hb-color-accent)";
+          (e.currentTarget).style.backgroundColor = "var(--hb-color-accent)";
         }}
         onPointerLeave={(e) => {
-          (e.currentTarget as HTMLDivElement).style.backgroundColor = "transparent";
+          (e.currentTarget).style.backgroundColor = "transparent";
         }}
         onPointerDown={(e) => {
           e.stopPropagation();

--- a/apps/hobom-system/src/features/kanban-board/lib/kanban-dnd.lib.spec.ts
+++ b/apps/hobom-system/src/features/kanban-board/lib/kanban-dnd.lib.spec.ts
@@ -19,7 +19,7 @@ const makeIssue = (id: string): IssueType =>
     priority: "MEDIUM",
     reporter: "user",
     labels: [],
-  }) as IssueType;
+  });
 
 const COLUMNS: ColumnMap = {
   todo: [makeIssue("i1"), makeIssue("i2")],

--- a/apps/hobom-system/src/features/kanban-board/lib/kanban-filter.lib.ts
+++ b/apps/hobom-system/src/features/kanban-board/lib/kanban-filter.lib.ts
@@ -26,7 +26,7 @@ export const filterColumnsByEpic = (
     Bom.mapValues((issues: IssueType[]) =>
       issues.filter((issue) => issue.id === epicId || isDescendantOf(issue.id, epicId, parentMap)),
     ),
-  ) as ColumnMap;
+  );
 
 export const buildSwimlaneGroups = (
   issues: IssueType[],

--- a/apps/hobom-system/src/features/kanban-board/model/useKanbanBoard.ts
+++ b/apps/hobom-system/src/features/kanban-board/model/useKanbanBoard.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { useSuspenseQuery } from "hobom-data";
 import { Bom } from "hobom-utils";
 import { issueQueries, buildIssueTree, type IssueType } from "@/entities/issue";
-import type { ColumnMap } from "../lib/kanban-dnd.lib";
 
 export const useKanbanBoard = (projectId: string, columnOrder: string[]) => {
   const { data } = useSuspenseQuery(issueQueries.listByProject(projectId));
@@ -13,7 +12,7 @@ export const useKanbanBoard = (projectId: string, columnOrder: string[]) => {
       Bom.groupBy((issue: IssueType) => issue.status),
     );
 
-    return Object.fromEntries(columnOrder.map((s) => [s, grouped[s] ?? []])) as ColumnMap;
+    return Object.fromEntries(columnOrder.map((s) => [s, grouped[s] ?? []]));
   }, [data.items, columnOrder]);
 
   const issueTree = useMemo(() => buildIssueTree(data.items), [data.items]);

--- a/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.spec.ts
+++ b/apps/hobom-system/src/features/kanban-board/model/useKanbanDnd.spec.ts
@@ -49,7 +49,7 @@ const makeIssue = (id: string, status: string): IssueType =>
     priority: "MEDIUM",
     reporter: "user-1",
     labels: [],
-  }) as IssueType;
+  });
 
 const makeColumns = (): ColumnMap => ({
   todo: [makeIssue("i1", "todo"), makeIssue("i2", "todo")],

--- a/apps/hobom-system/src/features/kanban-board/model/useKanbanFilters.spec.ts
+++ b/apps/hobom-system/src/features/kanban-board/model/useKanbanFilters.spec.ts
@@ -44,7 +44,7 @@ const makeIssue = (id: string, status: string, type = "TASK" as IssueType["type"
     priority: "MEDIUM",
     reporter: "user-1",
     labels: [],
-  }) as IssueType;
+  });
 
 const makeTree = (): IssueTreeResult => ({
   roots: [],

--- a/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
+++ b/apps/hobom-system/src/features/kanban-board/ui/KanbanBoard.tsx
@@ -5,13 +5,7 @@ import { getDescendantProgress, useCreateIssue, useTransitionIssue } from "@/ent
 import { IssueCard } from "@/entities/issue/ui";
 import { boardQueries, DEFAULT_BOARD_COLUMNS, type BoardColumn } from "@/entities/board";
 import { useProjectContext } from "@/entities/project";
-import {
-  Hb,
-  Sortable,
-  type DragEndEvent,
-  type DragStartEvent,
-  type DragOverEvent,
-} from "@/shared/ui";
+import { Hb, Sortable } from "@/shared/ui";
 import { useKanbanBoard } from "../model/useKanbanBoard";
 import { useKanbanDnd } from "../model/useKanbanDnd";
 import { useKanbanFilters } from "../model/useKanbanFilters";
@@ -68,9 +62,9 @@ export const KanbanBoard = ({ projectId, onIssueClick }: KanbanBoardProps) => {
   return (
     <KanbanContext.Provider value={contextValue}>
       <Sortable.Root
-        onDragStart={dnd.handleDragStart as (e: DragStartEvent) => void}
-        onDragOver={dnd.handleDragOver as (e: DragOverEvent) => void}
-        onDragEnd={dnd.handleDragEnd as (e: DragEndEvent) => void}
+        onDragStart={dnd.handleDragStart}
+        onDragOver={dnd.handleDragOver}
+        onDragEnd={dnd.handleDragEnd}
         onDragCancel={dnd.handleDragCancel}
         overlay={
           dnd.activeIssue ? (

--- a/apps/hobom-system/src/features/note/model/useNoteGrid.spec.ts
+++ b/apps/hobom-system/src/features/note/model/useNoteGrid.spec.ts
@@ -33,7 +33,7 @@ const makeNote = (overrides: Partial<NoteItemType> = {}): NoteItemType =>
     trashedAt: null,
     order: 0,
     ...overrides,
-  }) as NoteItemType;
+  });
 
 describe("useNoteGrid", () => {
   const onTogglePinMock = vi.fn();

--- a/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
+++ b/apps/hobom-system/src/features/notification/ui/NotificationPanel.tsx
@@ -27,7 +27,9 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
   const handleScroll = useInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
-    fetchNextPage,
+    fetchNextPage: () => {
+      void fetchNextPage();
+    },
     threshold: 100,
   });
 
@@ -181,7 +183,7 @@ export const NotificationPanel = ({ anchorEl, onClose }: Props) => {
           size="small"
           variant="ghost"
           onClick={() => {
-            navigate(RoutesConfig.NOTIFICATION.LIST);
+            void navigate(RoutesConfig.NOTIFICATION.LIST);
             onClose();
           }}
           style={{

--- a/apps/hobom-system/src/features/privacy-law-chat/model/useChatSession.ts
+++ b/apps/hobom-system/src/features/privacy-law-chat/model/useChatSession.ts
@@ -65,7 +65,7 @@ export const useChatSession = () => {
             };
 
             setLocalMessages((prev) => [...prev, assistantMsg]);
-            dataLot.invalidateQueries({
+            void dataLot.invalidateQueries({
               queryKey: privacyLawQueries.questionHistory().queryKey,
             });
           },

--- a/apps/hobom-system/src/features/privacy-law-exam/model/useExamSession.ts
+++ b/apps/hobom-system/src/features/privacy-law-exam/model/useExamSession.ts
@@ -28,7 +28,7 @@ export const useExamSession = (questions: ExamQuestion[]) => {
     finished: false,
   });
 
-  const currentQuestion = questions[state.currentIndex] as ExamQuestion | undefined;
+  const currentQuestion = questions[state.currentIndex];
   const currentAnswer = state.answers[state.currentIndex];
   const userAnswer = currentAnswer?.userAnswer ?? "";
   const revealed = currentAnswer?.revealed ?? false;

--- a/apps/hobom-system/src/features/privacy-law-exam/ui/ExamList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-exam/ui/ExamList.tsx
@@ -16,11 +16,11 @@ export const ExamList = () => {
   const { mutate: generate, isPending } = useMutation({
     ...privacyLawMutations.generateExam(),
     onSuccess: (res) => {
-      dataLot.invalidateQueries({ queryKey: privacyLawQueries.all() });
+      void dataLot.invalidateQueries({ queryKey: privacyLawQueries.all() });
       toast.openSuccessToast({
         message: "모의고사 문제를 생성했어요. 이동할게요.",
       });
-      navigate(`/privacy-law/exams/${res.items.id}`);
+      void navigate(`/privacy-law/exams/${res.items.id}`);
     },
     onError: (error) => {
       if (error instanceof DOMException && error.name === "AbortError") return;

--- a/apps/hobom-system/src/features/privacy-law-study/model/useQuizSession.ts
+++ b/apps/hobom-system/src/features/privacy-law-study/model/useQuizSession.ts
@@ -28,7 +28,7 @@ export const useQuizSession = (quizzes: Quiz[]) => {
     finished: false,
   });
 
-  const currentQuiz = quizzes[state.currentIndex] as Quiz | undefined;
+  const currentQuiz = quizzes[state.currentIndex];
   const currentAnswer = state.answers[state.currentIndex];
   const userAnswer = currentAnswer?.userAnswer ?? "";
   const revealed = currentAnswer?.revealed ?? false;

--- a/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
+++ b/apps/hobom-system/src/features/privacy-law-viewer/ui/LawVersionList.tsx
@@ -13,7 +13,7 @@ export const LawVersionList = () => {
   const fetchMutation = useMutation({
     ...privacyLawMutations.fetch(),
     onSuccess: () => {
-      dataLot.invalidateQueries({
+      void dataLot.invalidateQueries({
         queryKey: privacyLawQueries.all(),
       });
     },

--- a/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
+++ b/apps/hobom-system/src/features/project-settings/ui/DangerZoneSection.tsx
@@ -39,7 +39,7 @@ export const DangerZoneSection = ({ projectId }: DangerZoneSectionProps) => {
             {
               onSuccess: () => {
                 onClose();
-                navigate(RoutesConfig.PROJECTS.LIST);
+                void navigate(RoutesConfig.PROJECTS.LIST);
               },
             },
           );

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageRecipientFunnel.tsx
@@ -74,7 +74,7 @@ const Inner = ({ onNextStep }: Props) => {
           variant="secondary"
           onClick={() => {
             reset();
-            navigate(RoutesConfig.MESSAGE.RESERVATION);
+            void navigate(RoutesConfig.MESSAGE.RESERVATION);
           }}
         >
           취소

--- a/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/FutureMessageScheduleFunnel.tsx
@@ -86,16 +86,18 @@ export const FutureMessageScheduleFunnel = ({ onPrevStep }: Props) => {
                 },
                 (payload) => {
                   sendFutureMessageMutationHandler.mutate(payload, {
-                    onSuccess: async () => {
-                      await dataLot.invalidateQueries({
-                        queryKey: futureMessageQueries.futureMessages(),
-                      });
-                      openSuccessToast({
-                        message: "미래 메시지를 잘 예약했어요.",
-                      });
-                      navigate(`${RoutesConfig.MESSAGE.RESERVATION}?status=PENDING`, {
-                        replace: true,
-                      });
+                    onSuccess: () => {
+                      void (async () => {
+                        await dataLot.invalidateQueries({
+                          queryKey: futureMessageQueries.futureMessages(),
+                        });
+                        openSuccessToast({
+                          message: "미래 메시지를 잘 예약했어요.",
+                        });
+                        void navigate(`${RoutesConfig.MESSAGE.RESERVATION}?status=PENDING`, {
+                          replace: true,
+                        });
+                      })();
                     },
                     onError: () => {
                       openErrorToast({

--- a/apps/hobom-system/src/features/send-future-message/ui/GridHeaderCell.tsx
+++ b/apps/hobom-system/src/features/send-future-message/ui/GridHeaderCell.tsx
@@ -44,10 +44,10 @@ export const GridHeaderCell = ({ colIndex, onStartResize }: Props) => {
             transition: "background-color 0.15s",
           }}
           onPointerEnter={(e) => {
-            (e.currentTarget as HTMLDivElement).style.backgroundColor = COLORS.resizeHandle;
+            (e.currentTarget).style.backgroundColor = COLORS.resizeHandle;
           }}
           onPointerLeave={(e) => {
-            (e.currentTarget as HTMLDivElement).style.backgroundColor = "transparent";
+            (e.currentTarget).style.backgroundColor = "transparent";
           }}
           onPointerDown={(e) => {
             e.stopPropagation();

--- a/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-login/ui/AuthLoginForm.tsx
@@ -34,12 +34,14 @@ export const AuthLoginForm = () => {
         password,
       },
       {
-        onSuccess: async () => {
-          resetUnauthorizedState();
-          dataLot.clear();
-          setIsTransitioning(true);
-          await new Promise((resolve) => setTimeout(resolve, 2000));
-          navigate(RoutesConfig.DASHBOARD.HOME);
+        onSuccess: () => {
+          void (async () => {
+            resetUnauthorizedState();
+            dataLot.clear();
+            setIsTransitioning(true);
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            void navigate(RoutesConfig.DASHBOARD.HOME);
+          })();
         },
         onError: () => {
           openErrorToast({

--- a/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
+++ b/apps/hobom-system/src/features/submit-auth-signup/ui/AuthSignUpForm.tsx
@@ -29,7 +29,7 @@ export const AuthSignUpForm = () => {
         openSuccessToast({
           message: "가입이 완료되었어요. 관리자 승인 후 로그인할 수 있어요.",
         });
-        navigate(RoutesConfig.AUTH.LOGIN);
+        void navigate(RoutesConfig.AUTH.LOGIN);
       },
       onError: () => {
         openErrorToast({

--- a/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
+++ b/apps/hobom-system/src/features/wiki-label-manager/ui/PageLabelChips.tsx
@@ -21,7 +21,7 @@ export const PageLabelChips = ({ spaceKey, pageId, pageLabels }: PageLabelChipsP
   const removeLabel = useRemovePageLabel();
 
   const invalidatePageDetail = () => {
-    dataLot.invalidateQueries({ queryKey: wikiPageQueries.pages() });
+    void dataLot.invalidateQueries({ queryKey: wikiPageQueries.pages() });
   };
 
   const availableLabels = allLabels.filter((l) => !pageLabelIds.has(l.id));

--- a/apps/hobom-system/src/features/wiki-search/ui/WikiSearchField.tsx
+++ b/apps/hobom-system/src/features/wiki-search/ui/WikiSearchField.tsx
@@ -14,7 +14,7 @@ export const WikiSearchField = ({ spaceKey }: WikiSearchFieldProps) => {
 
   const handleSelect = (_: unknown, value: string | SearchResultType | null) => {
     if (value && typeof value !== "string") {
-      navigate(`/wiki/${spaceKey}/pages/${value.id}`);
+      void navigate(`/wiki/${spaceKey}/pages/${value.id}`);
       setQuery("");
     }
   };
@@ -31,7 +31,7 @@ export const WikiSearchField = ({ spaceKey }: WikiSearchFieldProps) => {
       noOptionsText={query.length < 2 ? "2글자 이상 입력" : "결과 없음"}
       renderOption={({ key, ...props }, option) => (
         <li key={key} {...props}>
-          <Hb.Text variant="body2">{(option as SearchResultType).title}</Hb.Text>
+          <Hb.Text variant="body2">{(option).title}</Hb.Text>
         </li>
       )}
       renderInput={(params) => (

--- a/apps/hobom-system/src/pages/not-found/ui/NotFoundPage.tsx
+++ b/apps/hobom-system/src/pages/not-found/ui/NotFoundPage.tsx
@@ -37,7 +37,7 @@ export default function NotFoundPage() {
             variant="primary"
             size="small"
             onClick={() => {
-              navigate(-1);
+              void navigate(-1);
             }}
           >
             돌아가기

--- a/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
+++ b/apps/hobom-system/src/pages/privacy-law-layout/ui/PrivacyLawLayoutPage.tsx
@@ -56,7 +56,7 @@ const PrivacyLawLayoutPage = () => {
         onChange={(_, idx) => {
           const target = TABS[idx];
 
-          if (target) navigate(target.path);
+          if (target) void navigate(target.path);
         }}
         style={{
           borderBottom: 1,

--- a/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
+++ b/apps/hobom-system/src/pages/studio-workspace/ui/WorkspacePage.tsx
@@ -115,7 +115,7 @@ export default function WorkspacePage() {
       return;
     }
 
-    openItem(createDesign(activeFolder.id, `디자인 ${items.length + 1}`));
+    void openItem(createDesign(activeFolder.id, `디자인 ${items.length + 1}`));
   };
 
   const handleDeleteFolder = (event: MouseEvent, id: FolderId) => {

--- a/apps/hobom-system/src/shared/lib/delay.spec.ts
+++ b/apps/hobom-system/src/shared/lib/delay.spec.ts
@@ -12,7 +12,7 @@ describe("delayThen", () => {
   it("does not call the function before the delay has elapsed", async () => {
     const fn = vi.fn().mockResolvedValue("result");
 
-    delayThen(1000, fn);
+    void delayThen(1000, fn);
 
     expect(fn).not.toHaveBeenCalled();
 
@@ -23,7 +23,7 @@ describe("delayThen", () => {
   it("calls the function after the specified delay", async () => {
     const fn = vi.fn().mockResolvedValue("result");
 
-    delayThen(1000, fn);
+    void delayThen(1000, fn);
 
     await vi.runAllTimersAsync();
 

--- a/apps/hobom-system/src/shared/lib/funnel.lib.ts
+++ b/apps/hobom-system/src/shared/lib/funnel.lib.ts
@@ -25,26 +25,30 @@ export const createFunnelStorage = <T>(
   switch (storageType) {
     case "sessionStorage":
       return {
-        get: async () => {
+        get: () => {
           const d = sessionStorage.getItem(funnelStateId);
 
           if (d === null) {
-            return null;
+            return Promise.resolve(null);
           }
 
           try {
-            return JSON.parse(d) as Partial<T>;
+            return Promise.resolve(JSON.parse(d) as Partial<T>);
           } catch {
             sessionStorage.removeItem(funnelStateId);
 
-            return null;
+            return Promise.resolve(null);
           }
         },
-        set: async (value: Partial<T>) => {
+        set: (value: Partial<T>) => {
           sessionStorage.setItem(funnelStateId, JSON.stringify(value));
+
+          return Promise.resolve();
         },
-        clear: async () => {
+        clear: () => {
           sessionStorage.removeItem(funnelStateId);
+
+          return Promise.resolve();
         },
       };
 

--- a/apps/hobom-system/src/shared/model/useFunnel.tsx
+++ b/apps/hobom-system/src/shared/model/useFunnel.tsx
@@ -104,7 +104,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
 
       options?.onStepChange?.(step);
 
-      navigate(
+      void navigate(
         {
           pathname: location.pathname,
           search: `?${newSearch}`,
@@ -178,7 +178,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
     }
 
     return [
-      FunnelComponent as FunnelComponent<Steps>,
+      FunnelComponent,
       state as State,
       setState as (
         next:
@@ -194,7 +194,7 @@ export const useFunnel = <Steps extends NonEmptyArray<string>>(
       (step: Steps[number], options?: SetStepOptions) => void,
     ],
     { withState },
-  ) as UseFunnelReturn<Steps>;
+  );
 };
 
 const useQueryString = (name: string) => {
@@ -214,7 +214,7 @@ const useQueryString = (name: string) => {
   return {
     qsValue: value[name],
     set: (params: Record<string, string>) => {
-      navigate({
+      void navigate({
         pathname: `${location.pathname}`,
         search: new URLSearchParams({ ...value, ...params }).toString(),
       });

--- a/apps/hobom-system/src/shared/model/useFunnelState.ts
+++ b/apps/hobom-system/src/shared/model/useFunnelState.ts
@@ -22,11 +22,11 @@ export const useFunnelState = <T extends Record<string, unknown>>(
         if (typeof state === "function") {
           const newState = state(prev);
 
-          persistentStorage.set(newState);
+          void persistentStorage.set(newState);
 
           return newState;
         }
-        persistentStorage.set(state);
+        void persistentStorage.set(state);
 
         return state;
       });

--- a/apps/hobom-system/src/shared/model/useRouterQuery.ts
+++ b/apps/hobom-system/src/shared/model/useRouterQuery.ts
@@ -21,7 +21,7 @@ export const useRouterQuery = () => {
     (newParams: Record<string, string | undefined>, options: UpdateQueryOptions = {}) => {
       const next = applyParams(new URLSearchParams(search), newParams);
 
-      navigate(buildPath(pathname, next), { replace: options.replace });
+      void navigate(buildPath(pathname, next), { replace: options.replace });
     },
     [search, pathname, navigate],
   );

--- a/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
+++ b/apps/hobom-system/src/shared/ui/ErrorBoundary.tsx
@@ -53,7 +53,7 @@ class ErrorBoundaryInner extends Component<InternalProps, State> {
   }
 
   private handleReset = () => {
-    this.props.dataLot.invalidateQueries();
+    void this.props.dataLot.invalidateQueries();
     this.setState({ hasError: false, error: null });
   };
 

--- a/apps/hobom-system/src/shared/ui/Funnel.spec.tsx
+++ b/apps/hobom-system/src/shared/ui/Funnel.spec.tsx
@@ -69,7 +69,7 @@ describe("Funnel", () => {
     render(
       <Funnel steps={STEPS} step="step1">
         <Step name="step1">스텝 1</Step>
-        <Step name={"invalid" as never}>유효하지 않은 스텝</Step>
+        <Step name={"invalid"}>유효하지 않은 스텝</Step>
       </Funnel>,
     );
 

--- a/apps/hobom-system/src/test/fixtures/issue.fixture.ts
+++ b/apps/hobom-system/src/test/fixtures/issue.fixture.ts
@@ -13,4 +13,4 @@ export const makeIssue = (overrides: Partial<IssueType> = {}): IssueType =>
     reporter: "user-1",
     labels: [],
     ...overrides,
-  }) as IssueType;
+  });

--- a/apps/hobom-system/src/test/fixtures/note.fixture.ts
+++ b/apps/hobom-system/src/test/fixtures/note.fixture.ts
@@ -27,4 +27,4 @@ export const toRawNote = (note: NoteItemType): RawNoteItemType =>
     color: { value: note.color },
     labels: note.labels.map((l) => ({ value: l })),
     members: note.members.map((m) => ({ value: m })),
-  }) as unknown as RawNoteItemType;
+  });

--- a/apps/hobom-system/src/test/integration/authGuard.integration.spec.tsx
+++ b/apps/hobom-system/src/test/integration/authGuard.integration.spec.tsx
@@ -41,7 +41,7 @@ const AuthGuardHarness = () => {
       openWarnToast({
         message: "인증이 필요해요. 로그인 페이지로 이동합니다.",
       });
-      navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
+      void navigate(RoutesConfig.AUTH.LOGIN, { replace: true });
     };
 
     window.addEventListener(UNAUTHORIZED_EVENT, handler);

--- a/apps/hobom-system/src/widgets/notification-center/model/useNotificationCenter.ts
+++ b/apps/hobom-system/src/widgets/notification-center/model/useNotificationCenter.ts
@@ -15,7 +15,9 @@ export const useNotificationCenter = () => {
   const handleScroll = useInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
-    fetchNextPage,
+    fetchNextPage: () => {
+      void fetchNextPage();
+    },
   });
 
   const handleMarkRead = (n: NotificationItemType) => {

--- a/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.ts
+++ b/apps/hobom-system/src/widgets/project-layout/model/useProjectLayout.ts
@@ -55,12 +55,12 @@ export const useProjectLayout = () => {
   const showSprintButton = currentPath === "backlog";
 
   const handleNavigateToProjects = useCallback(() => {
-    navigate("/projects");
+    void navigate("/projects");
   }, [navigate]);
 
   const handleNavigateToTab = useCallback(
     (tabPath: string) => {
-      navigate(`/projects/${projectId}/${tabPath}`);
+      void navigate(`/projects/${projectId}/${tabPath}`);
     },
     [navigate, projectId],
   );

--- a/apps/hobom-system/src/widgets/wiki-page-view-workspace/model/usePageContent.ts
+++ b/apps/hobom-system/src/widgets/wiki-page-view-workspace/model/usePageContent.ts
@@ -27,7 +27,7 @@ export const usePageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId:
       {
         onSuccess: () => {
           setDeleteDialogOpen(false);
-          navigate(`/wiki/${spaceKey}`);
+          void navigate(`/wiki/${spaceKey}`);
         },
       },
     );
@@ -39,7 +39,7 @@ export const usePageContent = ({ spaceKey, pageId }: { spaceKey: string; pageId:
       {
         onSuccess: () => {
           setMoveDialogOpen(false);
-          navigate(`/wiki/${targetSpaceKey}`);
+          void navigate(`/wiki/${targetSpaceKey}`);
         },
       },
     );

--- a/apps/hobom-system/src/widgets/wiki-space-layout/model/useWikiSpaceLayout.ts
+++ b/apps/hobom-system/src/widgets/wiki-space-layout/model/useWikiSpaceLayout.ts
@@ -26,12 +26,12 @@ export const useWikiSpaceLayout = () => {
   const space = data.items;
 
   const handleNavigateToWiki = useCallback(() => {
-    navigate("/wiki");
+    void navigate("/wiki");
   }, [navigate]);
 
   const handlePageSelect = useCallback(
     (selectedPageId: string) => {
-      navigate(`/wiki/${spaceKey}/pages/${selectedPageId}`);
+      void navigate(`/wiki/${spaceKey}/pages/${selectedPageId}`);
     },
     [navigate, spaceKey],
   );

--- a/apps/hobom-system/src/widgets/wiki-space-list-workspace/model/useSpaceListWorkspace.ts
+++ b/apps/hobom-system/src/widgets/wiki-space-list-workspace/model/useSpaceListWorkspace.ts
@@ -16,7 +16,7 @@ export const useSpaceListWorkspace = () => {
   const deleteMutation = useDeleteSpace();
 
   const handleNavigateToSpace = (key: string) => {
-    navigate(`/wiki/${key}`);
+    void navigate(`/wiki/${key}`);
   };
 
   const handleCreateSpace = (data: { key: string; name: string; description: string }) => {


### PR DESCRIPTION
## What
Turns on typescript-eslint's **`recommendedTypeChecked`** for the app (via the project service), which catches promise-handling and type bugs the syntactic rules can't. Enabled **scoped** per the agreed plan:

- **`no-unsafe-*` family deferred** — those need the source of every `any` typed (a separate, larger effort). Turned off here with a note; tracked as a follow-up.
- **`no-misused-promises`** allows async JSX event handlers (`checksVoidReturn: { attributes: false }`) — idiomatic React, where the returned promise is discarded — while still flagging promises passed to genuine void callbacks (`forEach`, the router prefetch maps, infinite-scroll `fetchNextPage`, effect bodies).

## Fixes (no `!` / `as` / eslint-disable)
- **`no-floating-promises` (40):** `void` on fire-and-forget calls (`void navigate(...)`, `void invalidateQueries(...)`, unawaited test setup).
- **`no-misused-promises` (11 after config):** wrapped the risky sites — `forEach((fn) => { void fn(); })`, `fetchNextPage: () => { void fetchNextPage(); }`, and `onSuccess: () => { void (async () => {…})(); }` (preserving the awaited ordering).
- **`no-unnecessary-type-assertion` (31):** removed via `--fix` (redundant casts — a nice win given the no-`as` preference); cleaned up the type imports that became orphaned.
- **`require-await` (3):** `FunnelStorage` now returns real `Promise`s (keeps its async contract) instead of empty `async`.
- **`no-redundant-type-constituents` (1):** trimmed a `string | "text"` union.

Config/declaration files outside the TS build (`vitest.config.ts`, the rule `.d.ts`) lint under an inferred default project so type-aware rules don't choke.

## Verify
- app `tsc -b` clean; `pnpm lint` (all packages, `--max-warnings=0`) exit 0
- 602 app tests pass; build ok

## Follow-up
- The `no-unsafe-*` family (~81 sites) — type the `any` sources, then flip them on.
- Extend type-aware linting to the packages (`hobom-data`/`schema`/`utils`/DS).