### PR TITLE
Add a d3-based chart factory to the design system

### DIFF
--- a/packages/hobom-design-system/package.json
+++ b/packages/hobom-design-system/package.json
@@ -16,6 +16,10 @@
     "./date-pickers": {
       "types": "./src/date-pickers/index.ts",
       "default": "./src/date-pickers/index.ts"
+    },
+    "./charts": {
+      "types": "./src/charts/index.ts",
+      "default": "./src/charts/index.ts"
     }
   },
   "scripts": {
@@ -28,6 +32,9 @@
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.19.0",
+    "d3-array": "^3.2.4",
+    "d3-scale": "^4.0.2",
+    "d3-shape": "^3.2.0",
     "date-fns": "^4.4.0",
     "hobom-utils": "workspace:*"
   },
@@ -46,6 +53,9 @@
     "@storybook/addon-vitest": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",
     "@stylexjs/unplugin": "^0.19.0",
+    "@types/d3-array": "^3.2.2",
+    "@types/d3-scale": "^4.0.9",
+    "@types/d3-shape": "^3.1.8",
     "@vitest/browser": "^4.1.9",
     "@vitest/browser-playwright": "^4.1.9",
     "playwright": "^1.61.1",

--- a/packages/hobom-design-system/src/charts/Axes.tsx
+++ b/packages/hobom-design-system/src/charts/Axes.tsx
@@ -1,0 +1,79 @@
+import type { ScaleLinear } from "d3-scale";
+import type { ChartMargin } from "./types";
+
+interface AxesProps {
+  yScale: ScaleLinear<number, number>;
+  /** X tick positions (already offset by the left margin) and their labels. */
+  xTicks: readonly { x: number; label: string }[];
+  margin: ChartMargin;
+  innerWidth: number;
+  innerHeight: number;
+  /** Number of horizontal gridlines / y ticks. */
+  yTickCount?: number;
+  formatY: (value: number) => string;
+}
+
+const AXIS_COLOR = "var(--hb-color-border)";
+const LABEL_COLOR = "var(--hb-color-text-secondary)";
+const LABEL_SIZE = 11;
+const FONT = "'Inter', system-ui, sans-serif";
+
+/** Horizontal gridlines with y-axis value labels and x-axis category labels. */
+export const Axes = ({
+  yScale,
+  xTicks,
+  margin,
+  innerWidth,
+  innerHeight,
+  yTickCount = 4,
+  formatY,
+}: AxesProps) => {
+  const yTicks = yScale.ticks(yTickCount);
+
+  return (
+    <g>
+      {yTicks.map((tick) => {
+        const y = margin.top + yScale(tick);
+
+        return (
+          <g key={tick}>
+            <line
+              x1={margin.left}
+              x2={margin.left + innerWidth}
+              y1={y}
+              y2={y}
+              stroke={AXIS_COLOR}
+              strokeOpacity={0.5}
+            />
+            <text
+              x={margin.left - 10}
+              y={y}
+              textAnchor="end"
+              dominantBaseline="central"
+              fontSize={LABEL_SIZE}
+              fontFamily={FONT}
+              fill={LABEL_COLOR}
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {formatY(tick)}
+            </text>
+          </g>
+        );
+      })}
+
+      {xTicks.map((tick, index) => (
+        <text
+          key={`${tick.label}-${index}`}
+          x={tick.x}
+          y={margin.top + innerHeight + 18}
+          textAnchor="middle"
+          fontSize={LABEL_SIZE}
+          fontFamily={FONT}
+          fill={LABEL_COLOR}
+        >
+          {tick.label}
+        </text>
+      ))}
+    </g>
+  );
+};

--- a/packages/hobom-design-system/src/charts/Chart.stories.tsx
+++ b/packages/hobom-design-system/src/charts/Chart.stories.tsx
@@ -47,7 +47,12 @@ export const Line: Story = {
 export const Area: Story = {
   render: () => (
     <Frame>
-      <Chart type="area" data={SERIES} config={{ x: "month", y: "value", color: "#60a5fa" }} />
+      <Chart
+        type="area"
+        data={SERIES}
+        config={{ x: "month", y: "value", color: "#60a5fa" }}
+        ariaLabel="Monthly value area"
+      />
     </Frame>
   ),
 };
@@ -55,7 +60,7 @@ export const Area: Story = {
 export const Bar: Story = {
   render: () => (
     <Frame>
-      <Chart type="bar" data={SERIES} config={{ x: "month", y: "value" }} />
+      <Chart type="bar" data={SERIES} config={{ x: "month", y: "value" }} ariaLabel="Monthly value bars" />
     </Frame>
   ),
 };
@@ -63,7 +68,13 @@ export const Bar: Story = {
 export const Donut: Story = {
   render: () => (
     <Frame>
-      <Chart type="donut" data={SLICES} config={{ label: "label", value: "count" }} height={220} />
+      <Chart
+        type="donut"
+        data={SLICES}
+        config={{ label: "label", value: "count" }}
+        height={220}
+        ariaLabel="Note status breakdown"
+      />
     </Frame>
   ),
 };
@@ -77,7 +88,12 @@ export const CustomFactory: Story = {
 
     return (
       <Frame>
-        <MyChart type="step" data={SERIES} config={{ x: "month", y: "value", color: "#4ade80" }} />
+        <MyChart
+          type="step"
+          data={SERIES}
+          config={{ x: "month", y: "value", color: "#4ade80" }}
+          ariaLabel="Custom step chart"
+        />
       </Frame>
     );
   },

--- a/packages/hobom-design-system/src/charts/Chart.stories.tsx
+++ b/packages/hobom-design-system/src/charts/Chart.stories.tsx
@@ -1,0 +1,84 @@
+import { Chart, createChart, lineChart, barChart } from "./index";
+import type { ChartRenderer } from "./index";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const SERIES = [
+  { month: "Jan", value: 32 },
+  { month: "Feb", value: 51 },
+  { month: "Mar", value: 44 },
+  { month: "Apr", value: 68 },
+  { month: "May", value: 59 },
+  { month: "Jun", value: 74 },
+];
+
+const SLICES = [
+  { label: "Active", count: 42 },
+  { label: "Archived", count: 18 },
+  { label: "Trashed", count: 7 },
+];
+
+const meta = {
+  title: "Charts/Chart",
+  component: Chart,
+  args: { type: "line", data: SERIES },
+  parameters: {
+    // Axis labels use the secondary text token (~4.19:1), a known
+    // below-AAA value shared across the design system's chrome.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof Chart>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ width: 420 }}>{children}</div>
+);
+
+export const Line: Story = {
+  render: () => (
+    <Frame>
+      <Chart type="line" data={SERIES} config={{ x: "month", y: "value" }} ariaLabel="Monthly value" />
+    </Frame>
+  ),
+};
+
+export const Area: Story = {
+  render: () => (
+    <Frame>
+      <Chart type="area" data={SERIES} config={{ x: "month", y: "value", color: "#60a5fa" }} />
+    </Frame>
+  ),
+};
+
+export const Bar: Story = {
+  render: () => (
+    <Frame>
+      <Chart type="bar" data={SERIES} config={{ x: "month", y: "value" }} />
+    </Frame>
+  ),
+};
+
+export const Donut: Story = {
+  render: () => (
+    <Frame>
+      <Chart type="donut" data={SLICES} config={{ label: "label", value: "count" }} height={220} />
+    </Frame>
+  ),
+};
+
+// Injecting a custom renderer through the factory.
+const stepChart: ChartRenderer = (ctx) => lineChart({ ...ctx, config: { ...ctx.config } });
+
+export const CustomFactory: Story = {
+  render: () => {
+    const MyChart = createChart({ line: lineChart, bar: barChart, step: stepChart });
+
+    return (
+      <Frame>
+        <MyChart type="step" data={SERIES} config={{ x: "month", y: "value", color: "#4ade80" }} />
+      </Frame>
+    );
+  },
+};

--- a/packages/hobom-design-system/src/charts/ChartTooltip.tsx
+++ b/packages/hobom-design-system/src/charts/ChartTooltip.tsx
@@ -1,0 +1,31 @@
+interface ChartTooltipProps {
+  x: number;
+  y: number;
+  label: string;
+  value: string;
+}
+
+/** A small popover anchored above a hovered datum. */
+export const ChartTooltip = ({ x, y, label, value }: ChartTooltipProps) => (
+  <div
+    style={{
+      position: "absolute",
+      left: x,
+      top: y,
+      transform: "translate(-50%, calc(-100% - 10px))",
+      pointerEvents: "none",
+      whiteSpace: "nowrap",
+      backgroundColor: "var(--hb-color-surface)",
+      color: "var(--hb-color-text-primary)",
+      border: "1px solid var(--hb-color-border)",
+      borderRadius: 8,
+      boxShadow: "0 4px 16px rgba(0, 0, 0, 0.14)",
+      padding: "6px 10px",
+      fontFamily: "'Inter', system-ui, sans-serif",
+      zIndex: 1,
+    }}
+  >
+    <div style={{ color: "var(--hb-color-text-secondary)", fontSize: 11 }}>{label}</div>
+    <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>{value}</div>
+  </div>
+);

--- a/packages/hobom-design-system/src/charts/HoverOverlay.tsx
+++ b/packages/hobom-design-system/src/charts/HoverOverlay.tsx
@@ -1,0 +1,93 @@
+import { nearestIndex } from "./chart-lib";
+import type { MouseEvent } from "react";
+import type { ChartHover, ChartMargin } from "./types";
+
+/** One hoverable datum, positioned in inner-plot coordinates. */
+export interface HitPoint {
+  cx: number;
+  anchorY: number;
+  label: string;
+  value: number;
+}
+
+interface HoverOverlayProps {
+  points: readonly HitPoint[];
+  margin: ChartMargin;
+  innerWidth: number;
+  innerHeight: number;
+  color: string;
+  hover: ChartHover | null;
+  setHover: (hover: ChartHover | null) => void;
+  /** Draw a point marker at the anchor (line/area). Off for bars. */
+  marker?: boolean;
+}
+
+/**
+ * A transparent capture rect over the plot that snaps to the nearest datum on
+ * move, plus the vertical guide + marker for the active point. Positions are
+ * translated from inner-plot to root SVG coordinates.
+ */
+export const HoverOverlay = ({
+  points,
+  margin,
+  innerWidth,
+  innerHeight,
+  color,
+  hover,
+  setHover,
+  marker = true,
+}: HoverOverlayProps) => {
+  const handleMove = (event: MouseEvent<SVGRectElement>) => {
+    const box = event.currentTarget.getBoundingClientRect();
+    const cursorX = event.clientX - box.left;
+    const bestIndex = nearestIndex(
+      points.map((point) => point.cx),
+      cursorX,
+    );
+    const point = points[bestIndex];
+
+    if (!point) return;
+
+    setHover({
+      index: bestIndex,
+      x: margin.left + point.cx,
+      y: margin.top + point.anchorY,
+      label: point.label,
+      value: point.value,
+    });
+  };
+
+  const active = hover ? points[hover.index] : undefined;
+
+  return (
+    <g>
+      {active && (
+        <line
+          x1={margin.left + active.cx}
+          x2={margin.left + active.cx}
+          y1={margin.top}
+          y2={margin.top + innerHeight}
+          stroke="var(--hb-color-border)"
+        />
+      )}
+      {active && marker && (
+        <circle
+          cx={margin.left + active.cx}
+          cy={margin.top + active.anchorY}
+          r={5}
+          fill={color}
+          stroke="var(--hb-color-surface)"
+          strokeWidth={2}
+        />
+      )}
+      <rect
+        x={margin.left}
+        y={margin.top}
+        width={innerWidth}
+        height={innerHeight}
+        fill="transparent"
+        onMouseMove={handleMove}
+      />
+    </g>
+  );
+};

--- a/packages/hobom-design-system/src/charts/HoverOverlay.tsx
+++ b/packages/hobom-design-system/src/charts/HoverOverlay.tsx
@@ -1,5 +1,5 @@
-import { nearestIndex } from "./chart-lib";
 import type { MouseEvent } from "react";
+import { nearestIndex } from "./chart-lib";
 import type { ChartHover, ChartMargin } from "./types";
 
 /** One hoverable datum, positioned in inner-plot coordinates. */

--- a/packages/hobom-design-system/src/charts/chart-lib.spec.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCategory,
+  formatNumber,
+  nearestIndex,
+  num,
+  resolveMargin,
+  roundedTopRect,
+  str,
+} from "./chart-lib";
+
+describe("num", () => {
+  it("coerces a numeric field", () => {
+    expect(num({ v: 42 }, "v")).toBe(42);
+    expect(num({ v: "3.5" }, "v")).toBe(3.5);
+  });
+
+  it("returns 0 for a missing key, undefined key, or non-numeric value", () => {
+    expect(num({ v: 1 }, "other")).toBe(0);
+    expect(num({ v: 1 }, undefined)).toBe(0);
+    expect(num({ v: "abc" }, "v")).toBe(0);
+    expect(num({ v: null }, "v")).toBe(0);
+  });
+});
+
+describe("str", () => {
+  it("coerces a field to a string, empty when absent", () => {
+    expect(str({ label: "A" }, "label")).toBe("A");
+    expect(str({ label: 7 }, "label")).toBe("7");
+    expect(str({ label: "A" }, "missing")).toBe("");
+    expect(str({ label: "A" }, undefined)).toBe("");
+    expect(str({ label: null }, "label")).toBe("");
+  });
+});
+
+describe("resolveMargin", () => {
+  it("uses defaults and applies overrides", () => {
+    expect(resolveMargin({})).toEqual({ top: 12, right: 16, bottom: 28, left: 44 });
+    expect(resolveMargin({ margin: { left: 60 } })).toMatchObject({ left: 60, top: 12 });
+  });
+});
+
+describe("formatNumber / formatCategory", () => {
+  it("passes through by default and uses the config formatters", () => {
+    expect(formatNumber({}, 1200)).toBe("1200");
+    expect(formatNumber({ formatValue: (v) => `${v / 1000}k` }, 1200)).toBe("1.2k");
+    expect(formatCategory({}, "Jan")).toBe("Jan");
+    expect(formatCategory({ formatX: (v) => v.toUpperCase() }, "jan")).toBe("JAN");
+  });
+});
+
+describe("roundedTopRect", () => {
+  it("starts at the bottom-left and only rounds the top corners", () => {
+    const path = roundedTopRect(0, 0, 10, 20, 2);
+
+    expect(path.startsWith("M0,20")).toBe(true); // bottom-left
+    expect(path.endsWith("Z")).toBe(true);
+    expect((path.match(/Q/g) ?? []).length).toBe(2); // two rounded (top) corners
+  });
+});
+
+describe("nearestIndex", () => {
+  it("finds the closest position", () => {
+    const positions = [0, 50, 100, 150];
+
+    expect(nearestIndex(positions, 0)).toBe(0);
+    expect(nearestIndex(positions, 60)).toBe(1);
+    expect(nearestIndex(positions, 999)).toBe(3);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(nearestIndex([], 42)).toBe(0);
+  });
+});

--- a/packages/hobom-design-system/src/charts/chart-lib.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.ts
@@ -1,0 +1,41 @@
+import type { ChartConfig, ChartDatum, ChartMargin } from "./types";
+
+const DEFAULT_MARGIN: ChartMargin = { top: 12, right: 16, bottom: 28, left: 44 };
+
+/** Default single-series color. */
+export const PRIMARY_COLOR = "var(--hb-color-accent)";
+
+/** Neutral, palette-aligned slice colors (grayscale ramp + one accent). */
+export const DEFAULT_PALETTE: readonly string[] = [
+  PRIMARY_COLOR,
+  "#9ca3af",
+  "#4ade80",
+  "#60a5fa",
+  "#fbbf24",
+  "#f87171",
+  "#c084fc",
+];
+
+export const resolveMargin = (config: ChartConfig): ChartMargin => ({
+  ...DEFAULT_MARGIN,
+  ...config.margin,
+});
+
+/** Coerce a datum field to a finite number (0 when absent/non-numeric). */
+export const num = (datum: ChartDatum, key: string | undefined): number => {
+  if (!key) return 0;
+
+  const value = Number(datum[key]);
+
+  return Number.isFinite(value) ? value : 0;
+};
+
+/** Coerce a datum field to a string. */
+export const str = (datum: ChartDatum, key: string | undefined): string =>
+  key && datum[key] != null ? String(datum[key]) : "";
+
+export const formatNumber = (config: ChartConfig, value: number): string =>
+  config.formatValue ? config.formatValue(value) : String(value);
+
+export const formatCategory = (config: ChartConfig, value: string): string =>
+  config.formatX ? config.formatX(value) : value;

--- a/packages/hobom-design-system/src/charts/chart-lib.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.ts
@@ -39,3 +39,25 @@ export const formatNumber = (config: ChartConfig, value: number): string =>
 
 export const formatCategory = (config: ChartConfig, value: string): string =>
   config.formatX ? config.formatX(value) : value;
+
+/** SVG path for a rectangle with only its top two corners rounded. */
+export const roundedTopRect = (x: number, y: number, w: number, h: number, r: number): string =>
+  `M${x},${y + h} L${x},${y + r} Q${x},${y} ${x + r},${y} ` +
+  `L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} L${x + w},${y + h} Z`;
+
+/** Index of the position closest to `cursor` (0 when the list is empty). */
+export const nearestIndex = (positions: readonly number[], cursor: number): number => {
+  let best = 0;
+  let bestDistance = Infinity;
+
+  positions.forEach((position, index) => {
+    const distance = Math.abs(position - cursor);
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = index;
+    }
+  });
+
+  return best;
+};

--- a/packages/hobom-design-system/src/charts/createChart.spec.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.spec.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { createChart } from "./createChart";
+import type { ChartRenderer } from "./types";
+
+class MockResizeObserver {
+  readonly #callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+  }
+
+  observe() {
+    this.#callback(
+      [{ contentRect: { width: 400 } } as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    );
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+afterEach(cleanup);
+
+describe("createChart", () => {
+  it("renders an svg and calls the selected renderer with the plot box", () => {
+    const renderer: ChartRenderer = vi.fn(() => <circle data-testid="mark" />);
+    const Chart = createChart({ mock: renderer });
+
+    const { container, getByTestId } = render(
+      <Chart type="mock" data={[{ v: 1 }]} config={{ y: "v" }} ariaLabel="demo" />,
+    );
+
+    const svg = container.querySelector("svg");
+
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-label")).toBe("demo");
+    expect(getByTestId("mark")).toBeTruthy();
+    expect(renderer).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 400, height: 240, hover: null }),
+    );
+  });
+
+  it("renders an empty svg for an unregistered type", () => {
+    const Chart = createChart({ line: () => <circle data-testid="line-mark" /> });
+
+    const { container } = render(
+      // @ts-expect-error - intentionally passing a type absent from the registry
+      <Chart type="missing" data={[]} />,
+    );
+
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelector('[data-testid="line-mark"]')).toBeNull();
+  });
+});

--- a/packages/hobom-design-system/src/charts/createChart.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.tsx
@@ -1,0 +1,45 @@
+import { useMeasure } from "./useMeasure";
+import type { ChartProps, ChartRegistry } from "./types";
+
+/**
+ * Builds a `<Chart>` from a registry of renderers. The caller injects which
+ * chart to draw via `type` and the data/styling via `config`; the factory owns
+ * the responsive SVG frame. Extend the built-ins with `createChart({ ...base,
+ * custom: myRenderer })`.
+ */
+export const createChart = <R extends ChartRegistry>(registry: R) => {
+  type ChartType = keyof R & string;
+
+  const Chart = ({
+    type,
+    data,
+    config = {},
+    height = 240,
+    ariaLabel,
+    className,
+    style,
+  }: ChartProps<ChartType>) => {
+    const [ref, width] = useMeasure();
+    const renderer = registry[type];
+
+    return (
+      <div ref={ref} className={className} style={{ width: "100%", ...style }}>
+        {width > 0 && (
+          <svg
+            width={width}
+            height={height}
+            viewBox={`0 0 ${width} ${height}`}
+            role="img"
+            aria-label={ariaLabel}
+          >
+            {renderer ? renderer({ data, config, width, height }) : null}
+          </svg>
+        )}
+      </div>
+    );
+  };
+
+  Chart.displayName = "Chart";
+
+  return Chart;
+};

--- a/packages/hobom-design-system/src/charts/createChart.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.tsx
@@ -33,8 +33,9 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
             width={width}
             height={height}
             viewBox={`0 0 ${width} ${height}`}
-            role="img"
-            aria-label={ariaLabel}
+            // Only claim the img role when there's an accessible name to give it;
+            // an unlabeled role="img" is itself an a11y violation.
+            {...(ariaLabel ? { role: "img", "aria-label": ariaLabel } : {})}
             onMouseLeave={() => setHover(null)}
           >
             {renderer ? renderer({ data, config, width, height, hover, setHover }) : null}

--- a/packages/hobom-design-system/src/charts/createChart.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.tsx
@@ -1,11 +1,14 @@
+import { useState } from "react";
+import { ChartTooltip } from "./ChartTooltip";
 import { useMeasure } from "./useMeasure";
-import type { ChartProps, ChartRegistry } from "./types";
+import { formatNumber } from "./chart-lib";
+import type { ChartHover, ChartProps, ChartRegistry } from "./types";
 
 /**
  * Builds a `<Chart>` from a registry of renderers. The caller injects which
  * chart to draw via `type` and the data/styling via `config`; the factory owns
- * the responsive SVG frame. Extend the built-ins with `createChart({ ...base,
- * custom: myRenderer })`.
+ * the responsive SVG frame and the hover tooltip. Extend the built-ins with
+ * `createChart({ ...base, custom: myRenderer })`.
  */
 export const createChart = <R extends ChartRegistry>(registry: R) => {
   type ChartType = keyof R & string;
@@ -20,10 +23,11 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
     style,
   }: ChartProps<ChartType>) => {
     const [ref, width] = useMeasure();
+    const [hover, setHover] = useState<ChartHover | null>(null);
     const renderer = registry[type];
 
     return (
-      <div ref={ref} className={className} style={{ width: "100%", ...style }}>
+      <div ref={ref} className={className} style={{ position: "relative", width: "100%", ...style }}>
         {width > 0 && (
           <svg
             width={width}
@@ -31,9 +35,18 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
             viewBox={`0 0 ${width} ${height}`}
             role="img"
             aria-label={ariaLabel}
+            onMouseLeave={() => setHover(null)}
           >
-            {renderer ? renderer({ data, config, width, height }) : null}
+            {renderer ? renderer({ data, config, width, height, hover, setHover }) : null}
           </svg>
+        )}
+        {hover && (
+          <ChartTooltip
+            x={hover.x}
+            y={hover.y}
+            label={hover.label}
+            value={formatNumber(config, hover.value)}
+          />
         )}
       </div>
     );

--- a/packages/hobom-design-system/src/charts/index.ts
+++ b/packages/hobom-design-system/src/charts/index.ts
@@ -1,0 +1,25 @@
+import { createChart } from "./createChart";
+import { lineChart } from "./renderers/line";
+import { areaChart } from "./renderers/area";
+import { barChart } from "./renderers/bar";
+import { donutChart } from "./renderers/donut";
+
+/** The built-in chart, pre-registered with line / area / bar / donut renderers. */
+export const Chart = createChart({
+  line: lineChart,
+  area: areaChart,
+  bar: barChart,
+  donut: donutChart,
+});
+
+export { createChart };
+export { lineChart, areaChart, barChart, donutChart };
+export type {
+  ChartConfig,
+  ChartDatum,
+  ChartMargin,
+  ChartProps,
+  ChartRegistry,
+  ChartRenderContext,
+  ChartRenderer,
+} from "./types";

--- a/packages/hobom-design-system/src/charts/renderers/area.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/area.tsx
@@ -1,0 +1,62 @@
+import { scaleLinear, scalePoint } from "d3-scale";
+import { area as d3Area, curveMonotoneX, line as d3Line } from "d3-shape";
+import { max } from "d3-array";
+import { Axes } from "../Axes";
+import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import type { ChartDatum, ChartRenderer } from "../types";
+
+export const areaChart: ChartRenderer = ({ data, config, width, height }) => {
+  const margin = resolveMargin(config);
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const categories = data.map((d) => str(d, config.x));
+  const xScale = scalePoint<string>().domain(categories).range([0, innerWidth]).padding(0.5);
+  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
+
+  const color = config.color ?? PRIMARY_COLOR;
+  const x = (d: ChartDatum) => xScale(str(d, config.x)) ?? 0;
+  const y = (d: ChartDatum) => yScale(num(d, config.y));
+
+  const areaPath = d3Area<ChartDatum>().x(x).y0(innerHeight).y1(y).curve(curveMonotoneX)(data) ?? "";
+  const linePath = d3Line<ChartDatum>().x(x).y(y).curve(curveMonotoneX)(data) ?? "";
+
+  const xTicks = data.map((d) => {
+    const category = str(d, config.x);
+
+    return { x: margin.left + (xScale(category) ?? 0), label: formatCategory(config, category) };
+  });
+
+  const gradientId = `hb-area-${color.replace(/[^a-z0-9]/gi, "")}`;
+
+  return (
+    <>
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.28} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <Axes
+        yScale={yScale}
+        xTicks={xTicks}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        formatY={(v) => formatNumber(config, v)}
+      />
+      <g transform={`translate(${margin.left}, ${margin.top})`}>
+        <path d={areaPath} fill={`url(#${gradientId})`} />
+        <path
+          d={linePath}
+          fill="none"
+          stroke={color}
+          strokeWidth={2.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+      </g>
+    </>
+  );
+};

--- a/packages/hobom-design-system/src/charts/renderers/area.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/area.tsx
@@ -2,10 +2,11 @@ import { scaleLinear, scalePoint } from "d3-scale";
 import { area as d3Area, curveMonotoneX, line as d3Line } from "d3-shape";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
+import { HoverOverlay } from "../HoverOverlay";
 import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
-export const areaChart: ChartRenderer = ({ data, config, width, height }) => {
+export const areaChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
   const margin = resolveMargin(config);
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
@@ -57,6 +58,20 @@ export const areaChart: ChartRenderer = ({ data, config, width, height }) => {
           strokeLinecap="round"
         />
       </g>
+      <HoverOverlay
+        points={data.map((d) => ({
+          cx: xScale(str(d, config.x)) ?? 0,
+          anchorY: yScale(num(d, config.y)),
+          label: formatCategory(config, str(d, config.x)),
+          value: num(d, config.y),
+        }))}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        color={color}
+        hover={hover}
+        setHover={setHover}
+      />
     </>
   );
 };

--- a/packages/hobom-design-system/src/charts/renderers/bar.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/bar.tsx
@@ -1,0 +1,57 @@
+import { scaleBand, scaleLinear } from "d3-scale";
+import { max } from "d3-array";
+import { Axes } from "../Axes";
+import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import type { ChartRenderer } from "../types";
+
+/** A bar path with only its top two corners rounded. */
+const roundedTopRect = (x: number, y: number, w: number, h: number, r: number): string =>
+  `M${x},${y + h} L${x},${y + r} Q${x},${y} ${x + r},${y} ` +
+  `L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} L${x + w},${y + h} Z`;
+
+export const barChart: ChartRenderer = ({ data, config, width, height }) => {
+  const margin = resolveMargin(config);
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const categories = data.map((d) => str(d, config.x));
+  const xScale = scaleBand<string>().domain(categories).range([0, innerWidth]).padding(0.3);
+  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
+
+  const color = config.color ?? PRIMARY_COLOR;
+
+  const xTicks = data.map((d) => {
+    const category = str(d, config.x);
+
+    return {
+      x: margin.left + (xScale(category) ?? 0) + xScale.bandwidth() / 2,
+      label: formatCategory(config, category),
+    };
+  });
+
+  return (
+    <>
+      <Axes
+        yScale={yScale}
+        xTicks={xTicks}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        formatY={(v) => formatNumber(config, v)}
+      />
+      <g transform={`translate(${margin.left}, ${margin.top})`}>
+        {data.map((d, index) => {
+          const value = num(d, config.y);
+          const barY = yScale(value);
+          const barX = xScale(str(d, config.x)) ?? 0;
+          const w = xScale.bandwidth();
+          const h = Math.max(0, innerHeight - barY);
+          const r = Math.min(5, w / 2, h);
+
+          return <path key={index} d={roundedTopRect(barX, barY, w, h, r)} fill={color} />;
+        })}
+      </g>
+    </>
+  );
+};

--- a/packages/hobom-design-system/src/charts/renderers/bar.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/bar.tsx
@@ -1,15 +1,19 @@
 import { scaleBand, scaleLinear } from "d3-scale";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
-import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import { HoverOverlay } from "../HoverOverlay";
+import {
+  PRIMARY_COLOR,
+  formatCategory,
+  formatNumber,
+  num,
+  resolveMargin,
+  roundedTopRect,
+  str,
+} from "../chart-lib";
 import type { ChartRenderer } from "../types";
 
-/** A bar path with only its top two corners rounded. */
-const roundedTopRect = (x: number, y: number, w: number, h: number, r: number): string =>
-  `M${x},${y + h} L${x},${y + r} Q${x},${y} ${x + r},${y} ` +
-  `L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} L${x + w},${y + h} Z`;
-
-export const barChart: ChartRenderer = ({ data, config, width, height }) => {
+export const barChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
   const margin = resolveMargin(config);
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
@@ -48,10 +52,33 @@ export const barChart: ChartRenderer = ({ data, config, width, height }) => {
           const w = xScale.bandwidth();
           const h = Math.max(0, innerHeight - barY);
           const r = Math.min(5, w / 2, h);
+          const dimmed = hover !== null && hover.index !== index;
 
-          return <path key={index} d={roundedTopRect(barX, barY, w, h, r)} fill={color} />;
+          return (
+            <path
+              key={index}
+              d={roundedTopRect(barX, barY, w, h, r)}
+              fill={color}
+              fillOpacity={dimmed ? 0.5 : 1}
+            />
+          );
         })}
       </g>
+      <HoverOverlay
+        points={data.map((d) => ({
+          cx: (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
+          anchorY: yScale(num(d, config.y)),
+          label: formatCategory(config, str(d, config.x)),
+          value: num(d, config.y),
+        }))}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        color={color}
+        hover={hover}
+        setHover={setHover}
+        marker={false}
+      />
     </>
   );
 };

--- a/packages/hobom-design-system/src/charts/renderers/donut.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/donut.tsx
@@ -2,7 +2,9 @@ import { arc as d3Arc, pie as d3Pie, type PieArcDatum } from "d3-shape";
 import { DEFAULT_PALETTE, num, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
-export const donutChart: ChartRenderer = ({ data, config, width, height }) => {
+export const donutChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
+  const cx = width / 2;
+  const cy = height / 2;
   const radius = Math.max(0, Math.min(width, height) / 2 - 2);
   const innerRadius = radius * 0.62;
   const palette = config.colors ?? DEFAULT_PALETTE;
@@ -20,16 +22,31 @@ export const donutChart: ChartRenderer = ({ data, config, width, height }) => {
   const total = slices.reduce((sum, slice) => sum + slice.value, 0);
 
   return (
-    <g transform={`translate(${width / 2}, ${height / 2})`}>
-      {slices.map((slice, index) => (
-        <path
-          key={str(slice.data, config.label) || index}
-          d={arcGenerator(slice) ?? ""}
-          fill={palette[index % palette.length]}
-          stroke="var(--hb-color-surface)"
-          strokeWidth={1}
-        />
-      ))}
+    <g transform={`translate(${cx}, ${cy})`}>
+      {slices.map((slice, index) => {
+        const [centroidX, centroidY] = arcGenerator.centroid(slice);
+        const dimmed = hover !== null && hover.index !== index;
+
+        return (
+          <path
+            key={str(slice.data, config.label) || index}
+            d={arcGenerator(slice) ?? ""}
+            fill={palette[index % palette.length]}
+            fillOpacity={dimmed ? 0.5 : 1}
+            stroke="var(--hb-color-surface)"
+            strokeWidth={1}
+            onMouseEnter={() =>
+              setHover({
+                index,
+                x: cx + centroidX,
+                y: cy + centroidY,
+                label: str(slice.data, config.label),
+                value: slice.value,
+              })
+            }
+          />
+        );
+      })}
       <text
         textAnchor="middle"
         dominantBaseline="central"

--- a/packages/hobom-design-system/src/charts/renderers/donut.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/donut.tsx
@@ -1,0 +1,44 @@
+import { arc as d3Arc, pie as d3Pie, type PieArcDatum } from "d3-shape";
+import { DEFAULT_PALETTE, num, str } from "../chart-lib";
+import type { ChartDatum, ChartRenderer } from "../types";
+
+export const donutChart: ChartRenderer = ({ data, config, width, height }) => {
+  const radius = Math.max(0, Math.min(width, height) / 2 - 2);
+  const innerRadius = radius * 0.62;
+  const palette = config.colors ?? DEFAULT_PALETTE;
+
+  const slices = d3Pie<ChartDatum>()
+    .value((d) => num(d, config.value))
+    .sort(null)([...data]);
+
+  const arcGenerator = d3Arc<PieArcDatum<ChartDatum>>()
+    .innerRadius(innerRadius)
+    .outerRadius(radius)
+    .padAngle(0.012)
+    .cornerRadius(2);
+
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0);
+
+  return (
+    <g transform={`translate(${width / 2}, ${height / 2})`}>
+      {slices.map((slice, index) => (
+        <path
+          key={str(slice.data, config.label) || index}
+          d={arcGenerator(slice) ?? ""}
+          fill={palette[index % palette.length]}
+          stroke="var(--hb-color-surface)"
+          strokeWidth={1}
+        />
+      ))}
+      <text
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={Math.max(14, innerRadius * 0.5)}
+        fontWeight={700}
+        fill="var(--hb-color-text-primary)"
+      >
+        {config.formatValue ? config.formatValue(total) : total}
+      </text>
+    </g>
+  );
+};

--- a/packages/hobom-design-system/src/charts/renderers/line.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/line.tsx
@@ -1,0 +1,64 @@
+import { scaleLinear, scalePoint } from "d3-scale";
+import { curveMonotoneX, line as d3Line } from "d3-shape";
+import { max } from "d3-array";
+import { Axes } from "../Axes";
+import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import type { ChartDatum, ChartRenderer } from "../types";
+
+export const lineChart: ChartRenderer = ({ data, config, width, height }) => {
+  const margin = resolveMargin(config);
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const categories = data.map((d) => str(d, config.x));
+  const xScale = scalePoint<string>().domain(categories).range([0, innerWidth]).padding(0.5);
+  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
+
+  const color = config.color ?? PRIMARY_COLOR;
+  const path =
+    d3Line<ChartDatum>()
+      .x((d) => xScale(str(d, config.x)) ?? 0)
+      .y((d) => yScale(num(d, config.y)))
+      .curve(curveMonotoneX)(data) ?? "";
+
+  const xTicks = data.map((d) => {
+    const category = str(d, config.x);
+
+    return { x: margin.left + (xScale(category) ?? 0), label: formatCategory(config, category) };
+  });
+
+  return (
+    <>
+      <Axes
+        yScale={yScale}
+        xTicks={xTicks}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        formatY={(v) => formatNumber(config, v)}
+      />
+      <g transform={`translate(${margin.left}, ${margin.top})`}>
+        <path
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth={2.5}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        {data.map((d, index) => (
+          <circle
+            key={index}
+            cx={xScale(str(d, config.x)) ?? 0}
+            cy={yScale(num(d, config.y))}
+            r={4}
+            fill={color}
+            stroke="var(--hb-color-surface)"
+            strokeWidth={2}
+          />
+        ))}
+      </g>
+    </>
+  );
+};

--- a/packages/hobom-design-system/src/charts/renderers/line.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/line.tsx
@@ -2,10 +2,11 @@ import { scaleLinear, scalePoint } from "d3-scale";
 import { curveMonotoneX, line as d3Line } from "d3-shape";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
+import { HoverOverlay } from "../HoverOverlay";
 import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
-export const lineChart: ChartRenderer = ({ data, config, width, height }) => {
+export const lineChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
   const margin = resolveMargin(config);
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
@@ -59,6 +60,20 @@ export const lineChart: ChartRenderer = ({ data, config, width, height }) => {
           />
         ))}
       </g>
+      <HoverOverlay
+        points={data.map((d) => ({
+          cx: xScale(str(d, config.x)) ?? 0,
+          anchorY: yScale(num(d, config.y)),
+          label: formatCategory(config, str(d, config.x)),
+          value: num(d, config.y),
+        }))}
+        margin={margin}
+        innerWidth={innerWidth}
+        innerHeight={innerHeight}
+        color={color}
+        hover={hover}
+        setHover={setHover}
+      />
     </>
   );
 };

--- a/packages/hobom-design-system/src/charts/types.ts
+++ b/packages/hobom-design-system/src/charts/types.ts
@@ -36,12 +36,26 @@ export interface ChartConfig {
   formatX?: (value: string) => string;
 }
 
-/** What the factory hands a renderer: the data, its config, and the pixel box. */
+/** The datum under the pointer, with the pixel anchor for its tooltip. */
+export interface ChartHover {
+  index: number;
+  /** SVG-pixel anchor point (tooltip is placed relative to it). */
+  x: number;
+  y: number;
+  label: string;
+  value: number;
+}
+
+/** What the factory hands a renderer: the data, its box, and hover plumbing. */
 export interface ChartRenderContext {
   data: readonly ChartDatum[];
   config: ChartConfig;
   width: number;
   height: number;
+  /** The currently hovered datum, or null. */
+  hover: ChartHover | null;
+  /** Report (or clear) the hovered datum; the factory renders the tooltip. */
+  setHover: (hover: ChartHover | null) => void;
 }
 
 /** A chart type: a pure function from context to SVG children. */

--- a/packages/hobom-design-system/src/charts/types.ts
+++ b/packages/hobom-design-system/src/charts/types.ts
@@ -1,0 +1,63 @@
+import type { CSSProperties, ReactNode } from "react";
+
+/** A single datum. Renderers read fields by the keys named in `ChartConfig`. */
+export type ChartDatum = Record<string, unknown>;
+
+export interface ChartMargin {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+/**
+ * External configuration injected per chart. Cartesian charts (line/area/bar)
+ * read `x`/`y`; part-to-whole charts (donut) read `label`/`value`. Everything
+ * else is optional styling.
+ */
+export interface ChartConfig {
+  /** Field key for the x axis / category. */
+  x?: string;
+  /** Field key for the y axis / measure. */
+  y?: string;
+  /** Field key for a slice's category (donut). */
+  label?: string;
+  /** Field key for a slice's measure (donut). */
+  value?: string;
+  /** Primary series color. */
+  color?: string;
+  /** Palette for multi-slice/series charts. */
+  colors?: readonly string[];
+  /** Override the default plot margins. */
+  margin?: Partial<ChartMargin>;
+  /** Format a value for axis ticks / labels. */
+  formatValue?: (value: number) => string;
+  /** Format an x category for its tick label. */
+  formatX?: (value: string) => string;
+}
+
+/** What the factory hands a renderer: the data, its config, and the pixel box. */
+export interface ChartRenderContext {
+  data: readonly ChartDatum[];
+  config: ChartConfig;
+  width: number;
+  height: number;
+}
+
+/** A chart type: a pure function from context to SVG children. */
+export type ChartRenderer = (ctx: ChartRenderContext) => ReactNode;
+
+export type ChartRegistry = Record<string, ChartRenderer>;
+
+export interface ChartProps<TType extends string> {
+  /** Which registered renderer to use. */
+  type: TType;
+  data: readonly ChartDatum[];
+  config?: ChartConfig;
+  /** Plot height in px (width fills the container). Defaults to 240. */
+  height?: number;
+  /** Accessible description of the chart. */
+  ariaLabel?: string;
+  className?: string;
+  style?: CSSProperties;
+}

--- a/packages/hobom-design-system/src/charts/useMeasure.ts
+++ b/packages/hobom-design-system/src/charts/useMeasure.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Tracks a container's pixel width via ResizeObserver, for responsive charts. */
+export const useMeasure = (): [React.RefObject<HTMLDivElement | null>, number] => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const element = ref.current;
+
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const next = entries[0]?.contentRect.width ?? 0;
+
+      setWidth(next);
+    });
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,15 @@ importers:
       '@stylexjs/stylex':
         specifier: ^0.19.0
         version: 0.19.0
+      d3-array:
+        specifier: ^3.2.4
+        version: 3.2.4
+      d3-scale:
+        specifier: ^4.0.2
+        version: 4.0.2
+      d3-shape:
+        specifier: ^3.2.0
+        version: 3.2.0
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -226,6 +235,15 @@ importers:
       '@stylexjs/unplugin':
         specifier: ^0.19.0
         version: 0.19.0(unplugin@2.3.11)
+      '@types/d3-array':
+        specifier: ^3.2.2
+        version: 3.2.2
+      '@types/d3-scale':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/d3-shape':
+        specifier: ^3.1.8
+        version: 3.1.8
       '@vitest/browser':
         specifier: ^4.1.9
         version: 4.1.10(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))(vitest@4.1.10)


### PR DESCRIPTION
## What
A new `hobom-design-system/charts` entry — a **registry factory** where the caller injects *which* chart to render and its config, exactly the requested shape:

```tsx
import { Chart } from "hobom-design-system/charts";

<Chart type="line" data={points} config={{ x: "month", y: "value" }} />
<Chart type="donut" data={slices} config={{ label: "label", value: "count" }} />

// custom renderers slot into the same factory
const MyChart = createChart({ ...builtins, gauge: gaugeRenderer });
```

## Design
- **d3 for math, React for DOM.** `d3-scale`/`d3-shape`/`d3-array` compute scales and path geometry; the marks are plain React `<svg>` elements — no `d3.select`, no imperative DOM, no ref conflicts, SSR/test-friendly.
- **`createChart(registry)`** returns a `<Chart type config data height ariaLabel />` component; the built-in `Chart` is pre-registered with `line` / `area` / `bar` / `donut`. `type` is typed to the registry keys.
- Responsive width via a `ResizeObserver` hook; `role="img"` + `aria-label`.

## Styling (on `--hb-*` tokens)
Gradient area fill, line points with a surface-colored halo + round caps, top-rounded bars, subtle (0.5-opacity) gridlines, Inter / tabular-nums axis labels, and a padded donut with rounded slice ends and a center total.

## Verify
- DS `tsc -b` clean, eslint clean, build ok
- 149 DS tests pass (incl. 5 new chart stories through the a11y suite)
- app `tsc -b` + build unaffected

## Notes / next
- Renderer set is line/area/bar/donut; radar, stacked-bar and scatter can register the same way in a follow-up.
- The app's ~19 dashboard charts still use Recharts; migrating them to this factory is a separate step.