### PR TITLE
Add multi-series and legends to the charts

### DIFF
--- a/packages/hobom-design-system/src/charts/Chart.stories.tsx
+++ b/packages/hobom-design-system/src/charts/Chart.stories.tsx
@@ -17,6 +17,20 @@ const SLICES = [
   { label: "Trashed", count: 7 },
 ];
 
+const MULTI = [
+  { month: "Jan", sent: 32, opened: 20 },
+  { month: "Feb", sent: 51, opened: 34 },
+  { month: "Mar", sent: 44, opened: 30 },
+  { month: "Apr", sent: 68, opened: 41 },
+  { month: "May", sent: 59, opened: 45 },
+  { month: "Jun", sent: 74, opened: 52 },
+];
+
+const SENT_OPENED = [
+  { key: "sent", label: "Sent" },
+  { key: "opened", label: "Opened" },
+];
+
 const meta = {
   title: "Charts/Chart",
   component: Chart,
@@ -74,6 +88,32 @@ export const Donut: Story = {
         config={{ label: "label", value: "count" }}
         height={220}
         ariaLabel="Note status breakdown"
+      />
+    </Frame>
+  ),
+};
+
+export const MultiSeriesLine: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="line"
+        data={MULTI}
+        config={{ x: "month", series: SENT_OPENED }}
+        ariaLabel="Sent vs opened over time"
+      />
+    </Frame>
+  ),
+};
+
+export const MultiSeriesBar: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="bar"
+        data={MULTI}
+        config={{ x: "month", series: SENT_OPENED }}
+        ariaLabel="Sent vs opened by month"
       />
     </Frame>
   ),

--- a/packages/hobom-design-system/src/charts/ChartLegend.tsx
+++ b/packages/hobom-design-system/src/charts/ChartLegend.tsx
@@ -1,0 +1,35 @@
+export interface LegendItem {
+  label: string;
+  color: string;
+}
+
+/** A horizontal legend of colored swatches, shown under the plot. */
+export const ChartLegend = ({ items }: { items: readonly LegendItem[] }) => (
+  <div
+    style={{
+      display: "flex",
+      flexWrap: "wrap",
+      gap: "6px 16px",
+      justifyContent: "center",
+      marginTop: 8,
+      fontFamily: "'Inter', system-ui, sans-serif",
+      fontSize: 12,
+      color: "var(--hb-color-text-secondary)",
+    }}
+  >
+    {items.map((item) => (
+      <span key={item.label} style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: 3,
+            backgroundColor: item.color,
+            flexShrink: 0,
+          }}
+        />
+        {item.label}
+      </span>
+    ))}
+  </div>
+);

--- a/packages/hobom-design-system/src/charts/ChartTooltip.tsx
+++ b/packages/hobom-design-system/src/charts/ChartTooltip.tsx
@@ -1,12 +1,15 @@
+import type { ChartHoverEntry } from "./types";
+
 interface ChartTooltipProps {
   x: number;
   y: number;
-  label: string;
-  value: string;
+  title: string;
+  entries: readonly ChartHoverEntry[];
+  format: (value: number) => string;
 }
 
-/** A small popover anchored above a hovered datum. */
-export const ChartTooltip = ({ x, y, label, value }: ChartTooltipProps) => (
+/** A popover anchored above a hovered point, listing each series' value. */
+export const ChartTooltip = ({ x, y, title, entries, format }: ChartTooltipProps) => (
   <div
     style={{
       position: "absolute",
@@ -25,7 +28,32 @@ export const ChartTooltip = ({ x, y, label, value }: ChartTooltipProps) => (
       zIndex: 1,
     }}
   >
-    <div style={{ color: "var(--hb-color-text-secondary)", fontSize: 11 }}>{label}</div>
-    <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>{value}</div>
+    {title && (
+      <div style={{ color: "var(--hb-color-text-secondary)", fontSize: 11, marginBottom: 2 }}>
+        {title}
+      </div>
+    )}
+    {entries.map((entry) => (
+      <div
+        key={entry.label}
+        style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, lineHeight: 1.5 }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: entry.color,
+            flexShrink: 0,
+          }}
+        />
+        {entries.length > 1 && (
+          <span style={{ color: "var(--hb-color-text-secondary)" }}>{entry.label}</span>
+        )}
+        <span style={{ marginLeft: "auto", fontWeight: 700, fontVariantNumeric: "tabular-nums" }}>
+          {format(entry.value)}
+        </span>
+      </div>
+    ))}
   </div>
 );

--- a/packages/hobom-design-system/src/charts/HoverOverlay.tsx
+++ b/packages/hobom-design-system/src/charts/HoverOverlay.tsx
@@ -1,63 +1,61 @@
 import type { MouseEvent } from "react";
 import { nearestIndex } from "./chart-lib";
-import type { ChartHover, ChartMargin } from "./types";
+import type { ChartHover, ChartHoverEntry, ChartMargin } from "./types";
 
-/** One hoverable datum, positioned in inner-plot coordinates. */
-export interface HitPoint {
+/** A hoverable x-category: its position, tooltip rows, and per-series markers. */
+export interface HoverColumn {
+  /** Inner-plot x of the category. */
   cx: number;
+  /** Inner-plot y the tooltip anchors to (usually the topmost point). */
   anchorY: number;
-  label: string;
-  value: number;
+  title: string;
+  entries: ChartHoverEntry[];
+  /** Per-series marker points (line/area); empty for bars. */
+  markers: readonly { cy: number; color: string }[];
 }
 
 interface HoverOverlayProps {
-  points: readonly HitPoint[];
+  columns: readonly HoverColumn[];
   margin: ChartMargin;
   innerWidth: number;
   innerHeight: number;
-  color: string;
   hover: ChartHover | null;
   setHover: (hover: ChartHover | null) => void;
-  /** Draw a point marker at the anchor (line/area). Off for bars. */
-  marker?: boolean;
 }
 
 /**
- * A transparent capture rect over the plot that snaps to the nearest datum on
- * move, plus the vertical guide + marker for the active point. Positions are
- * translated from inner-plot to root SVG coordinates.
+ * A transparent capture rect over the plot that snaps to the nearest x-category
+ * on move, drawing a vertical guide and per-series markers for the active one.
  */
 export const HoverOverlay = ({
-  points,
+  columns,
   margin,
   innerWidth,
   innerHeight,
-  color,
   hover,
   setHover,
-  marker = true,
 }: HoverOverlayProps) => {
   const handleMove = (event: MouseEvent<SVGRectElement>) => {
     const box = event.currentTarget.getBoundingClientRect();
     const cursorX = event.clientX - box.left;
-    const bestIndex = nearestIndex(
-      points.map((point) => point.cx),
+    const index = nearestIndex(
+      columns.map((column) => column.cx),
       cursorX,
     );
-    const point = points[bestIndex];
+    const column = columns[index];
 
-    if (!point) return;
+    if (!column) return;
 
     setHover({
-      index: bestIndex,
-      x: margin.left + point.cx,
-      y: margin.top + point.anchorY,
-      label: point.label,
-      value: point.value,
+      index,
+      x: margin.left + column.cx,
+      y: margin.top + column.anchorY,
+      title: column.title,
+      entries: column.entries,
     });
   };
 
-  const active = hover ? points[hover.index] : undefined;
+  const active = hover ? columns[hover.index] : undefined;
 
   return (
     <g>
@@ -70,16 +68,17 @@ export const HoverOverlay = ({
           stroke="var(--hb-color-border)"
         />
       )}
-      {active && marker && (
+      {active?.markers.map((marker, index) => (
         <circle
+          key={index}
           cx={margin.left + active.cx}
-          cy={margin.top + active.anchorY}
+          cy={margin.top + marker.cy}
           r={5}
-          fill={color}
+          fill={marker.color}
           stroke="var(--hb-color-surface)"
           strokeWidth={2}
         />
-      )}
+      ))}
       <rect
         x={margin.left}
         y={margin.top}

--- a/packages/hobom-design-system/src/charts/chart-lib.spec.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.spec.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   formatCategory,
   formatNumber,
+  legendItems,
   nearestIndex,
   num,
   resolveMargin,
+  resolveSeries,
   roundedTopRect,
   str,
 } from "./chart-lib";
@@ -56,6 +58,41 @@ describe("roundedTopRect", () => {
     expect(path.startsWith("M0,20")).toBe(true); // bottom-left
     expect(path.endsWith("Z")).toBe(true);
     expect((path.match(/Q/g) ?? []).length).toBe(2); // two rounded (top) corners
+  });
+});
+
+describe("resolveSeries", () => {
+  it("wraps a single `y` field as one series", () => {
+    expect(resolveSeries({ y: "value", color: "#111" })).toEqual([
+      { key: "value", label: "value", color: "#111" },
+    ]);
+  });
+
+  it("maps an explicit series list, filling label and color from the palette", () => {
+    const resolved = resolveSeries({ series: [{ key: "a" }, { key: "b", label: "Bee" }] });
+
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]).toMatchObject({ key: "a", label: "a" });
+    expect(resolved[1]).toMatchObject({ key: "b", label: "Bee" });
+    expect(resolved[0]?.color).not.toBe(resolved[1]?.color); // distinct palette entries
+  });
+});
+
+describe("legendItems", () => {
+  it("returns a slice per datum for a donut", () => {
+    const items = legendItems([{ k: "A" }, { k: "B" }], { label: "k", value: "v" });
+
+    expect(items.map((i) => i.label)).toEqual(["A", "B"]);
+  });
+
+  it("returns a row per series for multi-series", () => {
+    const items = legendItems([], { series: [{ key: "a", label: "A" }, { key: "b", label: "B" }] });
+
+    expect(items.map((i) => i.label)).toEqual(["A", "B"]);
+  });
+
+  it("is empty for a single series", () => {
+    expect(legendItems([], { y: "value" })).toEqual([]);
   });
 });
 

--- a/packages/hobom-design-system/src/charts/chart-lib.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.ts
@@ -2,6 +2,13 @@ import type { ChartConfig, ChartDatum, ChartMargin } from "./types";
 
 const DEFAULT_MARGIN: ChartMargin = { top: 12, right: 16, bottom: 28, left: 44 };
 
+/** A series with all styling resolved (color/label filled in). */
+export interface ResolvedSeries {
+  key: string;
+  label: string;
+  color: string;
+}
+
 /** Default single-series color. */
 export const PRIMARY_COLOR = "var(--hb-color-accent)";
 
@@ -39,6 +46,48 @@ export const formatNumber = (config: ChartConfig, value: number): string =>
 
 export const formatCategory = (config: ChartConfig, value: string): string =>
   config.formatX ? config.formatX(value) : value;
+
+/**
+ * Normalize a config to a resolved series list: `config.series` when present,
+ * otherwise a single series from `config.y`. Colors fall back to the palette.
+ */
+export const resolveSeries = (config: ChartConfig): ResolvedSeries[] => {
+  const palette = config.colors ?? DEFAULT_PALETTE;
+
+  if (config.series && config.series.length > 0) {
+    return config.series.map((series, index) => ({
+      key: series.key,
+      label: series.label ?? series.key,
+      color: series.color ?? palette[index % palette.length] ?? PRIMARY_COLOR,
+    }));
+  }
+
+  const key = config.y ?? "";
+
+  return [{ key, label: key, color: config.color ?? PRIMARY_COLOR }];
+};
+
+/**
+ * Legend rows for a chart: one per slice for a donut (`value`+`label`), one per
+ * series for a multi-series cartesian chart, or none for a single series.
+ */
+export const legendItems = (
+  data: readonly ChartDatum[],
+  config: ChartConfig,
+): { label: string; color: string }[] => {
+  const palette = config.colors ?? DEFAULT_PALETTE;
+
+  if (config.value != null && config.label != null) {
+    return data.map((datum, index) => ({
+      label: str(datum, config.label),
+      color: palette[index % palette.length] ?? PRIMARY_COLOR,
+    }));
+  }
+
+  const series = resolveSeries(config);
+
+  return series.length > 1 ? series.map((s) => ({ label: s.label, color: s.color })) : [];
+};
 
 /** SVG path for a rectangle with only its top two corners rounded. */
 export const roundedTopRect = (x: number, y: number, w: number, h: number, r: number): string =>

--- a/packages/hobom-design-system/src/charts/createChart.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { ChartLegend } from "./ChartLegend";
 import { ChartTooltip } from "./ChartTooltip";
 import { useMeasure } from "./useMeasure";
-import { formatNumber } from "./chart-lib";
+import { formatNumber, legendItems } from "./chart-lib";
 import type { ChartHover, ChartProps, ChartRegistry } from "./types";
 
 /**
@@ -25,6 +26,7 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
     const [ref, width] = useMeasure();
     const [hover, setHover] = useState<ChartHover | null>(null);
     const renderer = registry[type];
+    const legend = legendItems(data, config);
 
     return (
       <div ref={ref} className={className} style={{ position: "relative", width: "100%", ...style }}>
@@ -41,12 +43,14 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
             {renderer ? renderer({ data, config, width, height, hover, setHover }) : null}
           </svg>
         )}
+        {legend.length > 0 && <ChartLegend items={legend} />}
         {hover && (
           <ChartTooltip
             x={hover.x}
             y={hover.y}
-            label={hover.label}
-            value={formatNumber(config, hover.value)}
+            title={hover.title}
+            entries={hover.entries}
+            format={(v) => formatNumber(config, v)}
           />
         )}
       </div>

--- a/packages/hobom-design-system/src/charts/index.ts
+++ b/packages/hobom-design-system/src/charts/index.ts
@@ -17,9 +17,12 @@ export { lineChart, areaChart, barChart, donutChart };
 export type {
   ChartConfig,
   ChartDatum,
+  ChartHover,
+  ChartHoverEntry,
   ChartMargin,
   ChartProps,
   ChartRegistry,
   ChartRenderContext,
   ChartRenderer,
+  ChartSeries,
 } from "./types";

--- a/packages/hobom-design-system/src/charts/renderers/area.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/area.tsx
@@ -2,8 +2,8 @@ import { scaleLinear, scalePoint } from "d3-scale";
 import { area as d3Area, curveMonotoneX, line as d3Line } from "d3-shape";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
-import { HoverOverlay } from "../HoverOverlay";
-import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import { HoverOverlay, type HoverColumn } from "../HoverOverlay";
+import { formatCategory, formatNumber, num, resolveMargin, resolveSeries, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
 export const areaChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
@@ -11,33 +11,51 @@ export const areaChart: ChartRenderer = ({ data, config, width, height, hover, s
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
+  const series = resolveSeries(config);
   const categories = data.map((d) => str(d, config.x));
   const xScale = scalePoint<string>().domain(categories).range([0, innerWidth]).padding(0.5);
-  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const yMax = max(data, (d) => Math.max(...series.map((s) => num(d, s.key)))) ?? 0;
   const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
 
-  const color = config.color ?? PRIMARY_COLOR;
   const x = (d: ChartDatum) => xScale(str(d, config.x)) ?? 0;
-  const y = (d: ChartDatum) => yScale(num(d, config.y));
 
-  const areaPath = d3Area<ChartDatum>().x(x).y0(innerHeight).y1(y).curve(curveMonotoneX)(data) ?? "";
-  const linePath = d3Line<ChartDatum>().x(x).y(y).curve(curveMonotoneX)(data) ?? "";
+  const shapes = series.map((s) => {
+    const y = (d: ChartDatum) => yScale(num(d, s.key));
 
-  const xTicks = data.map((d) => {
-    const category = str(d, config.x);
-
-    return { x: margin.left + (xScale(category) ?? 0), label: formatCategory(config, category) };
+    return {
+      color: s.color,
+      gradientId: `hb-area-${s.key.replace(/[^a-z0-9]/gi, "")}-${s.color.replace(/[^a-z0-9]/gi, "")}`,
+      area: d3Area<ChartDatum>().x(x).y0(innerHeight).y1(y).curve(curveMonotoneX)(data) ?? "",
+      line: d3Line<ChartDatum>().x(x).y(y).curve(curveMonotoneX)(data) ?? "",
+    };
   });
 
-  const gradientId = `hb-area-${color.replace(/[^a-z0-9]/gi, "")}`;
+  const columns: HoverColumn[] = data.map((d) => {
+    const markers = series.map((s) => ({ cy: yScale(num(d, s.key)), color: s.color }));
+
+    return {
+      cx: x(d),
+      anchorY: Math.min(...markers.map((m) => m.cy)),
+      title: formatCategory(config, str(d, config.x)),
+      entries: series.map((s) => ({ label: s.label, value: num(d, s.key), color: s.color })),
+      markers,
+    };
+  });
+
+  const xTicks = data.map((d) => ({
+    x: margin.left + x(d),
+    label: formatCategory(config, str(d, config.x)),
+  }));
 
   return (
     <>
       <defs>
-        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={color} stopOpacity={0.28} />
-          <stop offset="100%" stopColor={color} stopOpacity={0} />
-        </linearGradient>
+        {shapes.map((shape) => (
+          <linearGradient key={shape.gradientId} id={shape.gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={shape.color} stopOpacity={0.28} />
+            <stop offset="100%" stopColor={shape.color} stopOpacity={0} />
+          </linearGradient>
+        ))}
       </defs>
       <Axes
         yScale={yScale}
@@ -48,27 +66,25 @@ export const areaChart: ChartRenderer = ({ data, config, width, height, hover, s
         formatY={(v) => formatNumber(config, v)}
       />
       <g transform={`translate(${margin.left}, ${margin.top})`}>
-        <path d={areaPath} fill={`url(#${gradientId})`} />
-        <path
-          d={linePath}
-          fill="none"
-          stroke={color}
-          strokeWidth={2.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
+        {shapes.map((shape) => (
+          <g key={shape.gradientId}>
+            <path d={shape.area} fill={`url(#${shape.gradientId})`} />
+            <path
+              d={shape.line}
+              fill="none"
+              stroke={shape.color}
+              strokeWidth={2.5}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+          </g>
+        ))}
       </g>
       <HoverOverlay
-        points={data.map((d) => ({
-          cx: xScale(str(d, config.x)) ?? 0,
-          anchorY: yScale(num(d, config.y)),
-          label: formatCategory(config, str(d, config.x)),
-          value: num(d, config.y),
-        }))}
+        columns={columns}
         margin={margin}
         innerWidth={innerWidth}
         innerHeight={innerHeight}
-        color={color}
         hover={hover}
         setHover={setHover}
       />

--- a/packages/hobom-design-system/src/charts/renderers/bar.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/bar.tsx
@@ -1,13 +1,13 @@
 import { scaleBand, scaleLinear } from "d3-scale";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
-import { HoverOverlay } from "../HoverOverlay";
+import { HoverOverlay, type HoverColumn } from "../HoverOverlay";
 import {
-  PRIMARY_COLOR,
   formatCategory,
   formatNumber,
   num,
   resolveMargin,
+  resolveSeries,
   roundedTopRect,
   str,
 } from "../chart-lib";
@@ -18,21 +18,28 @@ export const barChart: ChartRenderer = ({ data, config, width, height, hover, se
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
+  const series = resolveSeries(config);
   const categories = data.map((d) => str(d, config.x));
   const xScale = scaleBand<string>().domain(categories).range([0, innerWidth]).padding(0.3);
-  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const xSub = scaleBand<string>()
+    .domain(series.map((s) => s.key))
+    .range([0, xScale.bandwidth()])
+    .padding(0.15);
+  const yMax = max(data, (d) => Math.max(...series.map((s) => num(d, s.key)))) ?? 0;
   const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
 
-  const color = config.color ?? PRIMARY_COLOR;
+  const columns: HoverColumn[] = data.map((d) => ({
+    cx: (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
+    anchorY: Math.min(...series.map((s) => yScale(num(d, s.key)))),
+    title: formatCategory(config, str(d, config.x)),
+    entries: series.map((s) => ({ label: s.label, value: num(d, s.key), color: s.color })),
+    markers: [],
+  }));
 
-  const xTicks = data.map((d) => {
-    const category = str(d, config.x);
-
-    return {
-      x: margin.left + (xScale(category) ?? 0) + xScale.bandwidth() / 2,
-      label: formatCategory(config, category),
-    };
-  });
+  const xTicks = data.map((d) => ({
+    x: margin.left + (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
+    label: formatCategory(config, str(d, config.x)),
+  }));
 
   return (
     <>
@@ -45,39 +52,35 @@ export const barChart: ChartRenderer = ({ data, config, width, height, hover, se
         formatY={(v) => formatNumber(config, v)}
       />
       <g transform={`translate(${margin.left}, ${margin.top})`}>
-        {data.map((d, index) => {
-          const value = num(d, config.y);
-          const barY = yScale(value);
-          const barX = xScale(str(d, config.x)) ?? 0;
-          const w = xScale.bandwidth();
-          const h = Math.max(0, innerHeight - barY);
-          const r = Math.min(5, w / 2, h);
-          const dimmed = hover !== null && hover.index !== index;
+        {data.map((d, categoryIndex) => {
+          const bandX = xScale(str(d, config.x)) ?? 0;
+          const dimmed = hover !== null && hover.index !== categoryIndex;
 
-          return (
-            <path
-              key={index}
-              d={roundedTopRect(barX, barY, w, h, r)}
-              fill={color}
-              fillOpacity={dimmed ? 0.5 : 1}
-            />
-          );
+          return series.map((s, seriesIndex) => {
+            const barY = yScale(num(d, s.key));
+            const barX = bandX + (xSub(s.key) ?? 0);
+            const w = xSub.bandwidth();
+            const h = Math.max(0, innerHeight - barY);
+            const r = Math.min(4, w / 2, h);
+
+            return (
+              <path
+                key={`${categoryIndex}-${seriesIndex}`}
+                d={roundedTopRect(barX, barY, w, h, r)}
+                fill={s.color}
+                fillOpacity={dimmed ? 0.5 : 1}
+              />
+            );
+          });
         })}
       </g>
       <HoverOverlay
-        points={data.map((d) => ({
-          cx: (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
-          anchorY: yScale(num(d, config.y)),
-          label: formatCategory(config, str(d, config.x)),
-          value: num(d, config.y),
-        }))}
+        columns={columns}
         margin={margin}
         innerWidth={innerWidth}
         innerHeight={innerHeight}
-        color={color}
         hover={hover}
         setHover={setHover}
-        marker={false}
       />
     </>
   );

--- a/packages/hobom-design-system/src/charts/renderers/donut.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/donut.tsx
@@ -1,5 +1,5 @@
 import { arc as d3Arc, pie as d3Pie, type PieArcDatum } from "d3-shape";
-import { DEFAULT_PALETTE, num, str } from "../chart-lib";
+import { DEFAULT_PALETTE, PRIMARY_COLOR, num, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
 export const donutChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
@@ -26,12 +26,14 @@ export const donutChart: ChartRenderer = ({ data, config, width, height, hover, 
       {slices.map((slice, index) => {
         const [centroidX, centroidY] = arcGenerator.centroid(slice);
         const dimmed = hover !== null && hover.index !== index;
+        const color = palette[index % palette.length] ?? PRIMARY_COLOR;
+        const label = str(slice.data, config.label);
 
         return (
           <path
-            key={str(slice.data, config.label) || index}
+            key={label || index}
             d={arcGenerator(slice) ?? ""}
-            fill={palette[index % palette.length]}
+            fill={color}
             fillOpacity={dimmed ? 0.5 : 1}
             stroke="var(--hb-color-surface)"
             strokeWidth={1}
@@ -40,8 +42,8 @@ export const donutChart: ChartRenderer = ({ data, config, width, height, hover, 
                 index,
                 x: cx + centroidX,
                 y: cy + centroidY,
-                label: str(slice.data, config.label),
-                value: slice.value,
+                title: label,
+                entries: [{ label, value: slice.value, color }],
               })
             }
           />

--- a/packages/hobom-design-system/src/charts/renderers/line.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/line.tsx
@@ -2,8 +2,8 @@ import { scaleLinear, scalePoint } from "d3-scale";
 import { curveMonotoneX, line as d3Line } from "d3-shape";
 import { max } from "d3-array";
 import { Axes } from "../Axes";
-import { HoverOverlay } from "../HoverOverlay";
-import { PRIMARY_COLOR, formatCategory, formatNumber, num, resolveMargin, str } from "../chart-lib";
+import { HoverOverlay, type HoverColumn } from "../HoverOverlay";
+import { formatCategory, formatNumber, num, resolveMargin, resolveSeries, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
 export const lineChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
@@ -11,23 +11,35 @@ export const lineChart: ChartRenderer = ({ data, config, width, height, hover, s
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
+  const series = resolveSeries(config);
   const categories = data.map((d) => str(d, config.x));
   const xScale = scalePoint<string>().domain(categories).range([0, innerWidth]).padding(0.5);
-  const yMax = max(data, (d) => num(d, config.y)) ?? 0;
+  const yMax = max(data, (d) => Math.max(...series.map((s) => num(d, s.key)))) ?? 0;
   const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
 
-  const color = config.color ?? PRIMARY_COLOR;
-  const path =
-    d3Line<ChartDatum>()
-      .x((d) => xScale(str(d, config.x)) ?? 0)
-      .y((d) => yScale(num(d, config.y)))
-      .curve(curveMonotoneX)(data) ?? "";
+  const x = (d: ChartDatum) => xScale(str(d, config.x)) ?? 0;
 
-  const xTicks = data.map((d) => {
-    const category = str(d, config.x);
+  const paths = series.map((s) => ({
+    color: s.color,
+    d: d3Line<ChartDatum>().x(x).y((d) => yScale(num(d, s.key))).curve(curveMonotoneX)(data) ?? "",
+  }));
 
-    return { x: margin.left + (xScale(category) ?? 0), label: formatCategory(config, category) };
+  const columns: HoverColumn[] = data.map((d) => {
+    const markers = series.map((s) => ({ cy: yScale(num(d, s.key)), color: s.color }));
+
+    return {
+      cx: x(d),
+      anchorY: Math.min(...markers.map((m) => m.cy)),
+      title: formatCategory(config, str(d, config.x)),
+      entries: series.map((s) => ({ label: s.label, value: num(d, s.key), color: s.color })),
+      markers,
+    };
   });
+
+  const xTicks = data.map((d) => ({
+    x: margin.left + x(d),
+    label: formatCategory(config, str(d, config.x)),
+  }));
 
   return (
     <>
@@ -40,37 +52,35 @@ export const lineChart: ChartRenderer = ({ data, config, width, height, hover, s
         formatY={(v) => formatNumber(config, v)}
       />
       <g transform={`translate(${margin.left}, ${margin.top})`}>
-        <path
-          d={path}
-          fill="none"
-          stroke={color}
-          strokeWidth={2.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-        {data.map((d, index) => (
-          <circle
+        {paths.map((path, index) => (
+          <path
             key={index}
-            cx={xScale(str(d, config.x)) ?? 0}
-            cy={yScale(num(d, config.y))}
-            r={4}
-            fill={color}
-            stroke="var(--hb-color-surface)"
-            strokeWidth={2}
+            d={path.d}
+            fill="none"
+            stroke={path.color}
+            strokeWidth={2.5}
+            strokeLinejoin="round"
+            strokeLinecap="round"
           />
         ))}
+        {series.length === 1 &&
+          data.map((d, index) => (
+            <circle
+              key={index}
+              cx={x(d)}
+              cy={yScale(num(d, series[0]?.key))}
+              r={4}
+              fill={series[0]?.color}
+              stroke="var(--hb-color-surface)"
+              strokeWidth={2}
+            />
+          ))}
       </g>
       <HoverOverlay
-        points={data.map((d) => ({
-          cx: xScale(str(d, config.x)) ?? 0,
-          anchorY: yScale(num(d, config.y)),
-          label: formatCategory(config, str(d, config.x)),
-          value: num(d, config.y),
-        }))}
+        columns={columns}
         margin={margin}
         innerWidth={innerWidth}
         innerHeight={innerHeight}
-        color={color}
         hover={hover}
         setHover={setHover}
       />

--- a/packages/hobom-design-system/src/charts/types.ts
+++ b/packages/hobom-design-system/src/charts/types.ts
@@ -10,16 +10,28 @@ export interface ChartMargin {
   left: number;
 }
 
+/** One measure drawn across the x axis. Multiple series share the same x. */
+export interface ChartSeries {
+  /** Field key for this series' value. */
+  key: string;
+  /** Legend/tooltip label; defaults to `key`. */
+  label?: string;
+  /** Series color; defaults to the palette. */
+  color?: string;
+}
+
 /**
  * External configuration injected per chart. Cartesian charts (line/area/bar)
- * read `x`/`y`; part-to-whole charts (donut) read `label`/`value`. Everything
- * else is optional styling.
+ * read `x` plus either `y` (single series) or `series` (multi); part-to-whole
+ * charts (donut) read `label`/`value`. Everything else is optional styling.
  */
 export interface ChartConfig {
   /** Field key for the x axis / category. */
   x?: string;
-  /** Field key for the y axis / measure. */
+  /** Field key for the y axis / measure (single series). */
   y?: string;
+  /** Multiple measures over the same x. Takes precedence over `y`. */
+  series?: readonly ChartSeries[];
   /** Field key for a slice's category (donut). */
   label?: string;
   /** Field key for a slice's measure (donut). */
@@ -36,14 +48,22 @@ export interface ChartConfig {
   formatX?: (value: string) => string;
 }
 
-/** The datum under the pointer, with the pixel anchor for its tooltip. */
+/** One row in the hover tooltip (a series/slice value at the hovered point). */
+export interface ChartHoverEntry {
+  label: string;
+  value: number;
+  color: string;
+}
+
+/** The point under the pointer: its pixel anchor and the values to show. */
 export interface ChartHover {
   index: number;
   /** SVG-pixel anchor point (tooltip is placed relative to it). */
   x: number;
   y: number;
-  label: string;
-  value: number;
+  /** Heading (usually the x category). */
+  title: string;
+  entries: readonly ChartHoverEntry[];
 }
 
 /** What the factory hands a renderer: the data, its box, and hover plumbing. */


### PR DESCRIPTION
Builds on the chart factory (#178) with the top gap from that PR's notes: multi-series support, legends, and a multi-value tooltip.

## What
- **Multi-series** — cartesian charts take `config.series: { key, label?, color? }[]` (multiple measures over one x) alongside single-series `config.y`. Line/area draw one path per series; bar draws grouped sub-bars (a `scaleBand` inside each category).
- **Legend** — the factory renders a legend under the plot, derived from the series (multi-series cartesian) or the donut's slices. Single-series charts show none.
- **Multi-value tooltip** — hover is now **category-based**: a vertical guide snaps to the nearest x, per-series markers highlight, and the tooltip lists every series' value at that category with a matching color swatch. The donut keeps per-slice hover.

## API
```tsx
<Chart type="line" data={rows} config={{ x: "month", series: [
  { key: "sent", label: "Sent" },
  { key: "opened", label: "Opened" },
] }} />
```

## Tests
- `resolveSeries` / `legendItems` are pure and unit-tested (chart-lib.spec).
- New multi-series line & bar stories run through the browser a11y suite.

## Verify
- DS `tsc -b` clean; 15 chart unit tests + 7 chart story a11y tests pass (DS total up accordingly)

## Follow-up (from the gap list)
Radar & stacked-bar renderers, and keyboard-accessible data (SR table / focusable points), remain for later PRs.