### PR TITLE
Extend the chart factory for the dashboard migration

### DIFF
--- a/packages/hobom-design-system/src/charts/Chart.stories.tsx
+++ b/packages/hobom-design-system/src/charts/Chart.stories.tsx
@@ -31,6 +31,39 @@ const SENT_OPENED = [
   { key: "opened", label: "Opened" },
 ];
 
+const CYCLE = [
+  { cycle: "Daily", completed: 18, incomplete: 6 },
+  { cycle: "Weekday", completed: 12, incomplete: 9 },
+  { cycle: "Weekend", completed: 7, incomplete: 4 },
+];
+
+const DONE_TODO = [
+  { key: "completed", label: "Done", color: "#2ca87f" },
+  { key: "incomplete", label: "Todo", color: "#e9ecef" },
+];
+
+const LABELS = [
+  { label: "Idea", count: 24 },
+  { label: "Bug", count: 18 },
+  { label: "Chore", count: 12 },
+  { label: "Docs", count: 6 },
+];
+
+const STATUS = [
+  { code: "200", count: 1840, fill: "#4ade80" },
+  { code: "301", count: 220, fill: "#60a5fa" },
+  { code: "404", count: 96, fill: "#fbbf24" },
+  { code: "500", count: 34, fill: "#f87171" },
+];
+
+const MODULES = [
+  { module: "Todo", pct: 34 },
+  { module: "Note", pct: 26 },
+  { module: "Message", pct: 18 },
+  { module: "Alarm", pct: 14 },
+  { module: "Menu", pct: 8 },
+];
+
 const meta = {
   title: "Charts/Chart",
   component: Chart,
@@ -114,6 +147,59 @@ export const MultiSeriesBar: Story = {
         data={MULTI}
         config={{ x: "month", series: SENT_OPENED }}
         ariaLabel="Sent vs opened by month"
+      />
+    </Frame>
+  ),
+};
+
+export const StackedBar: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="bar"
+        data={CYCLE}
+        config={{ x: "cycle", series: DONE_TODO, stacked: true }}
+        ariaLabel="Completed vs remaining todos by cycle"
+      />
+    </Frame>
+  ),
+};
+
+export const HorizontalBar: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="bar"
+        data={LABELS}
+        config={{ x: "label", y: "count", horizontal: true, margin: { left: 72 } }}
+        ariaLabel="Notes per label"
+      />
+    </Frame>
+  ),
+};
+
+export const PerBarColor: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="bar"
+        data={STATUS}
+        config={{ x: "code", y: "count", colorKey: "fill" }}
+        ariaLabel="Requests by status code"
+      />
+    </Frame>
+  ),
+};
+
+export const Radar: Story = {
+  render: () => (
+    <Frame>
+      <Chart
+        type="radar"
+        data={MODULES}
+        config={{ x: "module", y: "pct", color: "#4680ff" }}
+        height={280}
+        ariaLabel="Module activity share"
       />
     </Frame>
   ),

--- a/packages/hobom-design-system/src/charts/chart-lib.spec.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.spec.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  colorFromDatum,
   formatCategory,
   formatNumber,
+  gradientId,
   legendItems,
   nearestIndex,
   num,
   resolveMargin,
   resolveSeries,
+  roundedRightRect,
   roundedTopRect,
   str,
 } from "./chart-lib";
@@ -58,6 +61,32 @@ describe("roundedTopRect", () => {
     expect(path.startsWith("M0,20")).toBe(true); // bottom-left
     expect(path.endsWith("Z")).toBe(true);
     expect((path.match(/Q/g) ?? []).length).toBe(2); // two rounded (top) corners
+  });
+});
+
+describe("roundedRightRect", () => {
+  it("starts at the top-left and only rounds the right corners", () => {
+    const path = roundedRightRect(0, 0, 20, 10, 2);
+
+    expect(path.startsWith("M0,0")).toBe(true); // top-left
+    expect(path.endsWith("Z")).toBe(true);
+    expect((path.match(/Q/g) ?? []).length).toBe(2); // two rounded (right) corners
+  });
+});
+
+describe("colorFromDatum", () => {
+  it("reads a per-datum color from colorKey, else null", () => {
+    expect(colorFromDatum({ fill: "#abc" }, { colorKey: "fill" })).toBe("#abc");
+    expect(colorFromDatum({ fill: "" }, { colorKey: "fill" })).toBeNull(); // empty ignored
+    expect(colorFromDatum({ fill: 123 }, { colorKey: "fill" })).toBeNull(); // non-string ignored
+    expect(colorFromDatum({ fill: "#abc" }, {})).toBeNull(); // no colorKey
+  });
+});
+
+describe("gradientId", () => {
+  it("builds a DOM-safe id, stripping non-alphanumerics", () => {
+    expect(gradientId("bar", "#4680ff")).toBe("hb-grad-bar-4680ff");
+    expect(gradientId("bar", "var(--hb-color-accent)")).toBe("hb-grad-bar-varhbcoloraccent");
   });
 });
 

--- a/packages/hobom-design-system/src/charts/chart-lib.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.ts
@@ -80,7 +80,7 @@ export const legendItems = (
   if (config.value != null && config.label != null) {
     return data.map((datum, index) => ({
       label: str(datum, config.label),
-      color: palette[index % palette.length] ?? PRIMARY_COLOR,
+      color: colorFromDatum(datum, config) ?? palette[index % palette.length] ?? PRIMARY_COLOR,
     }));
   }
 
@@ -89,10 +89,28 @@ export const legendItems = (
   return series.length > 1 ? series.map((s) => ({ label: s.label, color: s.color })) : [];
 };
 
+/** A per-datum color read from `config.colorKey`, or null when unset/empty. */
+export const colorFromDatum = (datum: ChartDatum, config: ChartConfig): string | null => {
+  if (!config.colorKey) return null;
+
+  const value = datum[config.colorKey];
+
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+/** A DOM-safe `<linearGradient>` id derived from arbitrary string parts. */
+export const gradientId = (...parts: string[]): string =>
+  `hb-grad-${parts.map((part) => part.replace(/[^a-z0-9]/gi, "")).join("-")}`;
+
 /** SVG path for a rectangle with only its top two corners rounded. */
 export const roundedTopRect = (x: number, y: number, w: number, h: number, r: number): string =>
   `M${x},${y + h} L${x},${y + r} Q${x},${y} ${x + r},${y} ` +
   `L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} L${x + w},${y + h} Z`;
+
+/** SVG path for a rectangle with only its right two corners rounded. */
+export const roundedRightRect = (x: number, y: number, w: number, h: number, r: number): string =>
+  `M${x},${y} L${x + w - r},${y} Q${x + w},${y} ${x + w},${y + r} ` +
+  `L${x + w},${y + h - r} Q${x + w},${y + h} ${x + w - r},${y + h} L${x},${y + h} Z`;
 
 /** Index of the position closest to `cursor` (0 when the list is empty). */
 export const nearestIndex = (positions: readonly number[], cursor: number): number => {

--- a/packages/hobom-design-system/src/charts/createChart.tsx
+++ b/packages/hobom-design-system/src/charts/createChart.tsx
@@ -26,7 +26,7 @@ export const createChart = <R extends ChartRegistry>(registry: R) => {
     const [ref, width] = useMeasure();
     const [hover, setHover] = useState<ChartHover | null>(null);
     const renderer = registry[type];
-    const legend = legendItems(data, config);
+    const legend = config.legend === false ? [] : legendItems(data, config);
 
     return (
       <div ref={ref} className={className} style={{ position: "relative", width: "100%", ...style }}>

--- a/packages/hobom-design-system/src/charts/index.ts
+++ b/packages/hobom-design-system/src/charts/index.ts
@@ -3,17 +3,19 @@ import { lineChart } from "./renderers/line";
 import { areaChart } from "./renderers/area";
 import { barChart } from "./renderers/bar";
 import { donutChart } from "./renderers/donut";
+import { radarChart } from "./renderers/radar";
 
-/** The built-in chart, pre-registered with line / area / bar / donut renderers. */
+/** The built-in chart, pre-registered with line / area / bar / donut / radar. */
 export const Chart = createChart({
   line: lineChart,
   area: areaChart,
   bar: barChart,
   donut: donutChart,
+  radar: radarChart,
 });
 
 export { createChart };
-export { lineChart, areaChart, barChart, donutChart };
+export { lineChart, areaChart, barChart, donutChart, radarChart };
 export type {
   ChartConfig,
   ChartDatum,

--- a/packages/hobom-design-system/src/charts/renderers.spec.tsx
+++ b/packages/hobom-design-system/src/charts/renderers.spec.tsx
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { Chart } from "./index";
+
+class MockResizeObserver {
+  readonly #callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+  }
+
+  observe() {
+    this.#callback([{ contentRect: { width: 400 } } as ResizeObserverEntry], this as unknown as ResizeObserver);
+  }
+
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+afterEach(cleanup);
+
+const CYCLE = [
+  { cycle: "Daily", completed: 18, incomplete: 6 },
+  { cycle: "Weekend", completed: 7, incomplete: 4 },
+];
+const STATUS = [
+  { code: "200", count: 1840, fill: "#4ade80" },
+  { code: "500", count: 34, fill: "#f87171" },
+];
+const MODULES = [
+  { module: "Todo", pct: 34 },
+  { module: "Note", pct: 26 },
+  { module: "Alarm", pct: 14 },
+];
+
+describe("bar renderer options", () => {
+  it("stacks series and emits one bar path per datum/series", () => {
+    const { container } = render(
+      <Chart
+        type="bar"
+        data={CYCLE}
+        config={{ x: "cycle", series: [{ key: "completed" }, { key: "incomplete" }], stacked: true }}
+        ariaLabel="stacked"
+      />,
+    );
+
+    expect(container.querySelectorAll("path").length).toBe(4); // 2 categories × 2 series
+  });
+
+  it("draws horizontal bars with category labels on the left", () => {
+    const { container } = render(
+      <Chart
+        type="bar"
+        data={STATUS}
+        config={{ x: "code", y: "count", horizontal: true }}
+        ariaLabel="horizontal"
+      />,
+    );
+
+    expect(container.querySelectorAll("path").length).toBe(2);
+    expect(container.textContent).toContain("200");
+  });
+
+  it("applies a per-datum color via colorKey (one gradient per unique color)", () => {
+    const { container } = render(
+      <Chart type="bar" data={STATUS} config={{ x: "code", y: "count", colorKey: "fill" }} ariaLabel="colored" />,
+    );
+
+    expect(container.querySelectorAll("linearGradient").length).toBe(2); // two distinct colors
+  });
+
+  it("omits gradients when gradient is disabled", () => {
+    const { container } = render(
+      <Chart type="bar" data={STATUS} config={{ x: "code", y: "count", gradient: false }} ariaLabel="flat" />,
+    );
+
+    expect(container.querySelectorAll("linearGradient").length).toBe(0);
+  });
+});
+
+describe("radar renderer", () => {
+  it("renders a value polygon with a vertex per category", () => {
+    const { container } = render(
+      <Chart type="radar" data={MODULES} config={{ x: "module", y: "pct" }} ariaLabel="radar" />,
+    );
+
+    expect(container.querySelectorAll("polygon").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll("circle").length).toBe(3); // one marker per category
+  });
+});
+
+describe("legend toggle", () => {
+  it("suppresses the built-in legend when legend is false", () => {
+    const data = [{ label: "A", count: 1 }, { label: "B", count: 2 }];
+    const { container, rerender } = render(
+      <Chart type="donut" data={data} config={{ label: "label", value: "count" }} ariaLabel="with" />,
+    );
+    const withLegend = container.textContent ?? "";
+
+    rerender(
+      <Chart type="donut" data={data} config={{ label: "label", value: "count", legend: false }} ariaLabel="without" />,
+    );
+
+    expect(withLegend).toContain("A");
+    expect(container.textContent).not.toContain("A");
+  });
+});

--- a/packages/hobom-design-system/src/charts/renderers/bar.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/bar.tsx
@@ -3,46 +3,115 @@ import { max } from "d3-array";
 import { Axes } from "../Axes";
 import { HoverOverlay, type HoverColumn } from "../HoverOverlay";
 import {
+  colorFromDatum,
   formatCategory,
   formatNumber,
+  gradientId,
   num,
   resolveMargin,
   resolveSeries,
+  roundedRightRect,
   roundedTopRect,
   str,
 } from "../chart-lib";
-import type { ChartRenderer } from "../types";
+import type { ChartConfig, ChartDatum, ChartRenderContext, ChartRenderer } from "../types";
 
-export const barChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
+/** Unique fill colors in draw order, so each gets exactly one gradient def. */
+const uniqueColors = (colors: readonly string[]): string[] => [...new Set(colors)];
+
+/** A `<defs>` of one vertical/horizontal gradient per color (full → faded). */
+const BarGradients = ({ colors, horizontal }: { colors: string[]; horizontal: boolean }) => (
+  <defs>
+    {colors.map((color) => (
+      <linearGradient
+        key={color}
+        id={gradientId("bar", color)}
+        x1="0"
+        y1="0"
+        x2={horizontal ? "1" : "0"}
+        y2={horizontal ? "0" : "1"}
+      >
+        <stop offset="0%" stopColor={color} stopOpacity={1} />
+        <stop offset="100%" stopColor={color} stopOpacity={0.6} />
+      </linearGradient>
+    ))}
+  </defs>
+);
+
+const fillFor = (color: string, gradient: boolean): string =>
+  gradient ? `url(#${gradientId("bar", color)})` : color;
+
+/** Series values as tooltip rows; used by both orientations. */
+const rowsFor = (d: ChartDatum, config: ChartConfig, series: ReturnType<typeof resolveSeries>) =>
+  series.map((s) => ({
+    label: s.label,
+    value: num(d, s.key),
+    color: colorFromDatum(d, config) ?? s.color,
+  }));
+
+const verticalBar = ({ data, config, width, height, hover, setHover }: ChartRenderContext) => {
   const margin = resolveMargin(config);
   const innerWidth = Math.max(0, width - margin.left - margin.right);
   const innerHeight = Math.max(0, height - margin.top - margin.bottom);
 
   const series = resolveSeries(config);
+  const stacked = config.stacked === true && series.length > 1;
+  const gradient = config.gradient !== false;
   const categories = data.map((d) => str(d, config.x));
-  const xScale = scaleBand<string>().domain(categories).range([0, innerWidth]).padding(0.3);
-  const xSub = scaleBand<string>()
+
+  const band = scaleBand<string>().domain(categories).range([0, innerWidth]).padding(0.3);
+  const sub = scaleBand<string>()
     .domain(series.map((s) => s.key))
-    .range([0, xScale.bandwidth()])
+    .range([0, band.bandwidth()])
     .padding(0.15);
-  const yMax = max(data, (d) => Math.max(...series.map((s) => num(d, s.key)))) ?? 0;
+  const yMax =
+    (stacked
+      ? max(data, (d) => series.reduce((sum, s) => sum + num(d, s.key), 0))
+      : max(data, (d) => Math.max(...series.map((s) => num(d, s.key))))) ?? 0;
   const yScale = scaleLinear().domain([0, yMax]).range([innerHeight, 0]).nice();
 
+  const bars = data.flatMap((d, categoryIndex) => {
+    const bandStart = band(str(d, config.x)) ?? 0;
+    let accum = 0;
+
+    return series.map((s, seriesIndex) => {
+      const value = num(d, s.key);
+      const color = colorFromDatum(d, config) ?? s.color;
+      const isTop = seriesIndex === series.length - 1;
+
+      const x = stacked ? bandStart : bandStart + (sub(s.key) ?? 0);
+      const w = stacked ? band.bandwidth() : sub.bandwidth();
+      const y = stacked ? yScale(accum + value) : yScale(value);
+      const h = stacked ? yScale(accum) - yScale(accum + value) : innerHeight - yScale(value);
+
+      accum += value;
+
+      const r = (stacked ? isTop : true) ? Math.min(4, w / 2, h) : 0;
+
+      return { key: `${categoryIndex}-${seriesIndex}`, d: roundedTopRect(x, y, w, h, r), color };
+    });
+  });
+
+  const colors = uniqueColors(bars.map((bar) => bar.color));
+
   const columns: HoverColumn[] = data.map((d) => ({
-    cx: (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
-    anchorY: Math.min(...series.map((s) => yScale(num(d, s.key)))),
+    cx: (band(str(d, config.x)) ?? 0) + band.bandwidth() / 2,
+    anchorY: stacked
+      ? yScale(series.reduce((sum, s) => sum + num(d, s.key), 0))
+      : Math.min(...series.map((s) => yScale(num(d, s.key)))),
     title: formatCategory(config, str(d, config.x)),
-    entries: series.map((s) => ({ label: s.label, value: num(d, s.key), color: s.color })),
+    entries: rowsFor(d, config, series),
     markers: [],
   }));
 
   const xTicks = data.map((d) => ({
-    x: margin.left + (xScale(str(d, config.x)) ?? 0) + xScale.bandwidth() / 2,
+    x: margin.left + (band(str(d, config.x)) ?? 0) + band.bandwidth() / 2,
     label: formatCategory(config, str(d, config.x)),
   }));
 
   return (
     <>
+      {gradient && <BarGradients colors={colors} horizontal={false} />}
       <Axes
         yScale={yScale}
         xTicks={xTicks}
@@ -52,27 +121,14 @@ export const barChart: ChartRenderer = ({ data, config, width, height, hover, se
         formatY={(v) => formatNumber(config, v)}
       />
       <g transform={`translate(${margin.left}, ${margin.top})`}>
-        {data.map((d, categoryIndex) => {
-          const bandX = xScale(str(d, config.x)) ?? 0;
-          const dimmed = hover !== null && hover.index !== categoryIndex;
-
-          return series.map((s, seriesIndex) => {
-            const barY = yScale(num(d, s.key));
-            const barX = bandX + (xSub(s.key) ?? 0);
-            const w = xSub.bandwidth();
-            const h = Math.max(0, innerHeight - barY);
-            const r = Math.min(4, w / 2, h);
-
-            return (
-              <path
-                key={`${categoryIndex}-${seriesIndex}`}
-                d={roundedTopRect(barX, barY, w, h, r)}
-                fill={s.color}
-                fillOpacity={dimmed ? 0.5 : 1}
-              />
-            );
-          });
-        })}
+        {bars.map((bar, index) => (
+          <path
+            key={bar.key}
+            d={bar.d}
+            fill={fillFor(bar.color, gradient)}
+            fillOpacity={hover !== null && hover.index !== Math.floor(index / series.length) ? 0.5 : 1}
+          />
+        ))}
       </g>
       <HoverOverlay
         columns={columns}
@@ -85,3 +141,95 @@ export const barChart: ChartRenderer = ({ data, config, width, height, hover, se
     </>
   );
 };
+
+const AXIS_COLOR = "var(--hb-color-border)";
+const LABEL_COLOR = "var(--hb-color-text-secondary)";
+
+const horizontalBar = ({ data, config, width, height, hover, setHover }: ChartRenderContext) => {
+  const margin = resolveMargin(config);
+  const innerWidth = Math.max(0, width - margin.left - margin.right);
+  const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+  const series = resolveSeries(config);
+  const gradient = config.gradient !== false;
+  const categories = data.map((d) => str(d, config.x));
+
+  const band = scaleBand<string>().domain(categories).range([0, innerHeight]).padding(0.3);
+  const sub = scaleBand<string>()
+    .domain(series.map((s) => s.key))
+    .range([0, band.bandwidth()])
+    .padding(0.15);
+  const xMax = max(data, (d) => Math.max(...series.map((s) => num(d, s.key)))) ?? 0;
+  const xScale = scaleLinear().domain([0, xMax]).range([0, innerWidth]).nice();
+
+  const bars = data.flatMap((d, categoryIndex) => {
+    const bandStart = band(str(d, config.x)) ?? 0;
+
+    return series.map((s, seriesIndex) => {
+      const value = num(d, s.key);
+      const color = colorFromDatum(d, config) ?? s.color;
+      const y = bandStart + (sub(s.key) ?? 0);
+      const h = sub.bandwidth();
+      const w = xScale(value);
+
+      return { categoryIndex, key: `${categoryIndex}-${seriesIndex}`, color, y, h, w, datum: d };
+    });
+  });
+
+  const colors = uniqueColors(bars.map((bar) => bar.color));
+
+  return (
+    <>
+      {gradient && <BarGradients colors={colors} horizontal />}
+      <g>
+        {xScale.ticks(4).map((tick) => (
+          <line
+            key={tick}
+            x1={margin.left + xScale(tick)}
+            x2={margin.left + xScale(tick)}
+            y1={margin.top}
+            y2={margin.top + innerHeight}
+            stroke={AXIS_COLOR}
+            strokeOpacity={0.5}
+          />
+        ))}
+        {categories.map((category, index) => (
+          <text
+            key={`${category}-${index}`}
+            x={margin.left - 10}
+            y={margin.top + (band(category) ?? 0) + band.bandwidth() / 2}
+            textAnchor="end"
+            dominantBaseline="central"
+            fontSize={11}
+            fontFamily="'Inter', system-ui, sans-serif"
+            fill={LABEL_COLOR}
+          >
+            {formatCategory(config, category)}
+          </text>
+        ))}
+      </g>
+      <g transform={`translate(${margin.left}, ${margin.top})`}>
+        {bars.map((bar) => (
+          <path
+            key={bar.key}
+            d={roundedRightRect(0, bar.y, bar.w, bar.h, Math.min(4, bar.h / 2, bar.w))}
+            fill={fillFor(bar.color, gradient)}
+            fillOpacity={hover !== null && hover.index !== bar.categoryIndex ? 0.5 : 1}
+            onMouseEnter={() =>
+              setHover({
+                index: bar.categoryIndex,
+                x: margin.left + bar.w,
+                y: margin.top + bar.y + bar.h / 2,
+                title: formatCategory(config, str(bar.datum, config.x)),
+                entries: rowsFor(bar.datum, config, series),
+              })
+            }
+          />
+        ))}
+      </g>
+    </>
+  );
+};
+
+export const barChart: ChartRenderer = (ctx) =>
+  ctx.config.horizontal === true ? horizontalBar(ctx) : verticalBar(ctx);

--- a/packages/hobom-design-system/src/charts/renderers/donut.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/donut.tsx
@@ -1,5 +1,5 @@
 import { arc as d3Arc, pie as d3Pie, type PieArcDatum } from "d3-shape";
-import { DEFAULT_PALETTE, PRIMARY_COLOR, num, str } from "../chart-lib";
+import { DEFAULT_PALETTE, PRIMARY_COLOR, colorFromDatum, num, str } from "../chart-lib";
 import type { ChartDatum, ChartRenderer } from "../types";
 
 export const donutChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
@@ -26,7 +26,8 @@ export const donutChart: ChartRenderer = ({ data, config, width, height, hover, 
       {slices.map((slice, index) => {
         const [centroidX, centroidY] = arcGenerator.centroid(slice);
         const dimmed = hover !== null && hover.index !== index;
-        const color = palette[index % palette.length] ?? PRIMARY_COLOR;
+        const color =
+          colorFromDatum(slice.data, config) ?? palette[index % palette.length] ?? PRIMARY_COLOR;
         const label = str(slice.data, config.label);
 
         return (

--- a/packages/hobom-design-system/src/charts/renderers/radar.tsx
+++ b/packages/hobom-design-system/src/charts/renderers/radar.tsx
@@ -1,0 +1,116 @@
+import { scaleLinear } from "d3-scale";
+import { max } from "d3-array";
+import { formatCategory, num, resolveSeries, str } from "../chart-lib";
+import type { ChartRenderer } from "../types";
+
+const GRID_COLOR = "var(--hb-color-border)";
+const LABEL_COLOR = "var(--hb-color-text-secondary)";
+const RINGS = 4;
+
+/** Anchor a spoke label by which side of the center it sits on. */
+const anchorFor = (labelX: number, centerX: number): "start" | "middle" | "end" => {
+  if (Math.abs(labelX - centerX) < 4) return "middle";
+
+  return labelX > centerX ? "start" : "end";
+};
+
+/**
+ * A polar/radar chart: one spoke per category, a filled polygon tracing the
+ * value of the first series. Single-series (reads `config.y` or `series[0]`).
+ */
+export const radarChart: ChartRenderer = ({ data, config, width, height, hover, setHover }) => {
+  const series = resolveSeries(config);
+  const measure = series[0];
+
+  if (!measure || data.length < 3) return null;
+
+  const cx = width / 2;
+  const cy = height / 2;
+  const radius = Math.max(0, Math.min(width, height) / 2 - 28);
+  const valueMax = max(data, (d) => num(d, measure.key)) ?? 0;
+  const radial = scaleLinear().domain([0, valueMax]).range([0, radius]).nice();
+
+  const angleAt = (index: number) => -Math.PI / 2 + (index * 2 * Math.PI) / data.length;
+  const pointAt = (index: number, distance: number): [number, number] => [
+    cx + distance * Math.cos(angleAt(index)),
+    cy + distance * Math.sin(angleAt(index)),
+  ];
+
+  const polygon = (distance: (index: number) => number): string =>
+    data.map((_, index) => pointAt(index, distance(index)).join(",")).join(" ");
+
+  const shape = data
+    .map((datum, index) => pointAt(index, radial(num(datum, measure.key))).join(","))
+    .join(" ");
+
+  return (
+    <g>
+      {radial
+        .ticks(RINGS)
+        .filter((tick) => tick > 0)
+        .map((tick) => (
+          <polygon
+            key={tick}
+            points={polygon(() => radial(tick))}
+            fill="none"
+            stroke={GRID_COLOR}
+            strokeOpacity={0.6}
+          />
+        ))}
+      {data.map((_, index) => {
+        const [ex, ey] = pointAt(index, radius);
+
+        return <line key={index} x1={cx} y1={cy} x2={ex} y2={ey} stroke={GRID_COLOR} strokeOpacity={0.6} />;
+      })}
+
+      <polygon points={shape} fill={measure.color} fillOpacity={0.3} stroke={measure.color} strokeWidth={2} />
+
+      {data.map((datum, index) => {
+        const value = num(datum, measure.key);
+        const [px, py] = pointAt(index, radial(value));
+        const dimmed = hover !== null && hover.index !== index;
+
+        return (
+          <circle
+            key={index}
+            cx={px}
+            cy={py}
+            r={4}
+            fill={measure.color}
+            fillOpacity={dimmed ? 0.5 : 1}
+            stroke="var(--hb-color-surface)"
+            strokeWidth={2}
+            onMouseEnter={() =>
+              setHover({
+                index,
+                x: px,
+                y: py,
+                title: formatCategory(config, str(datum, config.x)),
+                entries: [{ label: measure.label, value, color: measure.color }],
+              })
+            }
+          />
+        );
+      })}
+
+      {data.map((datum, index) => {
+        const [lx, ly] = pointAt(index, radius + 14);
+
+        return (
+          <text
+            key={index}
+            x={lx}
+            y={ly}
+            textAnchor={anchorFor(lx, cx)}
+            dominantBaseline="central"
+            fontSize={11}
+            fontFamily="'Inter', system-ui, sans-serif"
+            fill={LABEL_COLOR}
+          >
+            {formatCategory(config, str(datum, config.x))}
+          </text>
+        );
+      })}
+    </g>
+  );
+};

--- a/packages/hobom-design-system/src/charts/types.ts
+++ b/packages/hobom-design-system/src/charts/types.ts
@@ -40,6 +40,16 @@ export interface ChartConfig {
   color?: string;
   /** Palette for multi-slice/series charts. */
   colors?: readonly string[];
+  /** Field key for a per-datum color (bar/donut); overrides series/palette color. */
+  colorKey?: string;
+  /** Stack cartesian series instead of grouping them side by side (bar). */
+  stacked?: boolean;
+  /** Lay bars along the x axis with categories on the y axis (bar). */
+  horizontal?: boolean;
+  /** Fill bars with a subtle top-to-bottom gradient. Defaults to true. */
+  gradient?: boolean;
+  /** Render the built-in legend. Defaults to true; disable to supply your own. */
+  legend?: boolean;
   /** Override the default plot margins. */
   margin?: Partial<ChartMargin>;
   /** Format a value for axis ticks / labels. */


### PR DESCRIPTION
Prepares the in-house chart factory to absorb the dashboard's recharts charts without a visible style change. No app code changes yet — that migration follows in a second PR.

New `ChartConfig` options and one new renderer:

- **`stacked`** — stack cartesian series (completed vs remaining, read/unread).
- **`horizontal`** — bars along the x axis with categories on the left (per-label counts).
- **`colorKey`** — a per-datum color field, so a bar or slice can be colored by its own value (status codes, log levels).
- **`gradient`** — a subtle top-to-bottom bar fill, on by default, matching the current look.
- **`legend`** — opt out of the built-in legend when a screen supplies its own side legend.
- **`radar`** — a polar renderer for module-usage comparisons.

Bars emit one gradient def per unique color; horizontal bars carry their own category axis and per-bar hover. Verified with unit tests for the new geometry/color helpers and render smoke tests for each mode (35 chart tests), plus Storybook stories.