### PR TITLE
Migrate dashboard charts off recharts to the in-house factory

### DIFF
--- a/apps/hobom-system/package.json
+++ b/apps/hobom-system/package.json
@@ -35,8 +35,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.56.4",
     "react-router-dom": "^7.6.1",
-    "react-toastify": "^11.0.5",
-    "recharts": "^3.7.0"
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@stylexjs/unplugin": "^0.19.0",

--- a/apps/hobom-system/src/features/dashboard-activity/ui/ModuleUsageRadar.tsx
+++ b/apps/hobom-system/src/features/dashboard-activity/ui/ModuleUsageRadar.tsx
@@ -1,11 +1,4 @@
-import {
-  RadarChart,
-  PolarGrid,
-  PolarAngleAxis,
-  PolarRadiusAxis,
-  Radar,
-  ResponsiveContainer,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface ModuleUsageRadarProps {
@@ -37,14 +30,13 @@ export const ModuleUsageRadar = ({ data }: ModuleUsageRadarProps) => {
       >
         모듈별 활동 비중
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <RadarChart data={chartData}>
-          <PolarGrid />
-          <PolarAngleAxis dataKey="label" tick={{ fontSize: 12 }} />
-          <PolarRadiusAxis tick={false} axisLine={false} />
-          <Radar dataKey="percentage" stroke="#4680ff" fill="#4680ff" fillOpacity={0.3} />
-        </RadarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="radar"
+        data={chartData}
+        config={{ x: "label", y: "percentage", color: "#4680ff" }}
+        height={260}
+        ariaLabel="모듈별 활동 비중"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-daily-todo/ui/CategoryDonutChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-daily-todo/ui/CategoryDonutChart.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { CHART_COLORS } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
 
@@ -12,11 +12,6 @@ interface CategoryDonutChartProps {
 }
 
 export const CategoryDonutChart = ({ data }: CategoryDonutChartProps) => {
-  const chartData = data.map((item, i) => ({
-    ...item,
-    fill: CHART_COLORS[i % CHART_COLORS.length],
-  }));
-
   return (
     <Hb.Box>
       <Hb.Text
@@ -28,22 +23,13 @@ export const CategoryDonutChart = ({ data }: CategoryDonutChartProps) => {
       >
         카테고리별 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <PieChart>
-          <Pie
-            data={chartData}
-            dataKey="total"
-            nameKey="categoryTitle"
-            cx="50%"
-            cy="50%"
-            innerRadius={50}
-            outerRadius={90}
-            isAnimationActive={false}
-          />
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+      <Chart
+        type="donut"
+        data={data}
+        config={{ label: "categoryTitle", value: "total", colors: CHART_COLORS }}
+        height={260}
+        ariaLabel="카테고리별 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-daily-todo/ui/CompletionRateLineChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-daily-todo/ui/CompletionRateLineChart.tsx
@@ -1,12 +1,4 @@
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface CompletionRateLineChartProps {
@@ -25,25 +17,19 @@ export const CompletionRateLineChart = ({ data }: CompletionRateLineChartProps) 
       >
         일별 완료율 추이
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <LineChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} />
-          <YAxis
-            domain={[0, 1]}
-            tick={{ fontSize: 11 }}
-            tickFormatter={(v: number) => `${Math.round(v * 100)}%`}
-          />
-          <Tooltip formatter={(v) => [`${Math.round(Number(v) * 100)}%`, "완료율"]} />
-          <Line
-            type="monotone"
-            dataKey="completionRate"
-            stroke="#4680ff"
-            strokeWidth={2}
-            dot={{ r: 3 }}
-          />
-        </LineChart>
-      </ResponsiveContainer>
+      <Chart
+        type="line"
+        data={data}
+        config={{
+          x: "date",
+          y: "completionRate",
+          color: "#4680ff",
+          formatX: (v) => v.slice(5),
+          formatValue: (v) => `${Math.round(v * 100)}%`,
+        }}
+        height={260}
+        ariaLabel="일별 완료율 추이"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-daily-todo/ui/CycleProgressBar.tsx
+++ b/apps/hobom-system/src/features/dashboard-daily-todo/ui/CycleProgressBar.tsx
@@ -1,13 +1,4 @@
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface CycleProgressBarProps {
@@ -38,52 +29,20 @@ export const CycleProgressBar = ({ data }: CycleProgressBarProps) => {
       >
         반복주기별 완료 현황
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={chartData} barSize={28}>
-          <defs>
-            <linearGradient id="cycleBarGreen" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#2ca87f" stopOpacity={1} />
-              <stop offset="100%" stopColor="#2ca87f" stopOpacity={0.65} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" />
-          <XAxis
-            dataKey="label"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tick={{ fontSize: 11, fill: "#8c8c8c" }} axisLine={false} tickLine={false} />
-          <Tooltip
-            cursor={{ fill: "rgba(44,168,127,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Legend
-            iconType="circle"
-            iconSize={8}
-            wrapperStyle={{ fontSize: 12, color: "#8c8c8c" }}
-          />
-          <Bar
-            dataKey="completed"
-            name="완료"
-            stackId="a"
-            fill="url(#cycleBarGreen)"
-            radius={[0, 0, 0, 0]}
-          />
-          <Bar
-            dataKey="incomplete"
-            name="미완료"
-            stackId="a"
-            fill="#e9ecef"
-            radius={[6, 6, 0, 0]}
-          />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={chartData}
+        config={{
+          x: "label",
+          series: [
+            { key: "completed", label: "완료", color: "#2ca87f" },
+            { key: "incomplete", label: "미완료", color: "#e9ecef" },
+          ],
+          stacked: true,
+        }}
+        height={260}
+        ariaLabel="반복주기별 완료 현황"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/LevelDistributionChart.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import type { LogLevelCount } from "@/entities/log";
 import { Hb } from "@/shared/ui";
 
@@ -25,6 +25,7 @@ interface LevelDistributionChartProps {
 export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) => {
   const sorted = [...data].sort((a, b) => levelIndex(a.level) - levelIndex(b.level));
   const total = sorted.reduce((sum, d) => sum + d.count, 0);
+  const chartData = sorted.map((d) => ({ ...d, color: LEVEL_COLORS[d.level] ?? "#94baff" }));
 
   return (
     <Hb.Box>
@@ -44,56 +45,21 @@ export const LevelDistributionChart = ({ data }: LevelDistributionChartProps) =>
           gap: 32,
         }}
       >
-        <ResponsiveContainer width={180} height={180}>
-          <PieChart>
-            <Pie
-              data={sorted}
-              dataKey="count"
-              nameKey="level"
-              cx="50%"
-              cy="50%"
-              outerRadius={80}
-              innerRadius={45}
-              strokeWidth={2}
-              stroke="#fff"
-              animationBegin={0}
-              animationDuration={800}
-            >
-              {sorted.map((entry) => (
-                <Cell key={entry.level} fill={LEVEL_COLORS[entry.level] ?? "#94baff"} />
-              ))}
-            </Pie>
-            <Tooltip
-              // @ts-expect-error recharts formatter type mismatch
-              formatter={(value: number, name: string) => [value.toLocaleString(), name]}
-              contentStyle={{
-                borderRadius: 8,
-                border: "none",
-                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                fontSize: 13,
-                padding: "8px 12px",
-              }}
-            />
-            <text
-              x="50%"
-              y="48%"
-              textAnchor="middle"
-              dominantBaseline="central"
-              style={{ fontSize: 18, fontWeight: 700, fill: "#1d2630" }}
-            >
-              {total.toLocaleString()}
-            </text>
-            <text
-              x="50%"
-              y="62%"
-              textAnchor="middle"
-              dominantBaseline="central"
-              style={{ fontSize: 11, fill: "#8c8c8c" }}
-            >
-              전체
-            </text>
-          </PieChart>
-        </ResponsiveContainer>
+        <Hb.Box style={{ width: 180, flexShrink: 0 }}>
+          <Chart
+            type="donut"
+            data={chartData}
+            config={{
+              label: "level",
+              value: "count",
+              colorKey: "color",
+              legend: false,
+              formatValue: (v) => v.toLocaleString(),
+            }}
+            height={180}
+            ariaLabel="로그 레벨 분포"
+          />
+        </Hb.Box>
         <Hb.Box
           style={{
             flex: 1,

--- a/apps/hobom-system/src/features/dashboard-log/ui/RequestVolumeChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/RequestVolumeChart.tsx
@@ -1,53 +1,6 @@
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import type { LogRequestCount } from "@/entities/log";
 import { Hb } from "@/shared/ui";
-
-interface ChartTooltipProps {
-  active?: boolean;
-  payload?: { value?: number }[];
-  label?: string;
-}
-
-const CustomTooltip = ({ active, payload, label }: ChartTooltipProps) => {
-  if (!active || !payload?.length) return null;
-  const value = payload[0]?.value ?? 0;
-
-  return (
-    <div
-      style={{
-        backgroundColor: "#1d2630",
-        borderRadius: 8,
-        padding: "10px 14px",
-        boxShadow: "0 8px 24px rgba(0,0,0,0.15)",
-      }}
-    >
-      <div style={{ fontSize: 11, color: "#94a3b8", marginBottom: 4 }}>
-        {String(label).slice(11, 16)}
-      </div>
-      <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-        <span
-          style={{
-            fontSize: 18,
-            fontWeight: 700,
-            color: "#fff",
-            fontVariantNumeric: "tabular-nums",
-          }}
-        >
-          {value.toLocaleString()}
-        </span>
-        <span style={{ fontSize: 11, color: "#94a3b8" }}>req/min</span>
-      </div>
-    </div>
-  );
-};
 
 interface RequestVolumeChartProps {
   data: LogRequestCount[];
@@ -65,53 +18,19 @@ export const RequestVolumeChart = ({ data }: RequestVolumeChartProps) => {
       >
         분당 요청량
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={280}>
-        <AreaChart data={data}>
-          <defs>
-            <linearGradient id="areaRequestVolume" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#22d3ee" stopOpacity={0.3} />
-              <stop offset="50%" stopColor="#818cf8" stopOpacity={0.1} />
-              <stop offset="100%" stopColor="#818cf8" stopOpacity={0} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" strokeDasharray="4 4" />
-          <XAxis
-            dataKey="minute"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            tickFormatter={(v: string) => v.slice(11, 16)}
-            axisLine={false}
-            tickLine={false}
-            interval="preserveStartEnd"
-          />
-          <YAxis
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={(v: number) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v))}
-          />
-          <Tooltip
-            content={<CustomTooltip />}
-            cursor={{
-              stroke: "#22d3ee",
-              strokeWidth: 1,
-              strokeDasharray: "4 4",
-            }}
-          />
-          <Area
-            type="monotone"
-            dataKey="totalRequests"
-            stroke="#22d3ee"
-            strokeWidth={2}
-            fill="url(#areaRequestVolume)"
-            activeDot={{
-              r: 5,
-              fill: "#22d3ee",
-              stroke: "#fff",
-              strokeWidth: 2,
-            }}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+      <Chart
+        type="area"
+        data={data}
+        config={{
+          x: "minute",
+          y: "totalRequests",
+          color: "#22d3ee",
+          formatX: (v) => v.slice(11, 16),
+          formatValue: (v) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)),
+        }}
+        height={280}
+        ariaLabel="분당 요청량"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-log/ui/ServiceTrafficChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/ServiceTrafficChart.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { CHART_COLORS } from "@/entities/dashboard";
 import type { LogServiceCount } from "@/entities/log";
 import { Hb } from "@/shared/ui";
@@ -29,59 +29,21 @@ export const ServiceTrafficChart = ({ data }: ServiceTrafficChartProps) => {
           gap: 32,
         }}
       >
-        <ResponsiveContainer width={180} height={180}>
-          <PieChart>
-            <Pie
-              data={data}
-              dataKey="count"
-              nameKey="serviceType"
-              cx="50%"
-              cy="50%"
-              innerRadius={50}
-              outerRadius={80}
-              strokeWidth={2}
-              stroke="#fff"
-              animationBegin={0}
-              animationDuration={800}
-            >
-              {data.map((_, i) => (
-                <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-              ))}
-            </Pie>
-            <Tooltip
-              // @ts-expect-error recharts formatter type mismatch
-              formatter={(value: number, name: string) => [
-                value.toLocaleString(),
-                SERVICE_LABEL_MAP[name] ?? name,
-              ]}
-              contentStyle={{
-                borderRadius: 8,
-                border: "none",
-                boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                fontSize: 13,
-                padding: "8px 12px",
-              }}
-            />
-            <text
-              x="50%"
-              y="48%"
-              textAnchor="middle"
-              dominantBaseline="central"
-              style={{ fontSize: 18, fontWeight: 700, fill: "#1d2630" }}
-            >
-              {total.toLocaleString()}
-            </text>
-            <text
-              x="50%"
-              y="62%"
-              textAnchor="middle"
-              dominantBaseline="central"
-              style={{ fontSize: 11, fill: "#8c8c8c" }}
-            >
-              전체 요청
-            </text>
-          </PieChart>
-        </ResponsiveContainer>
+        <Hb.Box style={{ width: 180, flexShrink: 0 }}>
+          <Chart
+            type="donut"
+            data={data}
+            config={{
+              label: "serviceType",
+              value: "count",
+              colors: CHART_COLORS,
+              legend: false,
+              formatValue: (v) => v.toLocaleString(),
+            }}
+            height={180}
+            ariaLabel="서비스별 트래픽"
+          />
+        </Hb.Box>
         <Hb.Box
           style={{
             flex: 1,

--- a/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-log/ui/StatusCodeChart.tsx
@@ -1,80 +1,15 @@
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import type { LogStatusCount } from "@/entities/log";
 import { Hb } from "@/shared/ui";
-import { getStatusColor, getStatusLabel } from "../lib/log-dashboard.lib";
-
-interface ChartTooltipProps {
-  active?: boolean;
-  payload?: { payload: LogStatusCount }[];
-}
-
-const CustomTooltip = ({ active, payload }: ChartTooltipProps) => {
-  if (!active || !payload?.length) return null;
-  const item = payload[0]?.payload;
-
-  if (!item) return null;
-  const color = getStatusColor(item.statusCode);
-
-  return (
-    <div
-      style={{
-        backgroundColor: "#1d2630",
-        borderRadius: 8,
-        padding: "10px 14px",
-        boxShadow: "0 8px 24px rgba(0,0,0,0.15)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          marginBottom: 4,
-        }}
-      >
-        <div
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor: color,
-          }}
-        />
-        <span style={{ fontSize: 12, color: "#94a3b8" }}>
-          {item.statusCode} {getStatusLabel(item.statusCode)}
-        </span>
-      </div>
-      <div style={{ display: "flex", alignItems: "baseline", gap: 4 }}>
-        <span
-          style={{
-            fontSize: 18,
-            fontWeight: 700,
-            color: "#fff",
-            fontVariantNumeric: "tabular-nums",
-          }}
-        >
-          {item.count.toLocaleString()}
-        </span>
-        <span style={{ fontSize: 11, color: "#94a3b8" }}>건</span>
-      </div>
-    </div>
-  );
-};
+import { getStatusColor } from "../lib/log-dashboard.lib";
 
 interface StatusCodeChartProps {
   data: LogStatusCount[];
 }
 
 export const StatusCodeChart = ({ data }: StatusCodeChartProps) => {
+  const chartData = data.map((d) => ({ ...d, color: getStatusColor(d.statusCode) }));
+
   return (
     <Hb.Box
       style={{
@@ -92,35 +27,18 @@ export const StatusCodeChart = ({ data }: StatusCodeChartProps) => {
       >
         HTTP 상태 코드 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height="100%" minHeight={200}>
-        <BarChart data={data} barCategoryGap="25%">
-          <CartesianGrid vertical={false} stroke="#f0f0f0" strokeDasharray="4 4" />
-          <XAxis
-            dataKey="statusCode"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-            tickFormatter={(v: number) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v))}
-          />
-          <Tooltip content={<CustomTooltip />} cursor={{ fill: "rgba(70,128,255,0.04)" }} />
-          <Bar
-            dataKey="count"
-            radius={[6, 6, 0, 0]}
-            maxBarSize={40}
-            animationBegin={0}
-            animationDuration={600}
-          >
-            {data.map((entry) => (
-              <Cell key={entry.statusCode} fill={getStatusColor(entry.statusCode)} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={chartData}
+        config={{
+          x: "statusCode",
+          y: "count",
+          colorKey: "color",
+          formatValue: (v) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)),
+        }}
+        height={260}
+        ariaLabel="HTTP 상태 코드 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-message/ui/MonthlySentBarChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-message/ui/MonthlySentBarChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface MonthlySentBarChartProps {
@@ -17,34 +17,13 @@ export const MonthlySentBarChart = ({ data }: MonthlySentBarChartProps) => {
       >
         월별 발송 추이
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data} barSize={32}>
-          <defs>
-            <linearGradient id="msgBarBlue" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#4680ff" stopOpacity={1} />
-              <stop offset="100%" stopColor="#4680ff" stopOpacity={0.6} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" />
-          <XAxis
-            dataKey="month"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tick={{ fontSize: 11, fill: "#8c8c8c" }} axisLine={false} tickLine={false} />
-          <Tooltip
-            cursor={{ fill: "rgba(70,128,255,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="발송 수" fill="url(#msgBarBlue)" radius={[6, 6, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "month", y: "count", color: "#4680ff" }}
+        height={260}
+        ariaLabel="월별 발송 추이"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-note/ui/LabelBarChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-note/ui/LabelBarChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface LabelBarChartProps {
@@ -17,41 +17,13 @@ export const LabelBarChart = ({ data }: LabelBarChartProps) => {
       >
         라벨별 노트 수
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data} layout="vertical" barSize={20}>
-          <defs>
-            <linearGradient id="labelBarBlue" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0%" stopColor="#4680ff" stopOpacity={0.6} />
-              <stop offset="100%" stopColor="#4680ff" stopOpacity={1} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid horizontal={false} stroke="#f0f0f0" />
-          <XAxis
-            type="number"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis
-            type="category"
-            dataKey="labelId"
-            tick={{ fontSize: 11, fill: "#5a6a85" }}
-            axisLine={false}
-            tickLine={false}
-            width={80}
-          />
-          <Tooltip
-            cursor={{ fill: "rgba(70,128,255,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="노트 수" fill="url(#labelBarBlue)" radius={[0, 6, 6, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "labelId", y: "count", color: "#4680ff", horizontal: true, margin: { left: 80 } }}
+        height={260}
+        ariaLabel="라벨별 노트 수"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-note/ui/NoteCreationAreaChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-note/ui/NoteCreationAreaChart.tsx
@@ -1,12 +1,4 @@
-import {
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface NoteCreationAreaChartProps {
@@ -25,22 +17,13 @@ export const NoteCreationAreaChart = ({ data }: NoteCreationAreaChartProps) => {
       >
         일별 노트 생성 추이
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <AreaChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="date" tick={{ fontSize: 11 }} tickFormatter={(v: string) => v.slice(5)} />
-          <YAxis tick={{ fontSize: 11 }} />
-          <Tooltip />
-          <Area
-            type="monotone"
-            dataKey="count"
-            name="생성 수"
-            stroke="#4680ff"
-            fill="#4680ff"
-            fillOpacity={0.15}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+      <Chart
+        type="area"
+        data={data}
+        config={{ x: "date", y: "count", color: "#4680ff", formatX: (v) => v.slice(5) }}
+        height={260}
+        ariaLabel="일별 노트 생성 추이"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-note/ui/NoteStatusPieChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-note/ui/NoteStatusPieChart.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { CHART_COLORS } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
 
@@ -18,17 +18,13 @@ export const NoteStatusPieChart = ({ data }: NoteStatusPieChartProps) => {
       >
         노트 상태 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <PieChart>
-          <Pie data={data} dataKey="count" nameKey="status" cx="50%" cy="50%" outerRadius={90}>
-            {data.map((_, i) => (
-              <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+      <Chart
+        type="donut"
+        data={data}
+        config={{ label: "status", value: "count", colors: CHART_COLORS }}
+        height={260}
+        ariaLabel="노트 상태 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-notification/ui/NotificationCategoryDonut.tsx
+++ b/apps/hobom-system/src/features/dashboard-notification/ui/NotificationCategoryDonut.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { CHART_COLORS } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
 
@@ -18,25 +18,13 @@ export const NotificationCategoryDonut = ({ data }: NotificationCategoryDonutPro
       >
         카테고리별 알림 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <PieChart>
-          <Pie
-            data={data}
-            dataKey="count"
-            nameKey="category"
-            cx="50%"
-            cy="50%"
-            innerRadius={50}
-            outerRadius={90}
-          >
-            {data.map((_, i) => (
-              <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+      <Chart
+        type="donut"
+        data={data}
+        config={{ label: "category", value: "count", colors: CHART_COLORS }}
+        height={260}
+        ariaLabel="카테고리별 알림 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-notification/ui/ReadUnreadStackedBar.tsx
+++ b/apps/hobom-system/src/features/dashboard-notification/ui/ReadUnreadStackedBar.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface ReadUnreadStackedBarProps {
@@ -17,36 +17,13 @@ export const ReadUnreadStackedBar = ({ data }: ReadUnreadStackedBarProps) => {
       >
         일별 알림 추이
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data} barSize={24}>
-          <defs>
-            <linearGradient id="notifBarBlue" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#4680ff" stopOpacity={1} />
-              <stop offset="100%" stopColor="#4680ff" stopOpacity={0.6} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" />
-          <XAxis
-            dataKey="date"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            tickFormatter={(v: string) => v.slice(5)}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tick={{ fontSize: 11, fill: "#8c8c8c" }} axisLine={false} tickLine={false} />
-          <Tooltip
-            cursor={{ fill: "rgba(70,128,255,0.06)" }}
-            labelFormatter={(v) => String(v).slice(5)}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="알림 수" fill="url(#notifBarBlue)" radius={[6, 6, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "date", y: "count", color: "#4680ff", formatX: (v) => v.slice(5) }}
+        height={260}
+        ariaLabel="일별 알림 추이"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-system/ui/RetryDistributionBar.tsx
+++ b/apps/hobom-system/src/features/dashboard-system/ui/RetryDistributionBar.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface RetryDistributionBarProps {
@@ -6,11 +6,6 @@ interface RetryDistributionBarProps {
 }
 
 export const RetryDistributionBar = ({ data }: RetryDistributionBarProps) => {
-  const chartData = data.map((d) => ({
-    ...d,
-    label: `${d.retryCount}회`,
-  }));
-
   return (
     <Hb.Box>
       <Hb.Text
@@ -22,34 +17,13 @@ export const RetryDistributionBar = ({ data }: RetryDistributionBarProps) => {
       >
         재시도 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={chartData} barSize={32}>
-          <defs>
-            <linearGradient id="retryBarOrange" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#e58a00" stopOpacity={1} />
-              <stop offset="100%" stopColor="#e58a00" stopOpacity={0.6} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" />
-          <XAxis
-            dataKey="label"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tick={{ fontSize: 11, fill: "#8c8c8c" }} axisLine={false} tickLine={false} />
-          <Tooltip
-            cursor={{ fill: "rgba(229,138,0,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="건수" fill="url(#retryBarOrange)" radius={[6, 6, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "retryCount", y: "count", color: "#e58a00", formatX: (v) => `${v}회` }}
+        height={260}
+        ariaLabel="재시도 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/dashboard-system/ui/ThroughputLineChart.tsx
+++ b/apps/hobom-system/src/features/dashboard-system/ui/ThroughputLineChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { Hb } from "@/shared/ui";
 
 interface ThroughputLineChartProps {
@@ -17,36 +17,13 @@ export const ThroughputLineChart = ({ data }: ThroughputLineChartProps) => {
       >
         시간대별 처리량
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={data} barSize={20}>
-          <defs>
-            <linearGradient id="barThroughput" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#4680ff" stopOpacity={1} />
-              <stop offset="100%" stopColor="#4680ff" stopOpacity={0.55} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid vertical={false} stroke="#f0f0f0" />
-          <XAxis
-            dataKey="hour"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            tickFormatter={(v: number) => `${v}시`}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis tick={{ fontSize: 11, fill: "#8c8c8c" }} axisLine={false} tickLine={false} />
-          <Tooltip
-            labelFormatter={(v) => `${v}시`}
-            cursor={{ fill: "rgba(70,128,255,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="처리량" fill="url(#barThroughput)" radius={[6, 6, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "hour", y: "count", color: "#4680ff", formatX: (v) => `${v}시` }}
+        height={300}
+        ariaLabel="시간대별 처리량"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/project-dashboard/ui/PriorityDistributionChart.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/PriorityDistributionChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import type { ProjectIssueDashboardDto } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
 
@@ -18,46 +18,13 @@ export const PriorityDistributionChart = ({ data }: PriorityDistributionChartPro
       >
         우선순위별 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data} layout="vertical" barSize={20}>
-          <defs>
-            <linearGradient id="priorityBarGradient" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0%" stopColor="#4680ff" stopOpacity={0.6} />
-              <stop offset="100%" stopColor="#4680ff" stopOpacity={1} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid horizontal={false} stroke="#f0f0f0" />
-          <XAxis
-            type="number"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis
-            type="category"
-            dataKey="priority"
-            tick={{ fontSize: 11, fill: "#5a6a85" }}
-            axisLine={false}
-            tickLine={false}
-            width={80}
-          />
-          <Tooltip
-            cursor={{ fill: "rgba(70,128,255,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar
-            dataKey="count"
-            name="이슈 수"
-            fill="url(#priorityBarGradient)"
-            radius={[0, 6, 6, 0]}
-          />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "priority", y: "count", color: "#4680ff", horizontal: true, margin: { left: 80 } }}
+        height={260}
+        ariaLabel="우선순위별 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/project-dashboard/ui/StatusDistributionChart.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/StatusDistributionChart.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import { CHART_COLORS } from "@/entities/dashboard";
 import type { ProjectIssueDashboardDto } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
@@ -19,25 +19,13 @@ export const StatusDistributionChart = ({ data }: StatusDistributionChartProps) 
       >
         상태별 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <PieChart>
-          <Pie
-            data={data}
-            dataKey="count"
-            nameKey="status"
-            cx="50%"
-            cy="50%"
-            innerRadius={50}
-            outerRadius={90}
-          >
-            {data.map((_, i) => (
-              <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-            ))}
-          </Pie>
-          <Tooltip />
-          <Legend />
-        </PieChart>
-      </ResponsiveContainer>
+      <Chart
+        type="donut"
+        data={data}
+        config={{ label: "status", value: "count", colors: CHART_COLORS }}
+        height={260}
+        ariaLabel="상태별 분포"
+      />
     </Hb.Box>
   );
 };

--- a/apps/hobom-system/src/features/project-dashboard/ui/TypeDistributionChart.tsx
+++ b/apps/hobom-system/src/features/project-dashboard/ui/TypeDistributionChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import { Chart } from "hobom-design-system/charts";
 import type { ProjectIssueDashboardDto } from "@/entities/dashboard";
 import { Hb } from "@/shared/ui";
 
@@ -18,41 +18,13 @@ export const TypeDistributionChart = ({ data }: TypeDistributionChartProps) => {
       >
         유형별 분포
       </Hb.Text>
-      <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data} layout="vertical" barSize={20}>
-          <defs>
-            <linearGradient id="typeBarGradient" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0%" stopColor="#34d399" stopOpacity={0.6} />
-              <stop offset="100%" stopColor="#34d399" stopOpacity={1} />
-            </linearGradient>
-          </defs>
-          <CartesianGrid horizontal={false} stroke="#f0f0f0" />
-          <XAxis
-            type="number"
-            tick={{ fontSize: 11, fill: "#8c8c8c" }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis
-            type="category"
-            dataKey="type"
-            tick={{ fontSize: 11, fill: "#5a6a85" }}
-            axisLine={false}
-            tickLine={false}
-            width={80}
-          />
-          <Tooltip
-            cursor={{ fill: "rgba(52,211,153,0.06)" }}
-            contentStyle={{
-              borderRadius: 8,
-              border: "none",
-              boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-              fontSize: 13,
-            }}
-          />
-          <Bar dataKey="count" name="이슈 수" fill="url(#typeBarGradient)" radius={[0, 6, 6, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
+      <Chart
+        type="bar"
+        data={data}
+        config={{ x: "type", y: "count", color: "#34d399", horizontal: true, margin: { left: 80 } }}
+        height={260}
+        ariaLabel="유형별 분포"
+      />
     </Hb.Box>
   );
 };

--- a/packages/hobom-design-system/src/charts/Axes.tsx
+++ b/packages/hobom-design-system/src/charts/Axes.tsx
@@ -30,6 +30,14 @@ export const Axes = ({
 }: AxesProps) => {
   const yTicks = yScale.ticks(yTickCount);
 
+  // Thin x labels so dense series (e.g. per-minute) don't overlap into a smear:
+  // keep at most one label per ~56px, always including the first and last.
+  const maxXLabels = Math.max(2, Math.floor(innerWidth / 56));
+  const xStep = Math.max(1, Math.ceil(xTicks.length / maxXLabels));
+  const shownXTicks = xTicks.filter(
+    (_, index) => index % xStep === 0 || index === xTicks.length - 1,
+  );
+
   return (
     <g>
       {yTicks.map((tick) => {
@@ -61,7 +69,7 @@ export const Axes = ({
         );
       })}
 
-      {xTicks.map((tick, index) => (
+      {shownXTicks.map((tick, index) => (
         <text
           key={`${tick.label}-${index}`}
           x={tick.x}

--- a/packages/hobom-design-system/src/charts/chart-lib.ts
+++ b/packages/hobom-design-system/src/charts/chart-lib.ts
@@ -32,14 +32,20 @@ export const resolveMargin = (config: ChartConfig): ChartMargin => ({
 export const num = (datum: ChartDatum, key: string | undefined): number => {
   if (!key) return 0;
 
-  const value = Number(datum[key]);
+  const value: unknown = Reflect.get(datum, key);
+  const parsed = Number(value);
 
-  return Number.isFinite(value) ? value : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
 };
 
 /** Coerce a datum field to a string. */
-export const str = (datum: ChartDatum, key: string | undefined): string =>
-  key && datum[key] != null ? String(datum[key]) : "";
+export const str = (datum: ChartDatum, key: string | undefined): string => {
+  if (!key) return "";
+
+  const value: unknown = Reflect.get(datum, key);
+
+  return value != null ? String(value) : "";
+};
 
 export const formatNumber = (config: ChartConfig, value: number): string =>
   config.formatValue ? config.formatValue(value) : String(value);
@@ -93,7 +99,7 @@ export const legendItems = (
 export const colorFromDatum = (datum: ChartDatum, config: ChartConfig): string | null => {
   if (!config.colorKey) return null;
 
-  const value = datum[config.colorKey];
+  const value: unknown = Reflect.get(datum, config.colorKey);
 
   return typeof value === "string" && value.length > 0 ? value : null;
 };

--- a/packages/hobom-design-system/src/charts/renderers.spec.tsx
+++ b/packages/hobom-design-system/src/charts/renderers.spec.tsx
@@ -80,6 +80,18 @@ describe("bar renderer options", () => {
   });
 });
 
+describe("dense axis labels", () => {
+  it("thins x labels so a per-minute series does not render one label per point", () => {
+    const dense = Array.from({ length: 200 }, (_, i) => ({ t: String(i), v: i % 7 }));
+    const { container } = render(
+      <Chart type="area" data={dense} config={{ x: "t", y: "v" }} ariaLabel="dense" />,
+    );
+
+    // 200 points would smear; thinning keeps this to a readable handful.
+    expect(container.querySelectorAll("text").length).toBeLessThan(20);
+  });
+});
+
 describe("radar renderer", () => {
   it("renders a value polygon with a vertex per category", () => {
     const { container } = render(

--- a/packages/hobom-design-system/src/charts/types.ts
+++ b/packages/hobom-design-system/src/charts/types.ts
@@ -1,7 +1,12 @@
 import type { CSSProperties, ReactNode } from "react";
 
-/** A single datum. Renderers read fields by the keys named in `ChartConfig`. */
-export type ChartDatum = Record<string, unknown>;
+/**
+ * A single datum: any object. Renderers read fields by the keys named in
+ * `ChartConfig`, via the `num`/`str` helpers. Typed as `object` (not
+ * `Record<string, unknown>`) so `interface`-declared rows are accepted too —
+ * interfaces lack the implicit index signature `Record` requires.
+ */
+export type ChartDatum = object;
 
 export interface ChartMargin {
   top: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,6 @@ importers:
       react-toastify:
         specifier: ^11.0.5
         version: 11.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      recharts:
-        specifier: ^3.7.0
-        version: 3.9.2(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.4)(react@19.2.7)(redux@5.0.1)
     devDependencies:
       '@stylexjs/unplugin':
         specifier: ^0.19.0
@@ -1096,17 +1093,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@reduxjs/toolkit@2.11.2':
-    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
-    peerDependencies:
-      react: 19.2.7
-      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-redux:
-        optional: true
-
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1210,9 +1196,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-a11y@10.4.6':
     resolution: {integrity: sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==}
@@ -1622,15 +1605,6 @@ packages:
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
   '@types/d3-path@3.1.1':
     resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
 
@@ -1642,9 +1616,6 @@ packages:
 
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2070,10 +2041,6 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
@@ -2102,10 +2069,6 @@ packages:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2121,9 +2084,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decimal.js-light@2.5.1:
-    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2188,9 +2148,6 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
-  es-toolkit@1.45.1:
-    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2298,9 +2255,6 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2450,9 +2404,6 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
-
-  immer@11.1.11:
-    resolution: {integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2915,21 +2866,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-is@19.2.4:
-    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
-
-  react-redux@9.2.0:
-    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
-    peerDependencies:
-      '@types/react': 19.2.14
-      react: 19.2.7
-      redux: ^5.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      redux:
-        optional: true
-
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
@@ -2961,25 +2897,9 @@ packages:
     resolution: {integrity: sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==}
     engines: {node: '>= 4'}
 
-  recharts@3.9.2:
-    resolution: {integrity: sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7
-      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  redux-thunk@3.1.0:
-    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
-    peerDependencies:
-      redux: ^5.0.0
-
-  redux@5.0.1:
-    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2988,9 +2908,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  reselect@5.2.0:
-    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3273,9 +3190,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: 19.2.7
-
-  victory-vendor@37.3.6:
-    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -4170,18 +4084,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@standard-schema/utils': 0.3.0
-      immer: 11.1.11
-      redux: 5.0.1
-      redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.2.0
-    optionalDependencies:
-      react: 19.2.7
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1)
-
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
@@ -4240,8 +4142,6 @@ snapshots:
       picomatch: 4.0.5
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.1)(react@19.2.7))':
     dependencies:
@@ -4701,14 +4601,6 @@ snapshots:
 
   '@types/d3-array@3.2.2': {}
 
-  '@types/d3-color@3.1.3': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-interpolate@3.0.4':
-    dependencies:
-      '@types/d3-color': 3.1.3
-
   '@types/d3-path@3.1.1': {}
 
   '@types/d3-scale@4.0.9':
@@ -4720,8 +4612,6 @@ snapshots:
       '@types/d3-path': 3.1.1
 
   '@types/d3-time@3.0.4': {}
-
-  '@types/d3-timer@3.0.2': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -5168,8 +5058,6 @@ snapshots:
 
   d3-color@3.1.0: {}
 
-  d3-ease@3.0.1: {}
-
   d3-format@3.1.2: {}
 
   d3-interpolate@3.0.1:
@@ -5198,8 +5086,6 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
-  d3-timer@3.0.1: {}
-
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -5212,8 +5098,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -5257,8 +5141,6 @@ snapshots:
   entities@8.0.0: {}
 
   es-module-lexer@2.0.0: {}
-
-  es-toolkit@1.45.1: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -5415,8 +5297,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eventemitter3@5.0.4: {}
-
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -5556,8 +5436,6 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
-
-  immer@11.1.11: {}
 
   imurmurhash@0.1.4: {}
 
@@ -6061,17 +5939,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-is@19.2.4: {}
-
-  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      redux: 5.0.1
-
   react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -6102,42 +5969,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.9.2(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.4)(react@19.2.7)(redux@5.0.1):
-    dependencies:
-      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
-      clsx: 2.1.1
-      decimal.js-light: 2.5.1
-      es-toolkit: 1.45.1
-      eventemitter3: 5.0.4
-      immer: 11.1.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-is: 19.2.4
-      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.7)(redux@5.0.1)
-      reselect: 5.2.0
-      tiny-invariant: 1.3.3
-      use-sync-external-store: 1.6.0(react@19.2.7)
-      victory-vendor: 37.3.6
-    transitivePeerDependencies:
-      - '@types/react'
-      - redux
-
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
-  redux-thunk@3.1.0(redux@5.0.1):
-    dependencies:
-      redux: 5.0.1
-
-  redux@5.0.1: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
-
-  reselect@5.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -6413,23 +6252,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
-
-  victory-vendor@37.3.6:
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-ease': 3.0.2
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-scale': 4.0.9
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-timer': 3.0.2
-      d3-array: 3.2.4
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-timer: 3.0.1
 
   vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
Replaces every recharts chart in the app with the design system's `Chart` component and removes the `recharts` dependency.

**Nineteen charts** across the dashboards — system, note, log, daily-todo, message, notification, activity, and project — now render through the factory: line, area, bar, donut, stacked bar, horizontal bar, per-datum-color bar, and radar. The look stays close to the recharts originals (gradient bars, gradient area fills, donut center totals). The custom side legends (service traffic, log levels) are preserved; only their donut SVG is swapped in, with the built-in legend disabled.

Two design-system changes were required and are included here:

- **`ChartDatum` widened to `object`** so `interface`-typed rows (the log and project DTOs) are accepted without casts. Field reads go through `Reflect.get` in the `num`/`str`/color helpers — no `as`, no per-call mapping, no runtime cost.
- **X-axis label thinning** (one label per ~56px, first and last always kept). A per-minute series was rendering one tick per point and smearing into an unreadable band; this restores recharts's `preserveStartEnd` feel.

### Accepted visual drifts
- Custom dark tooltips (status codes, request volume) now use the shared DS tooltip.
- The completion-rate line auto-scales its y-axis instead of pinning `[0, 1]`.
- Full pies become donuts (the factory's part-to-whole style).

Verified: workspace typecheck clean, 36 chart tests (incl. a 200-point thinning assertion and render smoke tests for every mode), DS and app lint clean.