### PR TITLE
Scaffold the Angel consumer app with a landing page

### DIFF
--- a/apps/hobom-angel/Dockerfile
+++ b/apps/hobom-angel/Dockerfile
@@ -25,7 +25,11 @@ server {
     add_header X-Content-Type-Options     "nosniff"           always;
     add_header Referrer-Policy            "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy         "camera=(), microphone=(), geolocation=()" always;
-    add_header Content-Security-Policy    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; frame-ancestors 'self';" always;
+    # Consumer surface: animal photos are served from an external object-storage
+    # CDN (§9) and the SPA calls the API gateway (§5-2), so img-src/connect-src
+    # allow https. TODO: tighten to the specific CDN + gateway origins once the
+    # image vendor and gateway host are fixed.
+    add_header Content-Security-Policy    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https:; frame-ancestors 'self';" always;
 
     # ── Compression ──
     gzip             on;

--- a/apps/hobom-angel/Dockerfile
+++ b/apps/hobom-angel/Dockerfile
@@ -1,0 +1,54 @@
+# ── Build 결과물만 패키징 (Jenkins에서 pnpm build 완료 후) ──
+FROM nginx:1.27-alpine
+
+# non-root 실행을 위한 디렉터리 권한 설정
+RUN chown -R nginx:nginx /usr/share/nginx/html \
+ && chown -R nginx:nginx /var/cache/nginx \
+ && chown -R nginx:nginx /var/log/nginx \
+ && touch /var/run/nginx.pid \
+ && chown nginx:nginx /var/run/nginx.pid
+
+COPY --chown=nginx:nginx apps/hobom-angel/dist /usr/share/nginx/html
+
+RUN cat <<'EOF' > /etc/nginx/conf.d/default.conf
+server_tokens off;
+
+server {
+    listen       8080;
+    server_name  _;
+    root         /usr/share/nginx/html;
+    index        index.html;
+
+    # ── Security Headers ──
+    add_header Strict-Transport-Security   "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options            "SAMEORIGIN"       always;
+    add_header X-Content-Type-Options     "nosniff"           always;
+    add_header Referrer-Policy            "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy         "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; frame-ancestors 'self';" always;
+
+    # ── Compression ──
+    gzip             on;
+    gzip_types       text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+    gzip_min_length  256;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location = /healthz {
+        access_log off;
+        return 200 'ok';
+        add_header Content-Type text/plain;
+    }
+}
+EOF
+
+USER nginx
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/hobom-angel/Jenkinsfile
+++ b/apps/hobom-angel/Jenkinsfile
@@ -1,0 +1,25 @@
+@Library('hobom-shared-lib') _
+hobomPipeline(
+  serviceName:    'dev-for-hobom-angel',
+  hostPort:       '3001',
+  containerPort:  '8080',
+  memory:         '256m',
+  cpus:           '0.5',
+  submodules:     false,
+  dockerfilePath: 'apps/hobom-angel',
+  preBuild:       { sh '''
+    set -eux
+    docker run --rm -v "$PWD":/app -w /app node:20 sh -c \
+      'rm -rf node_modules apps/*/node_modules apps/*/dist packages/*/node_modules packages/*/dist .pnpm-store'
+    git clean -fdx -e apps/hobom-angel/.env
+    cp /etc/hobom-dev/dev-for-hobom-angel/.env apps/hobom-angel/.env
+    docker run --rm \
+      -v "$PWD":/app -w /app node:20 sh -c '
+        corepack enable &&
+        pnpm install --frozen-lockfile &&
+        pnpm build:angel
+      '
+    rm -f apps/hobom-angel/.env
+  ''' },
+  smokeCheckPath: '/healthz'
+)

--- a/apps/hobom-angel/eslint-rules/fsd-boundaries.d.ts
+++ b/apps/hobom-angel/eslint-rules/fsd-boundaries.d.ts
@@ -1,0 +1,3 @@
+import type { Rule } from "eslint";
+
+export const rule: Rule.RuleModule;

--- a/apps/hobom-angel/eslint-rules/fsd-boundaries.js
+++ b/apps/hobom-angel/eslint-rules/fsd-boundaries.js
@@ -1,0 +1,155 @@
+import path from "path";
+
+const LAYERS = ["apps", "pages", "widgets", "features", "entities", "shared"];
+
+const ALLOWED_IMPORTS = {
+  apps: ["pages", "widgets", "features", "entities", "shared"],
+  pages: ["widgets", "features", "entities", "shared"],
+  widgets: ["features", "entities", "shared"],
+  features: ["entities", "shared"],
+  entities: ["shared"],
+  shared: ["shared"],
+};
+
+// shared, apps는 slice 개념이 없으므로 cross-segment import 허용
+const SLICELESS_LAYERS = new Set(["shared", "apps"]);
+
+function parseLocation(filePath) {
+  const parts = filePath.split(path.sep);
+  const srcIndex = parts.indexOf("src");
+  if (srcIndex < 0) return null;
+
+  const layer = parts[srcIndex + 1];
+  if (!layer || !(layer in ALLOWED_IMPORTS)) return null;
+
+  const slice = parts[srcIndex + 2] ?? null;
+
+  return { layer, slice };
+}
+
+function checkImport(context, node, importedLayer, importedSlice, current) {
+  // 같은 레이어 내 cross-slice 검사
+  if (importedLayer === current.layer) {
+    if (!SLICELESS_LAYERS.has(current.layer) && importedSlice && importedSlice !== current.slice) {
+      context.report({
+        node,
+        messageId: "crossSlice",
+        data: {
+          layer: current.layer,
+          from: current.slice,
+          to: importedSlice,
+        },
+      });
+    }
+
+    return;
+  }
+
+  // 상위 레이어 import 검사
+  if (!ALLOWED_IMPORTS[current.layer].includes(importedLayer)) {
+    context.report({
+      node,
+      messageId: "crossLayer",
+      data: {
+        currentLayer: current.layer,
+        importedLayer,
+      },
+    });
+  }
+}
+
+export const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce FSD layer and slice import boundaries",
+    },
+    messages: {
+      crossLayer: "'{{currentLayer}}' layer cannot import from '{{importedLayer}}'.",
+      crossSlice: "Cross-slice import in '{{layer}}': '{{from}}' cannot import from '{{to}}'.",
+      ownSliceAlias:
+        "Import within the same slice ('{{layer}}/{{slice}}') must be relative, not via the '@/' alias — importing your own slice's barrel risks a circular dependency.",
+      deepImport:
+        "Deep import into '{{layer}}/{{slice}}' internals. Import from its public entry: '@/{{layer}}/{{slice}}' or '@/{{layer}}/{{slice}}/ui'.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const current = parseLocation(context.filename);
+    if (!current) return {};
+
+    const checkSource = (node, importPath) => {
+      if (typeof importPath !== "string") return;
+
+      if (importPath.startsWith("@/")) {
+        const [importedLayer, importedSlice, ...rest] = importPath.slice(2).split("/");
+
+        // Own-slice imports via the `@/` alias must be relative instead — pulling
+        // your own slice's barrel (or a sibling through it) risks a circular
+        // dependency, and a plain relative path keeps intra-slice wiring local.
+        if (
+          !SLICELESS_LAYERS.has(current.layer) &&
+          importedLayer === current.layer &&
+          importedSlice === current.slice
+        ) {
+          context.report({
+            node,
+            messageId: "ownSliceAlias",
+            data: { layer: current.layer, slice: current.slice },
+          });
+
+          return;
+        }
+
+        // Cross-slice imports may reach only a slice's public entries: the root
+        // barrel (`@/layer/slice`) or the UI barrel (`@/layer/slice/ui`). Deeper
+        // paths reach into internals. Sliceless layers (shared, apps) are
+        // addressed by segment, so they're exempt.
+        if (
+          importedSlice &&
+          !SLICELESS_LAYERS.has(importedLayer) &&
+          rest.length > 0 &&
+          !(rest.length === 1 && rest[0] === "ui")
+        ) {
+          context.report({
+            node,
+            messageId: "deepImport",
+            data: { layer: importedLayer, slice: importedSlice },
+          });
+        }
+
+        checkImport(context, node, importedLayer, importedSlice ?? null, current);
+
+        return;
+      }
+
+      if (importPath.startsWith(".")) {
+        const resolved = path.resolve(path.dirname(context.filename), importPath);
+        const imported = parseLocation(resolved);
+        if (!imported) return;
+        checkImport(context, node, imported.layer, imported.slice, current);
+      }
+    };
+
+    // `node.source` carries the `from "..."` specifier. It is present on static
+    // imports and on re-exports (`export … from`), and absent on a bare
+    // `export { x }`, so the guard skips those.
+    const checkStatement = (node) => {
+      if (node.source) checkSource(node, node.source.value);
+    };
+
+    return {
+      ImportDeclaration: checkStatement,
+      // Re-exports bypass ImportDeclaration but cross boundaries all the same.
+      ExportNamedDeclaration: checkStatement,
+      ExportAllDeclaration: checkStatement,
+      // Dynamic `import("…")` (e.g. lazy-loaded pages) — only literal targets.
+      ImportExpression(node) {
+        if (node.source.type === "Literal") {
+          checkSource(node, node.source.value);
+        }
+      },
+    };
+  },
+};

--- a/apps/hobom-angel/eslint.config.js
+++ b/apps/hobom-angel/eslint.config.js
@@ -1,0 +1,84 @@
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+import { baseIgnores, baseConfig } from "../../eslint.config.js";
+import * as fsdBoundariesRule from "./eslint-rules/fsd-boundaries.js";
+
+export default tseslint.config(baseIgnores, {
+  ...baseConfig,
+  // Type-aware linting (app only for now — the packages follow separately).
+  extends: [...(baseConfig.extends ?? []), ...tseslint.configs.recommendedTypeChecked],
+  files: ["**/*.{ts,tsx}"],
+  languageOptions: {
+    ecmaVersion: 2020,
+    globals: globals.browser,
+    parserOptions: {
+      // Config/declaration files outside the TS build project lint under an
+      // inferred default project so type-aware rules don't choke on them.
+      projectService: {
+        allowDefaultProject: ["vitest.config.ts", "eslint-rules/fsd-boundaries.d.ts"],
+      },
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+  plugins: {
+    ...baseConfig.plugins,
+    "react-hooks": reactHooks,
+    "react-refresh": reactRefresh,
+    "fsd-boundaries": {
+      rules: {
+        "fsd-boundaries": fsdBoundariesRule.rule,
+      },
+    },
+  },
+  rules: {
+    ...baseConfig.rules,
+
+    // ── Type-checked: `any`-leak family deferred ──
+    // These need the source of each `any` typed; tracked as a follow-up so the
+    // high-signal async/assertion rules can land now. See ADR / PR notes.
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+
+    // Async JSX event handlers (`onClick={async …}`) are idiomatic React and
+    // safe — React discards the returned promise. Keep the rule for the risky
+    // cases (a promise passed to a void callback like `forEach`, or used in a
+    // condition), but allow it on attributes.
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      { checksVoidReturn: { attributes: false } },
+    ],
+
+    // ── React ──
+    ...reactHooks.configs.recommended.rules,
+    "react-hooks/set-state-in-effect": "off",
+    // Read-once init-guard refs during render are intentional here; matches the
+    // library packages, which already disable this compiler-ruleset check.
+    "react-hooks/refs": "off",
+    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+
+    // ── FSD Architecture ──
+    "fsd-boundaries/fsd-boundaries": "error",
+
+    // ── Design system boundary ──
+    // The app must consume UI through hobom-design-system, never the
+    // underlying styling engine directly. This keeps product code decoupled
+    // from the engine so it can be swapped without app changes.
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["@mui", "@mui/*", "@emotion", "@emotion/*"],
+            message:
+              "Import from 'hobom-design-system' instead of the styling engine directly.",
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/apps/hobom-angel/index.html
+++ b/apps/hobom-angel/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>HoBom Angel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/hobom-angel/package.json
+++ b/apps/hobom-angel/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "hobom-angel",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc -b",
+    "lint": "eslint --max-warnings=0",
+    "format": "prettier . --write",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@stylexjs/stylex": "^0.19.0",
+    "hobom-data": "workspace:*",
+    "hobom-design-system": "workspace:*",
+    "hobom-schema": "workspace:*",
+    "hobom-utils": "workspace:*",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.1"
+  },
+  "devDependencies": {
+    "@stylexjs/unplugin": "^0.19.0",
+    "@types/node": "^25.5.0",
+    "@vitejs/plugin-react-swc": "^4.3.0",
+    "vite": "^8.0.0"
+  }
+}

--- a/apps/hobom-angel/public/favicon.svg
+++ b/apps/hobom-angel/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5a9aff"/>
+      <stop offset="100%" stop-color="#3366e6"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+  <text
+    x="64"
+    y="96"
+    text-anchor="middle"
+    font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif"
+    font-size="88"
+    font-weight="800"
+    fill="white"
+    letter-spacing="-4"
+  >H</text>
+</svg>

--- a/apps/hobom-angel/src/App.tsx
+++ b/apps/hobom-angel/src/App.tsx
@@ -1,0 +1,11 @@
+import { AngelBrandVars } from "hobom-design-system";
+import { AppRouter } from "@/apps/ui";
+
+export default function App() {
+  return (
+    <>
+      <AngelBrandVars />
+      <AppRouter />
+    </>
+  );
+}

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -1,0 +1,12 @@
+import { Route, Routes } from "react-router-dom";
+import { LandingPage } from "@/pages/landing";
+
+/**
+ * Public routing. Only the landing page is open to guests; the rest of the
+ * product will live behind auth as later phases land.
+ */
+export const AppRouter = () => (
+  <Routes>
+    <Route path="/" element={<LandingPage />} />
+  </Routes>
+);

--- a/apps/hobom-angel/src/apps/ui/index.ts
+++ b/apps/hobom-angel/src/apps/ui/index.ts
@@ -1,0 +1,1 @@
+export { AppRouter } from "./AppRouter";

--- a/apps/hobom-angel/src/index.css
+++ b/apps/hobom-angel/src/index.css
@@ -1,0 +1,28 @@
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+body {
+  min-height: 100vh;
+  font-family: "Inter", "Pretendard", system-ui, -apple-system, sans-serif;
+  color: var(--hb-angel-ink, #2c3830);
+  background: #ffffff;
+  -webkit-font-smoothing: antialiased;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/apps/hobom-angel/src/main.tsx
+++ b/apps/hobom-angel/src/main.tsx
@@ -1,0 +1,15 @@
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+
+import "./index.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) throw new Error("root element not found");
+
+createRoot(rootElement).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+);

--- a/apps/hobom-angel/src/pages/landing/index.ts
+++ b/apps/hobom-angel/src/pages/landing/index.ts
@@ -1,0 +1,1 @@
+export { LandingPage } from "./ui/LandingPage";

--- a/apps/hobom-angel/src/pages/landing/ui/LandingPage.tsx
+++ b/apps/hobom-angel/src/pages/landing/ui/LandingPage.tsx
@@ -1,0 +1,466 @@
+import * as stylex from "@stylexjs/stylex";
+import { AngelButton, AnimalCard, PublicShell } from "hobom-design-system";
+import type { PublicShellNavItem } from "hobom-design-system";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+const NAV: PublicShellNavItem[] = [
+  { label: "동물 찾기", href: "#animals" },
+  { label: "봉사활동", href: "#volunteer" },
+  { label: "보호소", href: "#shelters" },
+  { label: "소식", href: "#news" },
+];
+
+const STATS = [
+  { value: "1,840", label: "함께한 입양" },
+  { value: "96곳", label: "파트너 보호소" },
+  { value: "4,200", label: "봉사 참여" },
+];
+
+const ANIMALS = [
+  { name: "봄이", meta: "2살 · 암컷 · 소형", shelter: "서울보호소" },
+  { name: "초코", meta: "3살 · 수컷 · 중형", shelter: "경기보호소" },
+  { name: "하양", meta: "1살 · 암컷 · 소형", shelter: "인천보호소" },
+  { name: "바다", meta: "4살 · 수컷 · 대형", shelter: "부산보호소" },
+];
+
+const STEPS = [
+  { icon: "🔍", n: "01", title: "친구 찾기", desc: "지역·나이·성격으로 나와 맞는 아이를 찾아보세요." },
+  { icon: "📝", n: "02", title: "신청서 작성", desc: "보호소의 간단한 사전 설문에 답하고 신청해요." },
+  { icon: "🤝", n: "03", title: "만남과 입양", desc: "보호소 검토 후 만남을 거쳐 가족이 됩니다." },
+];
+
+const FOOTER_GROUPS = [
+  { title: "서비스", links: ["동물 찾기", "봉사활동", "보호소 등록"] },
+  { title: "안내", links: ["이용약관", "개인정보처리방침", "자주 묻는 질문"] },
+  { title: "문의", links: ["고객센터", "제휴 문의", "제보하기"] },
+];
+
+const styles = stylex.create({
+  container: { maxWidth: 1200, marginInline: "auto", paddingInline: 20 },
+
+  // ── Hero ──────────────────────────────────────────────
+  hero: {
+    position: "relative",
+    overflow: "hidden",
+    backgroundImage:
+      "radial-gradient(90% 120% at 15% 0%, var(--hb-angel-green-tint) 0%, var(--hb-angel-surface) 60%)",
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-angel-line)",
+  },
+  blob: {
+    position: "absolute",
+    top: -120,
+    right: -80,
+    width: 360,
+    height: 360,
+    borderRadius: "50%",
+    backgroundColor: "var(--hb-angel-green-tint-strong)",
+    filter: "blur(40px)",
+    opacity: 0.6,
+    pointerEvents: "none",
+  },
+  heroGrid: {
+    position: "relative",
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [DESKTOP]: "1.05fr 0.95fr" },
+    alignItems: "center",
+    gap: { default: 40, [DESKTOP]: 56 },
+    paddingBlock: { default: "56px 64px", [DESKTOP]: "88px 96px" },
+  },
+  heroCopy: { textAlign: { default: "center", [DESKTOP]: "left" } },
+  eyebrow: {
+    display: "inline-block",
+    paddingBlock: 6,
+    paddingInline: 14,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-angel-green-tint-strong)",
+    color: "var(--hb-angel-green-dark)",
+    fontSize: "0.75rem",
+    fontWeight: 700,
+    letterSpacing: "0.08em",
+  },
+  heroTitle: {
+    margin: 0,
+    marginTop: 20,
+    fontSize: { default: "36px", [TABLET]: "48px", [DESKTOP]: "60px" },
+    lineHeight: 1.18,
+    fontWeight: 800,
+    letterSpacing: "-0.025em",
+    color: "var(--hb-angel-ink)",
+  },
+  heroLead: {
+    margin: 0,
+    marginTop: 20,
+    marginInline: { default: "auto", [DESKTOP]: 0 },
+    maxWidth: 480,
+    fontSize: "1.0625rem",
+    lineHeight: 1.7,
+    color: "var(--hb-angel-ink-soft)",
+  },
+  heroCta: {
+    marginTop: 32,
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: { default: "center", [DESKTOP]: "flex-start" },
+    gap: 12,
+  },
+  trust: {
+    marginTop: 28,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: { default: "center", [DESKTOP]: "flex-start" },
+    gap: 12,
+  },
+  avatars: { display: "flex" },
+  avatar: {
+    width: 34,
+    height: 34,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: "1rem",
+    backgroundColor: "var(--hb-angel-green-tint)",
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderColor: "var(--hb-angel-surface)",
+    marginLeft: -10,
+  },
+  avatarFirst: { marginLeft: 0 },
+  trustText: { fontSize: "0.875rem", color: "var(--hb-angel-ink-soft)" },
+  trustStrong: { fontWeight: 700, color: "var(--hb-angel-ink)" },
+
+  // ── Hero visual ───────────────────────────────────────
+  visual: { position: "relative", display: { default: "none", [TABLET]: "block" } },
+  visualCard: {
+    aspectRatio: { default: "16 / 10", [DESKTOP]: "4 / 4.4" },
+    borderRadius: 28,
+    backgroundImage:
+      "linear-gradient(160deg, var(--hb-angel-green-tint) 0%, var(--hb-angel-green) 130%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: "96px",
+    boxShadow: "0 24px 60px rgba(46, 75, 57, 0.18)",
+  },
+  floatCard: {
+    position: "absolute",
+    left: -18,
+    bottom: 28,
+    display: { default: "none", [DESKTOP]: "flex" },
+    alignItems: "center",
+    gap: 10,
+    padding: "12px 16px",
+    borderRadius: 16,
+    backgroundColor: "var(--hb-angel-surface)",
+    boxShadow: "0 12px 32px rgba(46, 75, 57, 0.16)",
+  },
+  floatAvatar: {
+    width: 38,
+    height: 38,
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: "1.125rem",
+    backgroundColor: "var(--hb-angel-green-tint)",
+  },
+  floatName: { margin: 0, fontSize: "0.875rem", fontWeight: 700, color: "var(--hb-angel-ink)" },
+  floatSub: { margin: 0, fontSize: "0.75rem", color: "var(--hb-angel-green-dark)", fontWeight: 600 },
+  floatChip: {
+    position: "absolute",
+    top: 22,
+    right: -14,
+    display: { default: "none", [DESKTOP]: "inline-flex" },
+    alignItems: "center",
+    gap: 6,
+    padding: "8px 14px",
+    borderRadius: 999,
+    backgroundColor: "var(--hb-angel-surface)",
+    fontSize: "0.8125rem",
+    fontWeight: 700,
+    color: "var(--hb-angel-ink)",
+    boxShadow: "0 10px 28px rgba(46, 75, 57, 0.14)",
+  },
+
+  // ── Stats band ────────────────────────────────────────
+  statsBand: { borderBottomWidth: 1, borderBottomStyle: "solid", borderBottomColor: "var(--hb-angel-line)" },
+  statsRow: {
+    maxWidth: 1200,
+    marginInline: "auto",
+    paddingInline: 20,
+    paddingBlock: 32,
+    display: "grid",
+    gridTemplateColumns: "repeat(3, 1fr)",
+  },
+  statItem: {
+    textAlign: "center",
+    borderLeftWidth: { default: 0, [TABLET]: 1 },
+    borderLeftStyle: "solid",
+    borderLeftColor: "var(--hb-angel-line)",
+  },
+  statItemFirst: { borderLeftWidth: 0 },
+  statValue: {
+    fontSize: { default: "1.5rem", [TABLET]: "2rem" },
+    fontWeight: 800,
+    color: "var(--hb-angel-green-deep)",
+    fontVariantNumeric: "tabular-nums",
+  },
+  statLabel: { marginTop: 6, fontSize: { default: "0.75rem", [TABLET]: "0.875rem" }, color: "var(--hb-angel-ink-soft)" },
+
+  // ── Generic section ───────────────────────────────────
+  section: { paddingBlock: { default: 56, [DESKTOP]: 80 } },
+  sectionMuted: {
+    paddingBlock: { default: 56, [DESKTOP]: 80 },
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  head: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: 16,
+    marginBottom: 28,
+  },
+  headCenter: { textAlign: "center", marginBottom: 40 },
+  title: { margin: 0, fontSize: { default: "1.5rem", [DESKTOP]: "1.875rem" }, fontWeight: 800, letterSpacing: "-0.02em", color: "var(--hb-angel-ink)" },
+  subtitle: { margin: 0, marginTop: 12, fontSize: "1rem", color: "var(--hb-angel-ink-soft)" },
+  more: { fontSize: "0.875rem", fontWeight: 600, color: "var(--hb-angel-green-dark)", whiteSpace: "nowrap" },
+
+  animals: {
+    display: "grid",
+    gridTemplateColumns: { default: "repeat(2, 1fr)", [DESKTOP]: "repeat(4, 1fr)" },
+    gap: { default: 14, [TABLET]: 20 },
+  },
+
+  steps: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [TABLET]: "repeat(3, 1fr)" },
+    gap: 20,
+  },
+  step: {
+    position: "relative",
+    backgroundColor: "var(--hb-angel-surface)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-angel-line)",
+    borderRadius: 20,
+    padding: "32px 24px",
+    textAlign: "center",
+  },
+  stepIcon: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 56,
+    height: 56,
+    borderRadius: 18,
+    backgroundColor: "var(--hb-angel-green-tint)",
+    fontSize: "1.75rem",
+  },
+  stepN: { marginTop: 16, fontSize: "0.75rem", fontWeight: 800, letterSpacing: "0.1em", color: "var(--hb-angel-green)" },
+  stepTitle: { margin: 0, marginTop: 6, fontSize: "1.125rem", fontWeight: 700, color: "var(--hb-angel-ink)" },
+  stepDesc: { margin: 0, marginTop: 8, fontSize: "0.9375rem", lineHeight: 1.6, color: "var(--hb-angel-ink-soft)" },
+
+  // ── CTA ───────────────────────────────────────────────
+  cta: { paddingBlock: { default: 8, [DESKTOP]: 24 }, paddingInline: 20 },
+  ctaInner: {
+    maxWidth: 1200,
+    marginInline: "auto",
+    position: "relative",
+    overflow: "hidden",
+    padding: { default: "48px 28px", [DESKTOP]: "72px 40px" },
+    borderRadius: 28,
+    backgroundImage: "linear-gradient(135deg, var(--hb-angel-green) 0%, var(--hb-angel-green-deep) 100%)",
+    textAlign: "center",
+    color: "#ffffff",
+  },
+  ctaTitle: { margin: 0, fontSize: { default: "1.5rem", [DESKTOP]: "2rem" }, fontWeight: 800, letterSpacing: "-0.02em" },
+  ctaLead: { margin: 0, marginTop: 12, marginBottom: 28, fontSize: "1rem", color: "rgba(255,255,255,0.85)" },
+
+  // ── Footer ────────────────────────────────────────────
+  footer: {
+    display: "flex",
+    flexDirection: { default: "column", [DESKTOP]: "row" },
+    justifyContent: "space-between",
+    gap: 32,
+  },
+  footerBrand: { fontWeight: 800, fontSize: "1.125rem", color: "var(--hb-angel-green-deep)" },
+  footerTagline: { margin: 0, marginTop: 12, fontSize: "0.875rem", color: "var(--hb-angel-ink-soft)" },
+  footerGroups: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, 1fr)",
+    gap: 24,
+    flex: { default: "none", [DESKTOP]: 1 },
+    maxWidth: { default: "none", [DESKTOP]: 560 },
+  },
+  footerTitle: { margin: 0, marginBottom: 12, fontSize: "0.8125rem", fontWeight: 700, color: "var(--hb-angel-ink)" },
+  footerLink: {
+    display: "block",
+    paddingBlock: 5,
+    fontSize: "0.875rem",
+    color: { default: "var(--hb-angel-ink-soft)", ":hover": "var(--hb-angel-green-dark)" },
+  },
+});
+
+const HeroSection = () => (
+  <section {...stylex.props(styles.hero)} id="top">
+    <span {...stylex.props(styles.blob)} aria-hidden="true" />
+    <div {...stylex.props(styles.container, styles.heroGrid)}>
+      <div {...stylex.props(styles.heroCopy)}>
+        <span {...stylex.props(styles.eyebrow)}>HAPPINESS FOR ANIMALS</span>
+        <h1 {...stylex.props(styles.heroTitle)}>
+          좋은 만남은
+          <br />
+          서두르지 않아요.
+        </h1>
+        <p {...stylex.props(styles.heroLead)}>
+          임시보호와 입양으로 한 생명에게 새로운 봄을 선물하세요. 보호소와 함께 천천히, 신중하게
+          가족을 이어드립니다.
+        </p>
+        <div {...stylex.props(styles.heroCta)}>
+          <AngelButton variant="primary">동물 만나보기</AngelButton>
+          <AngelButton variant="outline">봉사 지원하기</AngelButton>
+        </div>
+        <div {...stylex.props(styles.trust)}>
+          <div {...stylex.props(styles.avatars)} aria-hidden="true">
+            {["🐶", "🐱", "🐰", "🐕"].map((emoji, index) => (
+              <span key={emoji} {...stylex.props(styles.avatar, index === 0 && styles.avatarFirst)}>
+                {emoji}
+              </span>
+            ))}
+          </div>
+          <p {...stylex.props(styles.trustText)}>
+            <span {...stylex.props(styles.trustStrong)}>1,840</span>명의 가족이 함께하고 있어요
+          </p>
+        </div>
+      </div>
+
+      <div {...stylex.props(styles.visual)} aria-hidden="true">
+        <div {...stylex.props(styles.visualCard)}>🐕</div>
+        <span {...stylex.props(styles.floatChip)}>🐾 96개 보호소 함께</span>
+        <div {...stylex.props(styles.floatCard)}>
+          <span {...stylex.props(styles.floatAvatar)}>🐶</span>
+          <div>
+            <p {...stylex.props(styles.floatName)}>봄이</p>
+            <p {...stylex.props(styles.floatSub)}>방금 가족을 만났어요 ✓</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+const StatsSection = () => (
+  <div {...stylex.props(styles.statsBand)}>
+    <div {...stylex.props(styles.statsRow)}>
+      {STATS.map((stat, index) => (
+        <div key={stat.label} {...stylex.props(styles.statItem, index === 0 && styles.statItemFirst)}>
+          <div {...stylex.props(styles.statValue)}>{stat.value}</div>
+          <div {...stylex.props(styles.statLabel)}>{stat.label}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const AnimalsSection = () => (
+  <section {...stylex.props(styles.section)} id="animals">
+    <div {...stylex.props(styles.container)}>
+      <header {...stylex.props(styles.head)}>
+        <h2 {...stylex.props(styles.title)}>지금 만날 수 있는 친구들</h2>
+        <a href="#animals" {...stylex.props(styles.more)}>
+          전체 보기 →
+        </a>
+      </header>
+      <div {...stylex.props(styles.animals)}>
+        {ANIMALS.map((animal) => (
+          <AnimalCard
+            key={animal.name}
+            name={animal.name}
+            meta={animal.meta}
+            shelter={animal.shelter}
+            status="입양가능"
+          />
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+const HowItWorksSection = () => (
+  <section {...stylex.props(styles.sectionMuted)} id="how">
+    <div {...stylex.props(styles.container)}>
+      <header {...stylex.props(styles.headCenter)}>
+        <h2 {...stylex.props(styles.title)}>이렇게 진행돼요</h2>
+        <p {...stylex.props(styles.subtitle)}>처음이어도 괜찮아요. 세 단계면 충분합니다.</p>
+      </header>
+      <ol {...stylex.props(styles.steps)}>
+        {STEPS.map((step) => (
+          <li key={step.n} {...stylex.props(styles.step)}>
+            <span {...stylex.props(styles.stepIcon)} aria-hidden="true">
+              {step.icon}
+            </span>
+            <div {...stylex.props(styles.stepN)}>STEP {step.n}</div>
+            <h3 {...stylex.props(styles.stepTitle)}>{step.title}</h3>
+            <p {...stylex.props(styles.stepDesc)}>{step.desc}</p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  </section>
+);
+
+const CtaSection = () => (
+  <section {...stylex.props(styles.cta)}>
+    <div {...stylex.props(styles.ctaInner)}>
+      <h2 {...stylex.props(styles.ctaTitle)}>오늘, 한 생명의 봄이 되어주세요</h2>
+      <p {...stylex.props(styles.ctaLead)}>지금 만날 수 있는 친구들이 기다리고 있어요.</p>
+      <AngelButton variant="onDark">지금 시작하기</AngelButton>
+    </div>
+  </section>
+);
+
+const Footer = () => (
+  <div {...stylex.props(styles.footer)}>
+    <div>
+      <div {...stylex.props(styles.footerBrand)}>🐾 HoBom Angel</div>
+      <p {...stylex.props(styles.footerTagline)}>한 생명의 봄이 되어주세요.</p>
+    </div>
+    <div {...stylex.props(styles.footerGroups)}>
+      {FOOTER_GROUPS.map((group) => (
+        <div key={group.title}>
+          <h3 {...stylex.props(styles.footerTitle)}>{group.title}</h3>
+          {group.links.map((link) => (
+            <a key={link} href="#top" {...stylex.props(styles.footerLink)}>
+              {link}
+            </a>
+          ))}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const LandingPage = () => (
+  <PublicShell
+    nav={NAV}
+    actions={
+      <AngelButton variant="ghost" size="small">
+        로그인
+      </AngelButton>
+    }
+    footer={<Footer />}
+  >
+    <HeroSection />
+    <StatsSection />
+    <AnimalsSection />
+    <HowItWorksSection />
+    <CtaSection />
+  </PublicShell>
+);

--- a/apps/hobom-angel/src/vite-env.d.ts
+++ b/apps/hobom-angel/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/hobom-angel/tsconfig.app.json
+++ b/apps/hobom-angel/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.spec.tsx", "src/**/*.test.ts", "src/**/*.test.tsx"],
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "useDefineForClassFields": true,
+    "types": ["node", "vitest/globals"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/apps/hobom-angel/tsconfig.json
+++ b/apps/hobom-angel/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/apps/hobom-angel/tsconfig.node.json
+++ b/apps/hobom-angel/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/hobom-angel/tsconfig.spec.json
+++ b/apps/hobom-angel/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "include": ["src"],
+  "exclude": [],
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"],
+    "noEmit": true
+  }
+}

--- a/apps/hobom-angel/vite.config.ts
+++ b/apps/hobom-angel/vite.config.ts
@@ -1,0 +1,50 @@
+import * as path from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import stylex from "@stylexjs/unplugin";
+
+export default defineConfig({
+  // StyleX must run before react to preserve Fast Refresh. `unstable_moduleResolution`
+  // in ESM mode lets the plugin resolve StyleX vars imported from the workspace
+  // design-system package.
+  plugins: [
+    stylex.vite({
+      useCSSLayers: true,
+      unstable_moduleResolution: { type: "commonJS", rootDir: path.resolve(__dirname, "../..") },
+    }),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  build: {
+    chunkSizeWarningLimit: 600,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes("/node_modules/react/") ||
+            id.includes("/node_modules/react-dom/") ||
+            id.includes("/node_modules/react-router") ||
+            id.includes("/node_modules/scheduler/")
+          ) {
+            return "framework";
+          }
+        },
+      },
+    },
+  },
+  server: {
+    port: 3001,
+    proxy: {
+      "/api": {
+        target: "https://hobom-system.com/hobom-api-gateway/hobom-angel",
+        changeOrigin: true,
+        secure: true,
+        rewrite: (p) => p.replace(/^\/api/, ""),
+      },
+    },
+  },
+});

--- a/apps/hobom-angel/vitest.config.ts
+++ b/apps/hobom-angel/vitest.config.ts
@@ -1,0 +1,52 @@
+import * as path from "path";
+import { defineConfig } from "vitest/config";
+import stylex from "@stylexjs/unplugin";
+
+export default defineConfig({
+  // StyleX must compile design-system source pulled in by tests too, so the
+  // package is inlined (Vite externalizes node_modules by default) and the
+  // plugin runs over it — otherwise `stylex.defineVars` throws at runtime.
+  plugins: [
+    stylex.vite({
+      unstable_moduleResolution: { type: "commonJS", rootDir: path.resolve(__dirname, "../..") },
+    }),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    globals: true,
+    // The consumer app is still mostly presentational scaffolding; keep the
+    // suite green while real logic (and its tests) land in later phases.
+    passWithNoTests: true,
+    include: ["src/**/*.{spec,test}.{ts,tsx}"],
+    server: {
+      deps: {
+        inline: ["hobom-design-system"],
+      },
+    },
+    typecheck: {
+      tsconfig: "./tsconfig.spec.json",
+    },
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts", "src/**/*.tsx"],
+      exclude: [
+        "src/**/*.type.ts",
+        "src/**/index.ts",
+        "src/main.tsx",
+        "src/App.tsx",
+        "src/**/*.spec.{ts,tsx}",
+        "src/**/*.test.{ts,tsx}",
+      ],
+      thresholds: {
+        lines: 0,
+        branches: 0,
+        functions: 0,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev:hobom": "pnpm --filter hobom-system dev",
     "build:hobom": "pnpm --filter hobom-system build",
+    "dev:angel": "pnpm --filter hobom-angel dev",
+    "build:angel": "pnpm --filter hobom-angel build",
     "typecheck": "pnpm -r --parallel typecheck",
     "lint": "pnpm -r --parallel lint",
     "lint:fix": "pnpm -r --parallel exec eslint --fix .",

--- a/packages/hobom-design-system/src/components/AngelButton/AngelButton.tsx
+++ b/packages/hobom-design-system/src/components/AngelButton/AngelButton.tsx
@@ -1,0 +1,100 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+type AngelButtonVariant = "primary" | "outline" | "ghost" | "onDark";
+
+type AngelButtonSize = "medium" | "small";
+
+interface AngelButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type"> {
+  variant?: AngelButtonVariant;
+  size?: AngelButtonSize;
+  startIcon?: ReactNode;
+  type?: "button" | "submit" | "reset";
+}
+
+const styles = stylex.create({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    boxSizing: "border-box",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "transparent",
+    borderRadius: 999,
+    fontFamily: "inherit",
+    fontWeight: 600,
+    lineHeight: 1,
+    whiteSpace: "nowrap",
+    cursor: "pointer",
+    appearance: "none",
+    outline: {
+      default: "none",
+      ":focus-visible": "2px solid var(--hb-angel-green)",
+    },
+    outlineOffset: 2,
+    transition: "background-color 0.15s, color 0.15s, border-color 0.15s, transform 0.05s",
+    transform: { default: "none", ":active": "translateY(1px)" },
+  },
+  medium: { paddingBlock: 12, paddingInline: 22, fontSize: "0.9375rem" },
+  small: { paddingBlock: 9, paddingInline: 18, fontSize: "0.875rem" },
+  primary: {
+    backgroundColor: { default: "var(--hb-angel-green)", ":hover": "var(--hb-angel-green-dark)" },
+    color: "#ffffff",
+  },
+  outline: {
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-angel-green-tint)" },
+    color: "var(--hb-angel-green-dark)",
+    borderColor: "var(--hb-angel-green)",
+  },
+  ghost: {
+    backgroundColor: {
+      default: "var(--hb-angel-green-tint)",
+      ":hover": "var(--hb-angel-green-tint-strong)",
+    },
+    color: "var(--hb-angel-green-dark)",
+  },
+  onDark: {
+    backgroundColor: { default: "#ffffff", ":hover": "var(--hb-angel-green-tint)" },
+    color: "var(--hb-angel-green-deep)",
+  },
+  icon: { display: "inline-flex", fontSize: "1.125rem" },
+});
+
+const VARIANT_STYLE = {
+  primary: styles.primary,
+  outline: styles.outline,
+  ghost: styles.ghost,
+  onDark: styles.onDark,
+} as const;
+
+/** Pill-shaped, brand-green button for the Angel consumer surface. */
+export const AngelButton = ({
+  variant = "primary",
+  size = "medium",
+  startIcon,
+  type = "button",
+  className,
+  style,
+  children,
+  ...rest
+}: AngelButtonProps) => {
+  const sx = stylex.props(
+    styles.root,
+    size === "small" ? styles.small : styles.medium,
+    VARIANT_STYLE[variant],
+  );
+
+  return (
+    <button
+      {...rest}
+      type={type}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {startIcon && <span {...stylex.props(styles.icon)}>{startIcon}</span>}
+      {children}
+    </button>
+  );
+};

--- a/packages/hobom-design-system/src/components/AngelButton/index.ts
+++ b/packages/hobom-design-system/src/components/AngelButton/index.ts
@@ -1,0 +1,1 @@
+export { AngelButton } from "./AngelButton";

--- a/packages/hobom-design-system/src/components/AnimalCard/AnimalCard.tsx
+++ b/packages/hobom-design-system/src/components/AnimalCard/AnimalCard.tsx
@@ -1,0 +1,107 @@
+import type { HTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+interface AnimalCardProps extends HTMLAttributes<HTMLElement> {
+  name: string;
+  /** Short attribute line, e.g. "2살 · 암컷 · 소형". */
+  meta: string;
+  /** Owning shelter name. */
+  shelter: string;
+  /** Status pill text, e.g. "입양가능". Hidden when omitted. */
+  status?: string;
+  /** Photo URL; falls back to a brand placeholder. */
+  imageUrl?: string;
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-angel-line)",
+    borderRadius: 16,
+    overflow: "hidden",
+    backgroundColor: "var(--hb-angel-surface)",
+    transition: "transform 0.15s ease, box-shadow 0.15s ease",
+    transform: { default: "none", ":hover": "translateY(-4px)" },
+    boxShadow: { default: "none", ":hover": "0 12px 28px rgba(46, 75, 57, 0.1)" },
+  },
+  photo: {
+    position: "relative",
+    aspectRatio: "4 / 3",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "var(--hb-angel-green-tint)",
+    backgroundImage:
+      "repeating-linear-gradient(45deg, var(--hb-angel-green-tint), var(--hb-angel-green-tint) 10px, var(--hb-angel-green-tint-strong) 10px, var(--hb-angel-green-tint-strong) 20px)",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    backgroundImage: "none",
+  },
+  badge: {
+    position: "absolute",
+    top: 10,
+    left: 10,
+    paddingBlock: 4,
+    paddingInline: 10,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-angel-green)",
+    color: "#ffffff",
+    fontSize: "0.6875rem",
+    fontWeight: 700,
+  },
+  paw: { fontSize: "2rem", opacity: 0.55 },
+  body: { paddingInline: 16, paddingTop: 14, paddingBottom: 18 },
+  name: { margin: 0, fontSize: "1.0625rem", fontWeight: 700, color: "var(--hb-angel-ink)" },
+  meta: { margin: 0, marginTop: 6, fontSize: "0.8125rem", color: "var(--hb-angel-ink-soft)" },
+  shelter: {
+    margin: 0,
+    marginTop: 2,
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-angel-green-dark)",
+  },
+});
+
+/** A shelter animal preview card — used on the landing, list, and shelter pages. */
+export const AnimalCard = ({
+  name,
+  meta,
+  shelter,
+  status,
+  imageUrl,
+  className,
+  style,
+  ...rest
+}: AnimalCardProps) => {
+  const sx = stylex.props(styles.root);
+
+  return (
+    <article
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      <div {...stylex.props(styles.photo)}>
+        {status && <span {...stylex.props(styles.badge)}>{status}</span>}
+        {imageUrl ? (
+          <img src={imageUrl} alt={name} {...stylex.props(styles.image)} />
+        ) : (
+          <span {...stylex.props(styles.paw)} aria-hidden="true">
+            🐾
+          </span>
+        )}
+      </div>
+      <div {...stylex.props(styles.body)}>
+        <h3 {...stylex.props(styles.name)}>{name}</h3>
+        <p {...stylex.props(styles.meta)}>{meta}</p>
+        <p {...stylex.props(styles.shelter)}>{shelter}</p>
+      </div>
+    </article>
+  );
+};

--- a/packages/hobom-design-system/src/components/AnimalCard/index.ts
+++ b/packages/hobom-design-system/src/components/AnimalCard/index.ts
@@ -1,0 +1,1 @@
+export { AnimalCard } from "./AnimalCard";

--- a/packages/hobom-design-system/src/foundations/angel-brand.tsx
+++ b/packages/hobom-design-system/src/foundations/angel-brand.tsx
@@ -1,0 +1,25 @@
+/**
+ * Angel product brand tokens.
+ *
+ * The Angel consumer surface uses a warm sage/forest green, distinct from the
+ * neutral back-office palette. Exposed as stable `--hb-angel-*` CSS variables
+ * (the single source of truth) so both StyleX styles and any inline styles can
+ * reference them as literal `var(--hb-angel-*)` strings — mirroring how the
+ * core `--hb-color-*` tokens work.
+ *
+ * Mount `<AngelBrandVars />` once near the app root.
+ */
+export const ANGEL_BRAND_CSS = `:root{` +
+  `--hb-angel-green:#4c7a5b;` +
+  `--hb-angel-green-dark:#3c6349;` +
+  `--hb-angel-green-deep:#2e4b39;` +
+  `--hb-angel-green-tint:#eef4ec;` +
+  `--hb-angel-green-tint-strong:#e1ebde;` +
+  `--hb-angel-ink:#2c3830;` +
+  `--hb-angel-ink-soft:#66756b;` +
+  `--hb-angel-line:#e4eae1;` +
+  `--hb-angel-surface:#ffffff;` +
+  `--hb-angel-surface-alt:#f6f8f4;` +
+  `}`;
+
+export const AngelBrandVars = () => <style>{ANGEL_BRAND_CSS}</style>;

--- a/packages/hobom-design-system/src/index.ts
+++ b/packages/hobom-design-system/src/index.ts
@@ -7,6 +7,8 @@ export { ErrorBoundary } from "./patterns/ErrorBoundary";
 export { Funnel, Step } from "./patterns/Funnel";
 export type { FunnelProps, StepProps } from "./patterns/Funnel";
 export { OverlayProvider, OverlayContext } from "./patterns/OverlayProvider";
+export { PublicShell } from "./patterns/PublicShell";
+export type { PublicShellNavItem } from "./patterns/PublicShell";
 export { Sortable, arrayMove, useDroppable } from "./patterns/Sortable";
 export type { DragEndEvent, DragStartEvent, DragOverEvent } from "./patterns/Sortable";
 export { SuspenseLoader } from "./patterns/SuspenseLoader";
@@ -23,6 +25,10 @@ export {
   useColorScheme,
 } from "./foundations/color-scheme";
 export type { ColorSchemeMode } from "./foundations/color-scheme";
+
+export { ANGEL_BRAND_CSS, AngelBrandVars } from "./foundations/angel-brand";
+export { AngelButton } from "./components/AngelButton";
+export { AnimalCard } from "./components/AnimalCard";
 
 export { Hb } from "./components";
 

--- a/packages/hobom-design-system/src/patterns/PublicShell/PublicShell.tsx
+++ b/packages/hobom-design-system/src/patterns/PublicShell/PublicShell.tsx
@@ -1,0 +1,189 @@
+import { useState, type ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+export interface PublicShellNavItem {
+  label: string;
+  href: string;
+}
+
+interface PublicShellProps {
+  /** Brand lockup shown at the start of the bar. */
+  brand?: ReactNode;
+  /** Primary navigation links. */
+  nav?: readonly PublicShellNavItem[];
+  /** Trailing bar content, e.g. a login button. */
+  actions?: ReactNode;
+  /** Footer content; wrapped in the shell's footer container. */
+  footer?: ReactNode;
+  children: ReactNode;
+}
+
+const DESKTOP = "@media (min-width: 768px)";
+
+const styles = stylex.create({
+  shell: {
+    display: "flex",
+    flexDirection: "column",
+    minHeight: "100vh",
+    backgroundColor: "var(--hb-angel-surface)",
+    color: "var(--hb-angel-ink)",
+  },
+  bar: {
+    position: "sticky",
+    top: 0,
+    zIndex: 20,
+    backgroundColor: "rgba(255, 255, 255, 0.86)",
+    backdropFilter: "saturate(1.4) blur(10px)",
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-angel-line)",
+  },
+  barInner: {
+    maxWidth: 1200,
+    marginInline: "auto",
+    paddingInline: 20,
+    height: 64,
+    display: "flex",
+    alignItems: "center",
+    gap: 16,
+  },
+  brand: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    fontWeight: 700,
+    fontSize: "1.125rem",
+    letterSpacing: "-0.01em",
+    color: "var(--hb-angel-green-deep)",
+  },
+  nav: {
+    display: { default: "none", [DESKTOP]: "flex" },
+    alignItems: "center",
+    gap: 28,
+    marginLeft: 8,
+  },
+  navLink: {
+    fontSize: "0.9375rem",
+    fontWeight: 500,
+    color: { default: "var(--hb-angel-ink-soft)", ":hover": "var(--hb-angel-green-dark)" },
+  },
+  actions: { marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 },
+  burger: {
+    display: { default: "inline-flex", [DESKTOP]: "none" },
+    alignItems: "center",
+    justifyContent: "center",
+    width: 40,
+    height: 40,
+    borderWidth: 0,
+    borderRadius: 10,
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-angel-green-tint)" },
+    color: "var(--hb-angel-ink)",
+    fontSize: "1.25rem",
+    cursor: "pointer",
+  },
+  mobileNav: {
+    display: { default: "flex", [DESKTOP]: "none" },
+    flexDirection: "column",
+    paddingInline: 20,
+    paddingBottom: 12,
+    gap: 2,
+    borderTopWidth: 1,
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-angel-line)",
+  },
+  mobileLink: {
+    paddingBlock: 12,
+    fontSize: "0.9375rem",
+    fontWeight: 500,
+    color: "var(--hb-angel-ink)",
+  },
+  main: { flex: 1 },
+  footer: {
+    marginTop: 72,
+    borderTopWidth: 1,
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-angel-line)",
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  footerInner: { maxWidth: 1120, marginInline: "auto", padding: 20 },
+});
+
+const DEFAULT_BRAND = (
+  <>
+    <span aria-hidden="true">🐾</span>
+    HoBom Angel
+  </>
+);
+
+/**
+ * Mobile-first public chrome for the consumer surface: a sticky top bar with
+ * brand + primary nav + trailing actions (with a mobile menu), plus a footer
+ * slot. The desktop back-office `AppShell` (240px drawer) is unsuitable here.
+ */
+export const PublicShell = ({
+  brand = DEFAULT_BRAND,
+  nav = [],
+  actions,
+  footer,
+  children,
+}: PublicShellProps) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <div {...stylex.props(styles.shell)}>
+      <header {...stylex.props(styles.bar)}>
+        <div {...stylex.props(styles.barInner)}>
+          <a href="#top" {...stylex.props(styles.brand)}>
+            {brand}
+          </a>
+
+          <nav {...stylex.props(styles.nav)} aria-label="주요 메뉴">
+            {nav.map((item) => (
+              <a key={item.label} href={item.href} {...stylex.props(styles.navLink)}>
+                {item.label}
+              </a>
+            ))}
+          </nav>
+
+          <div {...stylex.props(styles.actions)}>
+            {actions}
+            {nav.length > 0 && (
+              <button
+                type="button"
+                {...stylex.props(styles.burger)}
+                aria-label="메뉴 열기"
+                aria-expanded={menuOpen}
+                onClick={() => setMenuOpen((open) => !open)}
+              >
+                ☰
+              </button>
+            )}
+          </div>
+        </div>
+
+        {menuOpen && nav.length > 0 && (
+          <nav {...stylex.props(styles.mobileNav)} aria-label="모바일 메뉴">
+            {nav.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                {...stylex.props(styles.mobileLink)}
+                onClick={() => setMenuOpen(false)}
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+        )}
+      </header>
+
+      <main {...stylex.props(styles.main)}>{children}</main>
+
+      {footer && (
+        <footer {...stylex.props(styles.footer)}>
+          <div {...stylex.props(styles.footerInner)}>{footer}</div>
+        </footer>
+      )}
+    </div>
+  );
+};

--- a/packages/hobom-design-system/src/patterns/PublicShell/index.ts
+++ b/packages/hobom-design-system/src/patterns/PublicShell/index.ts
@@ -1,0 +1,2 @@
+export { PublicShell } from "./PublicShell";
+export type { PublicShellNavItem } from "./PublicShell";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,46 @@ importers:
         specifier: '>=4.1.10'
         version: 4.1.10(@types/node@25.9.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.4)(typescript@6.0.3))(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))
 
+  apps/hobom-angel:
+    dependencies:
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
+      hobom-data:
+        specifier: workspace:*
+        version: link:../../packages/hobom-data
+      hobom-design-system:
+        specifier: workspace:*
+        version: link:../../packages/hobom-design-system
+      hobom-schema:
+        specifier: workspace:*
+        version: link:../../packages/hobom-schema
+      hobom-utils:
+        specifier: workspace:*
+        version: link:../../packages/hobom-utils
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: '>=7.18.1'
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@stylexjs/unplugin':
+        specifier: ^0.19.0
+        version: 0.19.0(unplugin@2.3.11)
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.9.4
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.3.0
+        version: 4.3.1(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0))
+      vite:
+        specifier: '>=8.1.3'
+        version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0)
+
   apps/hobom-system:
     dependencies:
       '@hobom-grid/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "apps/hobom-system" },
+    { "path": "apps/hobom-angel" },
     { "path": "packages/hobom-design-system" },
     { "path": "packages/hobom-utils" },
     { "path": "packages/hobom-data" },


### PR DESCRIPTION
Kicks off the Angel consumer surface (P0, mockup-first) — a new mobile-first responsive app plus the reusable design-system pieces it composes.

## New app: `apps/hobom-angel`
Mirrors the `hobom-system` toolchain so it fits the monorepo and CI unchanged: Vite + StyleX + React Router, FSD layout, project-reference tsconfigs, the shared eslint config + FSD boundary rule, a Dockerfile + Jenkinsfile (`dev-for-hobom-angel`, hostPort 3001, `build:angel`), and root `build:angel`/`dev:angel` scripts. Registered in the workspace + root tsconfig references.

## Reusable UI → the design system (StyleX)
Per the Angel strategy, the reusable pieces live in `hobom-design-system`, not the app:
- **Angel brand tokens** (`--hb-angel-*`) — a warm sage/forest green, distinct from the neutral back-office palette, exposed as stable CSS vars via `AngelBrandVars` (single source of truth).
- **`PublicShell`** — mobile-first chrome (sticky bar + mobile menu toggle + footer slot); the desktop `AppShell` drawer is unsuitable for a consumer surface.
- **`AnimalCard`**, **`AngelButton`** — reusable across landing/list/detail/shelter pages.

All use StyleX with `var(--hb-angel-*)` literals, matching the existing DS convention (e.g. `Divider`, `Button`).

## Landing (composed in the app)
The app composes the DS primitives into landing sections — a two-column desktop hero with a brand visual that collapses to a single centered column on mobile, a stats band, an animal preview grid, a how-it-works strip, and a CTA banner. Backgrounds full-bleed, content constrained to 1200, breakpoints at 640/1024. Content is static mockup data; wiring lands in later phases.

Verified: workspace typecheck clean, DS + app lint clean, DS suite 180 tests pass, production build clean, rendered at desktop/tablet/mobile.

Follow-ups (not in this PR): Storybook stories for the new DS components; the Jenkins job registration + polling include-regions are a manual Jenkins-side step (the Jenkinsfile is in place).