### PR TITLE
Wire the Angel API layer and query provider

### DIFF
--- a/apps/hobom-angel/src/App.tsx
+++ b/apps/hobom-angel/src/App.tsx
@@ -1,11 +1,11 @@
 import { AngelBrandVars } from "hobom-design-system";
-import { AppRouter } from "@/apps/ui";
+import { AppProvider, AppRouter } from "@/apps/ui";
 
 export default function App() {
   return (
-    <>
+    <AppProvider>
       <AngelBrandVars />
       <AppRouter />
-    </>
+    </AppProvider>
   );
 }

--- a/apps/hobom-angel/src/apps/ui/AppProvider.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppProvider.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { DataLot, DataLotProvider } from "hobom-data";
+
+const STALE_TIME = 5 * 60 * 1000;
+const GC_TIME = 10 * 60 * 1000;
+
+const dataLot = new DataLot({
+  defaultOptions: {
+    queries: {
+      staleTime: STALE_TIME,
+      gcTime: GC_TIME,
+      retry: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+interface Props {
+  children: ReactNode;
+}
+
+export const AppProvider = ({ children }: Props) => (
+  <DataLotProvider client={dataLot}>{children}</DataLotProvider>
+);

--- a/apps/hobom-angel/src/apps/ui/index.ts
+++ b/apps/hobom-angel/src/apps/ui/index.ts
@@ -1,1 +1,2 @@
+export { AppProvider } from "./AppProvider";
 export { AppRouter } from "./AppRouter";

--- a/apps/hobom-angel/src/shared/api/auth.middleware.ts
+++ b/apps/hobom-angel/src/shared/api/auth.middleware.ts
@@ -1,0 +1,75 @@
+import { env } from "@/shared/config";
+import { HttpStatusModel } from "./http-status.api";
+import { applyCsrfHeader } from "./csrf.middleware";
+import type { Middleware } from "./middleware.type";
+
+const REFRESH_URL = `${env.VITE_APP_HOBOM_API_GATEWAY_URL}/auth/refresh`;
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export const UNAUTHORIZED_EVENT = "hobom:unauthorized";
+
+let unauthorizedDispatched = false;
+
+export const resetUnauthorizedState = () => {
+  unauthorizedDispatched = false;
+};
+
+let refreshPromise: Promise<boolean> | null = null;
+
+const tryRefresh = async (): Promise<boolean> => {
+  try {
+    const res = await fetch(REFRESH_URL, {
+      method: "POST",
+      credentials: "include",
+      headers: applyCsrfHeader({
+        "X-Hobom-Api-Key": env.VITE_APP_HOBOM_API_KEY,
+      }),
+    });
+
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+export const authMiddleware: Middleware = {
+  onResponse: async (ctx) => {
+    if (ctx.response?.status !== HttpStatusModel.UNAUTHORIZED) return;
+    if (unauthorizedDispatched) return;
+
+    if (!refreshPromise) {
+      refreshPromise = tryRefresh();
+    }
+
+    const refreshed = await refreshPromise;
+
+    refreshPromise = null;
+
+    if (refreshed) {
+      const headers = new Headers(ctx.init.headers);
+      const headerRecord: Record<string, string> = {};
+
+      headers.forEach((value, key) => {
+        headerRecord[key] = value;
+      });
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+      try {
+        const retryInit: RequestInit = {
+          ...ctx.init,
+          headers: applyCsrfHeader(headerRecord),
+          signal: controller.signal,
+        };
+
+        ctx.response = await fetch(ctx.input, retryInit);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    } else {
+      unauthorizedDispatched = true;
+      window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
+    }
+  },
+};

--- a/apps/hobom-angel/src/shared/api/csrf.middleware.ts
+++ b/apps/hobom-angel/src/shared/api/csrf.middleware.ts
@@ -1,0 +1,35 @@
+import type { Middleware } from "./middleware.type";
+
+const CSRF_COOKIE = "XSRF-TOKEN";
+const CSRF_HEADER = "X-XSRF-TOKEN";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const getCsrfToken = (): string | null => {
+  const match = document.cookie.match(new RegExp(`(?:^|;\\s*)${CSRF_COOKIE}=([^;]*)`));
+
+  return match?.[1] != null ? decodeURIComponent(match[1]) : null;
+};
+
+export const applyCsrfHeader = (headers: Record<string, string>): Record<string, string> => {
+  const token = getCsrfToken();
+
+  return token ? { ...headers, [CSRF_HEADER]: token } : headers;
+};
+
+export const csrfMiddleware: Middleware = {
+  onRequest: (ctx) => {
+    const method = (ctx.init.method ?? "GET").toUpperCase();
+
+    if (SAFE_METHODS.has(method)) return;
+
+    const token = getCsrfToken();
+
+    if (token) {
+      ctx.init.headers = {
+        ...(ctx.init.headers as Record<string, string>),
+        [CSRF_HEADER]: token,
+      };
+    }
+  },
+};

--- a/apps/hobom-angel/src/shared/api/http-client.api.ts
+++ b/apps/hobom-angel/src/shared/api/http-client.api.ts
@@ -1,0 +1,167 @@
+import { env } from "@/shared/config";
+import { HttpError } from "./http-error.api";
+import type { Middleware, MiddlewareContext } from "./middleware.type";
+import type { HttpMethod, RequestOptions } from "./http-options.type";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface HttpClient {
+  use: (middleware: Middleware) => void;
+  get: <T>(url: string, options?: RequestOptions) => Promise<T>;
+  post: <T>(url: string, body: unknown, options?: Omit<RequestOptions, "json">) => Promise<T>;
+  put: <T>(url: string, body: unknown, options?: Omit<RequestOptions, "json">) => Promise<T>;
+  patch: <T>(url: string, body: unknown, options?: Omit<RequestOptions, "json">) => Promise<T>;
+  delete: <T>(url: string, options?: RequestOptions) => Promise<T>;
+}
+
+/**
+ * 미들웨어 기반 HTTP 클라이언트 팩토리.
+ *
+ * - 모든 요청에 `Content-Type: application/json`, `X-Hobom-Api-Key`, `credentials: "include"` 자동 부여
+ * - `timeout` 기본값 30초. 초과 시 `AbortError` 발생
+ * - `retry` 옵션으로 실패 시 재시도 횟수 지정 가능
+ * - 204 응답은 body 파싱 없이 `undefined` 반환
+ * - 미들웨어 훅 실행 순서: `onRequest` → fetch → `onResponse` (또는 `onError`), 등록 순으로 순차 실행
+ */
+export const createHttpClient = (baseUrl = ""): HttpClient => {
+  const middlewares: Middleware[] = [];
+
+  const runMiddlewareHook = async (hookName: keyof Middleware, ctx: MiddlewareContext) => {
+    for (const m of middlewares) {
+      const fn = m[hookName];
+
+      if (fn) await fn(ctx);
+    }
+  };
+
+  const request = async (method: HttpMethod, url: string, options: RequestOptions = {}) => {
+    const { json, retry: maxRetry = 0, timeout, ...fetchOptions } = options;
+    const fullUrl = baseUrl + url;
+
+    const init: RequestInit = {
+      ...fetchOptions,
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        ...(fetchOptions.headers || {}),
+        "X-Hobom-Api-Key": env.VITE_APP_HOBOM_API_KEY,
+      },
+      credentials: "include",
+    };
+
+    if (json !== undefined) {
+      init.body = JSON.stringify(json);
+    }
+
+    // Compose the caller's signal (e.g. a query's cancel signal) with the
+    // timeout into one controller, so a fetch aborts when either fires. Using
+    // the external signal directly would silently disable the timeout.
+    const externalSignal = init.signal ?? undefined;
+    const controller = new AbortController();
+
+    const onExternalAbort = () => controller.abort(externalSignal?.reason);
+
+    if (externalSignal?.aborted) {
+      controller.abort(externalSignal.reason);
+    } else {
+      externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+    }
+
+    init.signal = controller.signal;
+    const timeoutId = setTimeout(() => controller.abort(), timeout ?? DEFAULT_TIMEOUT_MS);
+
+    const ctx: MiddlewareContext = { input: fullUrl, init };
+
+    await runMiddlewareHook("onRequest", ctx);
+
+    let attempt = 0;
+
+    try {
+      while (true) {
+        try {
+          ctx.response = await fetch(ctx.input, ctx.init);
+          await runMiddlewareHook("onResponse", ctx);
+
+          if (!ctx.response.ok) {
+            let serverMessage: string | undefined;
+
+            try {
+              const body = await ctx.response.clone().json();
+
+              serverMessage = typeof body?.message === "string" ? body.message : undefined;
+            } catch {
+              /* non-JSON or no message field */
+            }
+            const error = new HttpError(ctx.response.status, serverMessage);
+
+            ctx.error = error;
+            throw error;
+          }
+
+          return ctx.response;
+        } catch (error) {
+          ctx.error = error;
+          await runMiddlewareHook("onError", ctx);
+
+          if (attempt < maxRetry) {
+            attempt++;
+            continue;
+          }
+          throw error;
+        }
+      }
+    } finally {
+      clearTimeout(timeoutId);
+      externalSignal?.removeEventListener("abort", onExternalAbort);
+    }
+  };
+
+  const parseJson = async <T>(res: Response): Promise<T> => {
+    if (res.status === 204) return undefined as T;
+
+    return res.json();
+  };
+
+  return {
+    use: (middleware) => {
+      middlewares.push(middleware);
+    },
+    get: async <T>(url: string, options?: RequestOptions): Promise<T> => {
+      const res = await request("GET", url, options);
+
+      return parseJson<T>(res);
+    },
+    post: async <T>(
+      url: string,
+      body: unknown,
+      options?: Omit<RequestOptions, "json">,
+    ): Promise<T> => {
+      const res = await request("POST", url, { ...options, json: body });
+
+      return parseJson<T>(res);
+    },
+    put: async <T>(
+      url: string,
+      body: unknown,
+      options?: Omit<RequestOptions, "json">,
+    ): Promise<T> => {
+      const res = await request("PUT", url, { ...options, json: body });
+
+      return parseJson<T>(res);
+    },
+    patch: async <T>(
+      url: string,
+      body: unknown,
+      options?: Omit<RequestOptions, "json">,
+    ): Promise<T> => {
+      const res = await request("PATCH", url, { ...options, json: body });
+
+      return parseJson<T>(res);
+    },
+    delete: async <T>(url: string, options?: RequestOptions): Promise<T> => {
+      const res = await request("DELETE", url, options);
+
+      return parseJson<T>(res);
+    },
+  };
+};

--- a/apps/hobom-angel/src/shared/api/http-error.api.ts
+++ b/apps/hobom-angel/src/shared/api/http-error.api.ts
@@ -1,0 +1,15 @@
+/**
+ * HTTP 응답 에러. `status`는 HTTP 상태 코드, `serverMessage`는 응답 body의 `message` 필드.
+ * `Error.message`에 `serverMessage`가 있으면 그 값을, 없으면 `"HTTP error! status: {code}"`를 넣는다.
+ */
+export class HttpError extends Error {
+  readonly status: number;
+  readonly serverMessage?: string;
+
+  constructor(status: number, serverMessage?: string) {
+    super(serverMessage ?? `HTTP error! status: ${status}`);
+    this.name = "HttpError";
+    this.status = status;
+    this.serverMessage = serverMessage;
+  }
+}

--- a/apps/hobom-angel/src/shared/api/http-options.type.ts
+++ b/apps/hobom-angel/src/shared/api/http-options.type.ts
@@ -1,0 +1,8 @@
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+export interface RequestOptions extends Omit<RequestInit, "method" | "body"> {
+  json?: unknown;
+  retry?: number;
+  /** 요청 타임아웃 (ms). 기본값 30000 */
+  timeout?: number;
+}

--- a/apps/hobom-angel/src/shared/api/http-response.type.ts
+++ b/apps/hobom-angel/src/shared/api/http-response.type.ts
@@ -1,0 +1,13 @@
+export interface HttpResponseType<T> {
+  success: boolean;
+  message: string;
+  timestamp: Date;
+  items: T;
+}
+
+export interface PaginatedItems<T> {
+  items: T[];
+  totalCount: number;
+  offset: number;
+  limit: number;
+}

--- a/apps/hobom-angel/src/shared/api/http-status.api.ts
+++ b/apps/hobom-angel/src/shared/api/http-status.api.ts
@@ -1,0 +1,4 @@
+export const HttpStatusModel = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+} as const;

--- a/apps/hobom-angel/src/shared/api/http.api.ts
+++ b/apps/hobom-angel/src/shared/api/http.api.ts
@@ -1,0 +1,18 @@
+import { env } from "@/shared/config";
+import { createHttpClient } from "./http-client.api";
+import { csrfMiddleware } from "./csrf.middleware";
+import { authMiddleware, UNAUTHORIZED_EVENT, resetUnauthorizedState } from "./auth.middleware";
+
+const createConfiguredClient = (baseUrl: string) => {
+  const client = createHttpClient(baseUrl);
+
+  client.use(csrfMiddleware);
+  client.use(authMiddleware);
+
+  return client;
+};
+
+// Angel talks to a single backend behind the gateway (hobom-angel).
+const httpClient = createConfiguredClient(env.VITE_APP_HOBOM_API_GATEWAY_URL);
+
+export { httpClient, UNAUTHORIZED_EVENT, resetUnauthorizedState };

--- a/apps/hobom-angel/src/shared/api/index.ts
+++ b/apps/hobom-angel/src/shared/api/index.ts
@@ -1,0 +1,4 @@
+export { httpClient, UNAUTHORIZED_EVENT, resetUnauthorizedState } from "./http.api";
+export { HttpError } from "./http-error.api";
+export type { HttpResponseType, PaginatedItems } from "./http-response.type";
+export { parseResponse } from "./parse-response.api";

--- a/apps/hobom-angel/src/shared/api/middleware.type.ts
+++ b/apps/hobom-angel/src/shared/api/middleware.type.ts
@@ -1,0 +1,17 @@
+export interface MiddlewareContext {
+  /** 요청 URL. `onRequest`에서 수정 가능. */
+  input: RequestInfo;
+  /** fetch init 옵션. `onRequest`에서 수정 가능. */
+  init: RequestInit;
+  /** fetch 완료 후에만 존재. `onResponse`/`onError`에서 접근 가능. */
+  response?: Response;
+  /** 에러 발생 후에만 존재. `onError`에서 접근 가능. */
+  error?: unknown;
+}
+
+/** HTTP 클라이언트 미들웨어. 훅은 등록 순서대로 순차 실행된다. */
+export interface Middleware {
+  onRequest?: (ctx: MiddlewareContext) => Promise<void> | void;
+  onResponse?: (ctx: MiddlewareContext) => Promise<void> | void;
+  onError?: (ctx: MiddlewareContext) => Promise<void> | void;
+}

--- a/apps/hobom-angel/src/shared/api/parse-response.api.ts
+++ b/apps/hobom-angel/src/shared/api/parse-response.api.ts
@@ -1,0 +1,30 @@
+import { reportError } from "@/shared/lib/report-error.lib";
+import type { Schema } from "hobom-schema";
+
+/**
+ * 응답 페이로드를 스키마로 검증하는 경계 파서.
+ *
+ * 불일치해도 throw하지 않는다 — `reportError`로 계약 위반을 보고하고 원본 데이터를
+ * 그대로 통과시켜, 백엔드 드리프트가 화면을 깨뜨리지 않게 한다. 로깅된 불일치를
+ * 근거로 스키마/타입을 점진적으로 실제 계약에 맞춰간다 (advisory validation).
+ *
+ * @param schema  기대하는 페이로드 스키마
+ * @param context 보고 메시지에 붙일 식별자 (예: `"GET /labels"`)
+ */
+export const parseResponse =
+  <T>(schema: Schema<T>, context: string) =>
+  (data: unknown): T => {
+    const result = schema.safeParse(data);
+
+    if (result.success) {
+      return result.data;
+    }
+
+    const detail = result.error.issues.map((issue) => issue.message).join("; ");
+
+    reportError(new Error(`Response validation mismatch (${context}): ${detail}`));
+
+    // Advisory only: pass the unvalidated payload through so a schema/wire
+    // mismatch is reported, not fatal.
+    return data as T;
+  };

--- a/apps/hobom-angel/src/shared/config/env.ts
+++ b/apps/hobom-angel/src/shared/config/env.ts
@@ -1,0 +1,4 @@
+export const env = {
+  VITE_APP_HOBOM_API_KEY: import.meta.env.VITE_APP_HOBOM_API_KEY ?? "",
+  VITE_APP_HOBOM_API_GATEWAY_URL: import.meta.env.VITE_APP_HOBOM_API_GATEWAY_URL ?? "/api",
+};

--- a/apps/hobom-angel/src/shared/config/index.ts
+++ b/apps/hobom-angel/src/shared/config/index.ts
@@ -1,0 +1,1 @@
+export { env } from "./env";

--- a/apps/hobom-angel/src/shared/lib/index.ts
+++ b/apps/hobom-angel/src/shared/lib/index.ts
@@ -1,0 +1,1 @@
+export { reportError } from "./report-error.lib";

--- a/apps/hobom-angel/src/shared/lib/report-error.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/report-error.lib.ts
@@ -1,0 +1,12 @@
+import { HttpError } from "../api/http-error.api";
+
+/**
+ * 에러 리포터. 현재는 콘솔 로깅만 — Angel 백엔드에 에러 수집 엔드포인트가 생기면
+ * fire-and-forget 원격 캡처를 붙인다(hobom-system의 captureError 패턴). 서버 응답
+ * 에러와 클라이언트 로직 에러를 구분해 둔다.
+ */
+export const reportError = (error: Error, errorInfo?: Record<string, unknown>) => {
+  const errorType = error instanceof HttpError ? "SERVER_RESPONSE" : "CLIENT_LOGIC";
+
+  console.error(`[${errorType}]`, error, errorInfo);
+};


### PR DESCRIPTION
Follow-up to #183 (app scaffold + landing). Gives the Angel consumer app its data foundation so screens can start fetching in the next phase.

Ports the proven `hobom-system` HTTP stack, adapted to Angel's single backend:
- **`shared/config/env.ts`** — reads `VITE_APP_HOBOM_API_KEY` and `VITE_APP_HOBOM_API_GATEWAY_URL`.
- **`shared/api`** — a middleware HTTP client (auto `X-Hobom-Api-Key` + `credentials: include`, timeout, retry, composed abort signals) pointed at the single `hobom-angel` gateway, with CSRF and auth-refresh middleware, and a schema-advisory `parseResponse` (reports contract drift via `reportError`, never throws).
- **`shared/lib/report-error.lib.ts`** — console-only for now; remote capture wires up once the Angel backend exposes an errors endpoint (the back-office posts to a space service Angel doesn't have).
- **`AppProvider`** — wraps the app in `DataLotProvider` (hobom-data) so queries work.

Env values live only in a local, git-ignored `.env` (key + gateway base URL); no `.env.example`/`.env.production` per request.

**Verified against the live gateway:**
```
GET https://hobom-system.com/hobom-api-gateway/hobom-angel/health/live
x-hobom-api-key: <key>
→ 200 {"success":true,"items":{"status":"ok",...},"message":"OK","timestamp":...}
```
The envelope matches the ported `HttpResponseType<T>`. Workspace typecheck + app lint clean.