### PR TITLE
Serve the Angel app under the /hobom-angel/ base path

### DIFF
--- a/apps/hobom-angel/src/main.tsx
+++ b/apps/hobom-angel/src/main.tsx
@@ -9,7 +9,8 @@ const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("root element not found");
 
 createRoot(rootElement).render(
-  <BrowserRouter>
+  // basename tracks Vite's `base` (/hobom-angel/) so routes work under the prefix.
+  <BrowserRouter basename={import.meta.env.BASE_URL}>
     <App />
   </BrowserRouter>,
 );

--- a/apps/hobom-angel/vite.config.ts
+++ b/apps/hobom-angel/vite.config.ts
@@ -4,6 +4,9 @@ import react from "@vitejs/plugin-react-swc";
 import stylex from "@stylexjs/unplugin";
 
 export default defineConfig({
+  // Served under the `/hobom-angel/` path prefix, so assets must resolve there
+  // (a root base would 404). Keep this in sync with the router basename.
+  base: "/hobom-angel/",
   // StyleX must run before react to preserve Fast Refresh. `unstable_moduleResolution`
   // in ESM mode lets the plugin resolve StyleX vars imported from the workspace
   // design-system package.


### PR DESCRIPTION
The Angel app is served behind a `/hobom-angel/` path prefix. Without a matching Vite `base`, the built `index.html` references assets at `/assets/...` and `/favicon.svg`, which 404 under the prefix.

- Set `base: '/hobom-angel/'` in `vite.config.ts` — assets now emit at `/hobom-angel/assets/...`.
- Track the same prefix in the router via `basename={import.meta.env.BASE_URL}` so client-side routes resolve under `/hobom-angel/` too (otherwise SPA navigation 404s).

Verified: production build emits `/hobom-angel/`-prefixed asset URLs; typecheck + lint clean.

Note: if the reverse proxy strips the `/hobom-angel/` prefix before it reaches the app, the router basename is still correct (BASE_URL stays in sync with the build base) — confirm the proxy behavior when wiring the deploy.