### PR TITLE
Add PII masking helpers to hobom-utils

### DIFF
--- a/packages/hobom-utils/src/functions.ts
+++ b/packages/hobom-utils/src/functions.ts
@@ -50,6 +50,11 @@ export * from "./packages/add/add";
 export * from "./packages/subtract/subtract";
 export * from "./packages/clamp/clamp";
 
+// String — masking (PII)
+export * from "./packages/maskName/maskName";
+export * from "./packages/maskPhone/maskPhone";
+export * from "./packages/maskEmail/maskEmail";
+
 // Type guards
 export * from "./packages/isArray/isArray";
 export * from "./packages/isDefined/isDefined";

--- a/packages/hobom-utils/src/packages/maskEmail/maskEmail.spec.ts
+++ b/packages/hobom-utils/src/packages/maskEmail/maskEmail.spec.ts
@@ -1,0 +1,18 @@
+import { maskEmail } from "./maskEmail";
+
+describe("maskEmail()", () => {
+  test("keeps the first local character and the domain", () => {
+    expect(maskEmail("foxmon1524@gmail.com")).toBe("f*********@gmail.com");
+    expect(maskEmail("ab@hobom.io")).toBe("a*@hobom.io");
+  });
+
+  test("masks a single-character local part", () => {
+    expect(maskEmail("a@hobom.io")).toBe("*@hobom.io");
+  });
+
+  test("fully masks input without a usable local part", () => {
+    expect(maskEmail("@hobom.io")).toBe("*********");
+    expect(maskEmail("not-an-email")).toBe("************");
+    expect(maskEmail("")).toBe("*");
+  });
+});

--- a/packages/hobom-utils/src/packages/maskEmail/maskEmail.ts
+++ b/packages/hobom-utils/src/packages/maskEmail/maskEmail.ts
@@ -1,0 +1,25 @@
+/**
+ * Mask an email's local part, keeping its first character and the full domain.
+ *
+ * `foxmon1524@gmail.com` → `f*********@gmail.com`. A single-character local part
+ * becomes `*`. Input without a usable local part (`@x.com`, no `@`) is fully
+ * masked.
+ *
+ * @param email - The email address to mask.
+ *
+ * @category String
+ */
+export function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+
+  if (at <= 0) return "*".repeat(Math.max(email.length, 1));
+
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+
+  if (local.length === 1) return `*${domain}`;
+
+  const first = local[0] ?? "";
+
+  return `${first}${"*".repeat(local.length - 1)}${domain}`;
+}

--- a/packages/hobom-utils/src/packages/maskName/maskName.spec.ts
+++ b/packages/hobom-utils/src/packages/maskName/maskName.spec.ts
@@ -1,0 +1,24 @@
+import { maskName } from "./maskName";
+
+describe("maskName()", () => {
+  test("keeps the first and last character, masking the middle", () => {
+    expect(maskName("홍길동")).toBe("홍*동");
+    expect(maskName("남궁민수")).toBe("남**수");
+  });
+
+  test("masks only the second character for a two-character name", () => {
+    expect(maskName("김철")).toBe("김*");
+  });
+
+  test("masks a single-character name entirely", () => {
+    expect(maskName("A")).toBe("*");
+  });
+
+  test("returns an empty string for empty input", () => {
+    expect(maskName("")).toBe("");
+  });
+
+  test("counts by code point (no surrogate splitting)", () => {
+    expect(maskName("🙂😀😉")).toBe("🙂*😉");
+  });
+});

--- a/packages/hobom-utils/src/packages/maskName/maskName.ts
+++ b/packages/hobom-utils/src/packages/maskName/maskName.ts
@@ -1,0 +1,25 @@
+/**
+ * Mask a personal name, revealing only the first and last characters.
+ *
+ * `홍길동` → `홍*동`, `남궁민수` → `남**수`, `김철` → `김*`, `A` → `*`, `""` → `""`.
+ * Counts by code point so surrogate-pair characters aren't split.
+ *
+ * @param name - The name to mask.
+ *
+ * @category String
+ */
+export function maskName(name: string): string {
+  const chars = Array.from(name);
+  const length = chars.length;
+
+  if (length === 0) return "";
+  if (length === 1) return "*";
+
+  const first = chars[0] ?? "";
+
+  if (length === 2) return `${first}*`;
+
+  const last = chars[length - 1] ?? "";
+
+  return `${first}${"*".repeat(length - 2)}${last}`;
+}

--- a/packages/hobom-utils/src/packages/maskPhone/maskPhone.spec.ts
+++ b/packages/hobom-utils/src/packages/maskPhone/maskPhone.spec.ts
@@ -1,0 +1,22 @@
+import { maskPhone } from "./maskPhone";
+
+describe("maskPhone()", () => {
+  test("masks the middle of an 11-digit mobile number", () => {
+    expect(maskPhone("01012341234")).toBe("010-****-1234");
+    expect(maskPhone("010-1234-1234")).toBe("010-****-1234");
+  });
+
+  test("strips separators and spaces before masking", () => {
+    expect(maskPhone("010 1234 1234")).toBe("010-****-1234");
+    expect(maskPhone("+82 10-1234-1234")).toBe("821-*****-1234");
+  });
+
+  test("keeps prefix + last four for a 10-digit number", () => {
+    expect(maskPhone("0212345678")).toBe("021-***-5678");
+  });
+
+  test("fully masks numbers shorter than seven digits", () => {
+    expect(maskPhone("12345")).toBe("*****");
+    expect(maskPhone("")).toBe("*");
+  });
+});

--- a/packages/hobom-utils/src/packages/maskPhone/maskPhone.ts
+++ b/packages/hobom-utils/src/packages/maskPhone/maskPhone.ts
@@ -1,0 +1,21 @@
+/**
+ * Mask a phone number, keeping the leading prefix and the last four digits.
+ *
+ * Non-digits are stripped first, so `01012341234` and `010-1234-1234` both
+ * become `010-****-1234`. Numbers shorter than seven digits are fully masked.
+ *
+ * @param phone - The phone number to mask.
+ *
+ * @category String
+ */
+export function maskPhone(phone: string): string {
+  const digits = phone.replace(/\D/g, "");
+
+  if (digits.length < 7) return "*".repeat(Math.max(digits.length, 1));
+
+  const head = digits.slice(0, 3);
+  const tail = digits.slice(-4);
+  const middle = "*".repeat(digits.length - 7);
+
+  return `${head}-${middle}-${tail}`;
+}


### PR DESCRIPTION
Groundwork for the Angel consumer surface, where names, phone numbers, and emails must be masked on display (spec §3, §13-3).

Three pure functions with unit tests, following the package's convention (`packages/<name>/<name>.ts` + `.spec.ts`, re-exported from `functions.ts`):

- **`maskName`** — reveals only the first and last character (`홍길동` → `홍*동`, `김철` → `김*`); counts by code point so surrogate pairs aren't split.
- **`maskPhone`** — strips separators, keeps the prefix + last four digits (`010-1234-1234` → `010-****-1234`); fully masks anything under seven digits.
- **`maskEmail`** — keeps the first local character and the full domain (`foxmon1524@gmail.com` → `f*********@gmail.com`); masks input without a usable local part.

12 unit tests, typecheck + lint clean.