### PR TITLE
Add the email-verification signup funnel

### DIFF
--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -10,6 +10,9 @@ const LandingPage = lazy(() =>
 const LoginPage = lazy(() =>
   import("@/pages/login").then((module) => ({ default: module.LoginPage })),
 );
+const SignupPage = lazy(() =>
+  import("@/pages/signup").then((module) => ({ default: module.SignupPage })),
+);
 
 /**
  * Public routing. Only the landing page is open to guests; the rest of the
@@ -20,6 +23,7 @@ export const AppRouter = () => (
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignupPage />} />
       <Route path="*" element={<NotFoundState />} />
     </Routes>
   </Suspense>

--- a/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
@@ -7,7 +7,7 @@ export type AnimalStatus = "입양가능" | "예약중";
 interface AnimalCardProps {
   name: string;
   status: AnimalStatus;
-  /** Attribute line, e.g. "강아지 · 2살 · 서울". */
+  /** Attribute line, e.g. "dog · 2yr · Seoul". */
   meta: string;
   imageUrl?: string;
 }

--- a/apps/hobom-angel/src/features/signup/index.ts
+++ b/apps/hobom-angel/src/features/signup/index.ts
@@ -1,0 +1,1 @@
+export { SignupFunnel } from "./ui/SignupFunnel";

--- a/apps/hobom-angel/src/features/signup/lib/validate-signup.lib.spec.ts
+++ b/apps/hobom-angel/src/features/signup/lib/validate-signup.lib.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isValidCode, isValidEmail, validateProfile } from "./validate-signup.lib";
+
+describe("isValidEmail", () => {
+  it("accepts a well-formed address and trims whitespace", () => {
+    expect(isValidEmail("hobom@example.com")).toBe(true);
+    expect(isValidEmail("  hobom@example.com  ")).toBe(true);
+  });
+
+  it("rejects malformed addresses", () => {
+    expect(isValidEmail("hobom@")).toBe(false);
+    expect(isValidEmail("hobom.com")).toBe(false);
+    expect(isValidEmail("")).toBe(false);
+  });
+});
+
+describe("isValidCode", () => {
+  it("accepts exactly six digits", () => {
+    expect(isValidCode("417284")).toBe(true);
+  });
+
+  it("rejects anything that isn't six digits", () => {
+    expect(isValidCode("4172")).toBe(false);
+    expect(isValidCode("4172840")).toBe(false);
+    expect(isValidCode("41728a")).toBe(false);
+  });
+});
+
+describe("validateProfile", () => {
+  it("passes for a nickname and an 8+ character password", () => {
+    expect(validateProfile({ nickname: "봄이네", password: "hobom1234" })).toEqual({});
+  });
+
+  it("requires a nickname", () => {
+    expect(validateProfile({ nickname: " ", password: "hobom1234" }).nickname).toBe(
+      "닉네임을 입력해주세요.",
+    );
+  });
+
+  it("requires an 8+ character password", () => {
+    expect(validateProfile({ nickname: "봄이네", password: "short" }).password).toBe(
+      "비밀번호는 8자 이상이어야 해요.",
+    );
+  });
+});

--- a/apps/hobom-angel/src/features/signup/lib/validate-signup.lib.ts
+++ b/apps/hobom-angel/src/features/signup/lib/validate-signup.lib.ts
@@ -1,0 +1,32 @@
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Instant client-side email format check (server re-validates). */
+export const isValidEmail = (email: string): boolean => EMAIL_PATTERN.test(email.trim());
+
+/** A verification code is exactly six digits. */
+export const isValidCode = (code: string): boolean => /^\d{6}$/.test(code);
+
+export interface ProfileValues {
+  nickname: string;
+  password: string;
+}
+
+export interface ProfileErrors {
+  nickname?: string;
+  password?: string;
+}
+
+/** Validate the profile step; returns a per-field error map (empty when valid). */
+export const validateProfile = ({ nickname, password }: ProfileValues): ProfileErrors => {
+  const errors: ProfileErrors = {};
+
+  if (nickname.trim().length === 0) {
+    errors.nickname = "닉네임을 입력해주세요.";
+  }
+
+  if (password.length < 8) {
+    errors.password = "비밀번호는 8자 이상이어야 해요.";
+  }
+
+  return errors;
+};

--- a/apps/hobom-angel/src/features/signup/ui/AgreementStep.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/AgreementStep.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles } from "./SignupFunnel.styles";
+
+interface AgreementStepProps {
+  onNext: () => void;
+}
+
+type AgreementKey = "terms" | "privacy" | "age" | "marketing";
+
+const ROWS: { key: AgreementKey; label: string; required: boolean; hasView: boolean }[] = [
+  { key: "terms", label: "이용약관", required: true, hasView: true },
+  { key: "privacy", label: "개인정보 수집·이용", required: true, hasView: true },
+  { key: "age", label: "만 19세 이상", required: true, hasView: false },
+  { key: "marketing", label: "마케팅·알림 수신", required: false, hasView: true },
+];
+
+const REQUIRED_KEYS: AgreementKey[] = ["terms", "privacy", "age"];
+
+export const AgreementStep = ({ onNext }: AgreementStepProps) => {
+  const [agreed, setAgreed] = useState<Record<AgreementKey, boolean>>({
+    terms: false,
+    privacy: false,
+    age: false,
+    marketing: false,
+  });
+
+  const allChecked = ROWS.every((row) => agreed[row.key]);
+  const requiredMet = REQUIRED_KEYS.every((key) => agreed[key]);
+
+  const toggle = (key: AgreementKey) => setAgreed((prev) => ({ ...prev, [key]: !prev[key] }));
+  const toggleAll = () => {
+    const next = !allChecked;
+
+    setAgreed({ terms: next, privacy: next, age: next, marketing: next });
+  };
+
+  return (
+    <div {...stylex.props(styles.step)}>
+      <h2 {...stylex.props(styles.title)}>환영해요</h2>
+      <p {...stylex.props(styles.subtitle)}>시작하기 전에 약관에 동의해주세요.</p>
+
+      <label {...stylex.props(styles.agreeAll)}>
+        <Hb.Checkbox checked={allChecked} onChange={toggleAll} />
+        전체 동의
+      </label>
+
+      {ROWS.map((row) => (
+        <label key={row.key} {...stylex.props(styles.agreeRow)}>
+          <Hb.Checkbox checked={agreed[row.key]} onChange={() => toggle(row.key)} />
+          <span {...stylex.props(styles.agreeLabel)}>
+            <span {...stylex.props(row.required ? undefined : styles.optionalTag)}>
+              [{row.required ? "필수" : "선택"}]
+            </span>{" "}
+            {row.label}
+          </span>
+          {row.hasView && <span {...stylex.props(styles.agreeView)}>보기</span>}
+        </label>
+      ))}
+
+      <Hb.Button
+        variant="primary"
+        fullWidth
+        disabled={!requiredMet}
+        onClick={onNext}
+        {...stylex.props(styles.submit)}
+      >
+        동의하고 계속
+      </Hb.Button>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/signup/ui/CodeStep.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/CodeStep.tsx
@@ -1,0 +1,69 @@
+import { useState, type ChangeEvent, type FormEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { isValidCode } from "../lib/validate-signup.lib";
+import { styles } from "./SignupFunnel.styles";
+
+interface CodeStepProps {
+  onNext: () => void;
+}
+
+const BOXES = [0, 1, 2, 3, 4, 5];
+
+export const CodeStep = ({ onNext }: CodeStepProps) => {
+  const [code, setCode] = useState("");
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) =>
+    setCode(event.target.value.replace(/\D/g, "").slice(0, 6));
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isValidCode(code)) onNext();
+  };
+
+  return (
+    <form {...stylex.props(styles.step)} onSubmit={submit}>
+      <h2 {...stylex.props(styles.title)}>코드를 입력해주세요</h2>
+      <p {...stylex.props(styles.subtitle)}>메일로 받은 6자리를 입력하세요.</p>
+
+      <div {...stylex.props(styles.codeWrap)}>
+        <input
+          {...stylex.props(styles.codeInput)}
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          aria-label="인증코드"
+          maxLength={6}
+          value={code}
+          onChange={onChange}
+          autoFocus
+        />
+        {BOXES.map((index) => (
+          <div
+            key={index}
+            {...stylex.props(styles.codeBox, index === code.length && styles.codeBoxActive)}
+          >
+            {code[index] ?? ""}
+          </div>
+        ))}
+      </div>
+
+      <p {...stylex.props(styles.codeMeta)}>
+        남은 시간 4:52 ·{" "}
+        <button type="button" {...stylex.props(styles.resend)}>
+          재전송
+        </button>
+      </p>
+
+      <Hb.Button
+        type="submit"
+        variant="primary"
+        fullWidth
+        disabled={!isValidCode(code)}
+        {...stylex.props(styles.submit)}
+      >
+        확인
+      </Hb.Button>
+    </form>
+  );
+};

--- a/apps/hobom-angel/src/features/signup/ui/DoneStep.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/DoneStep.tsx
@@ -1,0 +1,26 @@
+import { useNavigate } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles } from "./SignupFunnel.styles";
+
+export const DoneStep = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div {...stylex.props(styles.step, styles.done)}>
+      <span {...stylex.props(styles.doneCheck)} aria-hidden="true">
+        ✓
+      </span>
+      <h2 {...stylex.props(styles.title)}>가입 완료</h2>
+      <p {...stylex.props(styles.subtitle)}>이제 새로운 가족을 만나볼 수 있어요.</p>
+      <Hb.Button
+        variant="primary"
+        fullWidth
+        onClick={() => navigate("/")}
+        {...stylex.props(styles.submit)}
+      >
+        동물 둘러보기
+      </Hb.Button>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/signup/ui/EmailStep.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/EmailStep.tsx
@@ -1,0 +1,50 @@
+import { useState, type FormEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { isValidEmail } from "../lib/validate-signup.lib";
+import { styles } from "./SignupFunnel.styles";
+
+interface EmailStepProps {
+  onNext: (email: string) => void;
+}
+
+export const EmailStep = ({ onNext }: EmailStepProps) => {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string>();
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!isValidEmail(email)) {
+      setError("올바른 이메일 형식이 아니에요.");
+
+      return;
+    }
+
+    onNext(email.trim());
+  };
+
+  return (
+    <form {...stylex.props(styles.step)} onSubmit={submit} noValidate>
+      <h2 {...stylex.props(styles.title)}>이메일로 시작하기</h2>
+      <p {...stylex.props(styles.subtitle)}>인증 코드를 보내드릴 이메일을 입력해주세요.</p>
+
+      <Hb.TextField
+        label="이메일"
+        type="email"
+        placeholder="hobom@example.com"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        error={Boolean(error)}
+        helperText={error}
+        fullWidth
+      />
+
+      <Hb.Button type="submit" variant="primary" fullWidth {...stylex.props(styles.submit)}>
+        인증 메일 보내기
+      </Hb.Button>
+
+      <p {...stylex.props(styles.hint)}>비용이 들지 않아요. 스팸함도 확인해주세요.</p>
+    </form>
+  );
+};

--- a/apps/hobom-angel/src/features/signup/ui/ProfileStep.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/ProfileStep.tsx
@@ -1,0 +1,89 @@
+import { useState, type FormEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { validateProfile, type ProfileErrors } from "../lib/validate-signup.lib";
+import { styles } from "./SignupFunnel.styles";
+
+interface ProfileStepProps {
+  onNext: (nickname: string, password: string) => void;
+}
+
+export const ProfileStep = ({ onNext }: ProfileStepProps) => {
+  const [nickname, setNickname] = useState("");
+  const [realName, setRealName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [errors, setErrors] = useState<ProfileErrors>({});
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const next = validateProfile({ nickname, password });
+
+    setErrors(next);
+
+    if (Object.keys(next).length === 0) onNext(nickname.trim(), password);
+  };
+
+  return (
+    <form {...stylex.props(styles.step)} onSubmit={submit} noValidate>
+      <h2 {...stylex.props(styles.title)}>정보를 입력해주세요</h2>
+
+      <div {...stylex.props(styles.fields)}>
+        <div>
+          <span {...stylex.props(styles.fieldLabel)}>닉네임 (공개)</span>
+          <div {...stylex.props(styles.nickRow)}>
+            <Hb.TextField
+              aria-label="닉네임"
+              placeholder="봄이네"
+              value={nickname}
+              onChange={(event) => setNickname(event.target.value)}
+              error={Boolean(errors.nickname)}
+              helperText={errors.nickname}
+              fullWidth
+            />
+            <Hb.Button variant="secondary" type="button">
+              중복확인
+            </Hb.Button>
+          </div>
+        </div>
+
+        <div>
+          <span {...stylex.props(styles.fieldLabel)}>실명 · 휴대폰 (선택)</span>
+          <div {...stylex.props(styles.fields)}>
+            <Hb.TextField
+              aria-label="실명"
+              placeholder="김민수"
+              value={realName}
+              onChange={(event) => setRealName(event.target.value)}
+              fullWidth
+            />
+            <Hb.TextField
+              aria-label="휴대폰"
+              type="tel"
+              placeholder="010-0000-0000"
+              value={phone}
+              onChange={(event) => setPhone(event.target.value)}
+              fullWidth
+            />
+          </div>
+        </div>
+
+        <Hb.TextField
+          label="비밀번호"
+          type="password"
+          placeholder="••••••••"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          error={Boolean(errors.password)}
+          helperText={errors.password}
+          fullWidth
+        />
+      </div>
+
+      <Hb.Button type="submit" variant="primary" fullWidth {...stylex.props(styles.submit)}>
+        가입 완료
+      </Hb.Button>
+    </form>
+  );
+};

--- a/apps/hobom-angel/src/features/signup/ui/SignupFunnel.styles.ts
+++ b/apps/hobom-angel/src/features/signup/ui/SignupFunnel.styles.ts
@@ -1,0 +1,159 @@
+import * as stylex from "@stylexjs/stylex";
+
+const REDUCED = "@media (prefers-reduced-motion: reduce)";
+
+// Step transition: incoming step fades and lifts in; stilled under reduced-motion.
+const stepEnter = stylex.keyframes({
+  from: { opacity: 0, transform: "translateY(8px)" },
+  to: { opacity: 1, transform: "translateY(0)" },
+});
+
+export const styles = stylex.create({
+  page: {
+    minHeight: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "clamp(16px, 4vw, 40px)",
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  card: {
+    width: "100%",
+    maxWidth: 440,
+    backgroundColor: "var(--hb-color-surface)",
+    borderRadius: 24,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    boxShadow: "var(--hb-angel-shadow)",
+    overflow: "hidden",
+  },
+  body: { padding: "32px 28px" },
+  step: {
+    animationName: stepEnter,
+    animationDuration: { default: "0.28s", [REDUCED]: "0.01s" },
+    animationTimingFunction: "ease-out",
+  },
+
+  // ── Headings ────────────────────────────────────────────
+  title: { margin: 0, fontSize: "1.375rem", fontWeight: 800, color: "var(--hb-color-text-primary)" },
+  subtitle: {
+    margin: 0,
+    marginTop: 8,
+    marginBottom: 24,
+    fontSize: "0.9375rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-secondary)",
+  },
+
+  // ── Fields ──────────────────────────────────────────────
+  fields: { display: "flex", flexDirection: "column", gap: 16 },
+  fieldLabel: {
+    display: "block",
+    marginBottom: 6,
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+  nickRow: { display: "flex", gap: 8, alignItems: "flex-start" },
+  submit: { marginTop: 24 },
+  hint: {
+    margin: 0,
+    marginTop: 12,
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+    textAlign: "center",
+  },
+  footer: {
+    margin: 0,
+    marginTop: 20,
+    textAlign: "center",
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  footerLink: { fontWeight: 700, color: "var(--hb-color-accent-dark)" },
+
+  // ── Agreement ───────────────────────────────────────────
+  agreeAll: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: "var(--hb-angel-surface-alt)",
+    fontSize: "0.9375rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+    marginBottom: 8,
+  },
+  agreeRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    paddingBlock: 8,
+    paddingInline: 4,
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+  },
+  agreeLabel: { flex: 1 },
+  agreeView: { fontSize: "0.8125rem", color: "var(--hb-color-text-secondary)" },
+  optionalTag: { color: "var(--hb-color-text-secondary)", fontWeight: 500 },
+
+  // ── Code boxes ──────────────────────────────────────────
+  codeWrap: { position: "relative", display: "flex", justifyContent: "center", gap: 8 },
+  codeInput: {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    height: "100%",
+    opacity: 0,
+    cursor: "pointer",
+    borderWidth: 0,
+  },
+  codeBox: {
+    width: 44,
+    height: 54,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    fontSize: "1.375rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  codeBoxActive: { borderColor: "var(--hb-color-accent)" },
+  codeMeta: {
+    marginTop: 16,
+    textAlign: "center",
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  resend: {
+    borderWidth: 0,
+    borderStyle: "none",
+    backgroundColor: "transparent",
+    color: "var(--hb-color-accent-dark)",
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+
+  // ── Done ────────────────────────────────────────────────
+  done: { textAlign: "center", paddingBlock: 12 },
+  doneCheck: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 64,
+    height: 64,
+    borderRadius: "50%",
+    marginBottom: 20,
+    backgroundColor: "var(--hb-angel-green-tint)",
+    color: "var(--hb-color-accent)",
+    fontSize: "2rem",
+  },
+});

--- a/apps/hobom-angel/src/features/signup/ui/SignupFunnel.tsx
+++ b/apps/hobom-angel/src/features/signup/ui/SignupFunnel.tsx
@@ -1,0 +1,51 @@
+import * as stylex from "@stylexjs/stylex";
+import { useFunnel } from "@/shared/model";
+import { styles } from "./SignupFunnel.styles";
+import { AgreementStep } from "./AgreementStep";
+import { EmailStep } from "./EmailStep";
+import { CodeStep } from "./CodeStep";
+import { ProfileStep } from "./ProfileStep";
+import { DoneStep } from "./DoneStep";
+
+const STEPS = ["agreement", "email", "code", "profile", "done"] as const;
+
+interface SignupState extends Record<string, unknown> {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+/** Email-verification signup funnel (§0.7): agreement → email → code → profile → done. */
+export const SignupFunnel = () => {
+  const [Funnel, , setState] = useFunnel(STEPS, { initialStep: "agreement" }).withState<SignupState>(
+    { email: "", nickname: "", password: "" },
+  );
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <div {...stylex.props(styles.card)}>
+        <div {...stylex.props(styles.body)}>
+          <Funnel>
+            <Funnel.Step name="agreement">
+              <AgreementStep onNext={() => setState({ step: "email" })} />
+            </Funnel.Step>
+            <Funnel.Step name="email">
+              <EmailStep onNext={(email) => setState({ step: "code", email })} />
+            </Funnel.Step>
+            <Funnel.Step name="code">
+              <CodeStep onNext={() => setState({ step: "profile" })} />
+            </Funnel.Step>
+            <Funnel.Step name="profile">
+              <ProfileStep
+                onNext={(nickname, password) => setState({ step: "done", nickname, password })}
+              />
+            </Funnel.Step>
+            <Funnel.Step name="done">
+              <DoneStep />
+            </Funnel.Step>
+          </Funnel>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/pages/login/lib/validate-login.lib.ts
+++ b/apps/hobom-angel/src/pages/login/lib/validate-login.lib.ts
@@ -9,7 +9,7 @@ export interface LoginErrors {
 }
 
 // Intentionally lenient — the server is the source of truth; this is just an
-// instant client-side format check (spec §검증: 즉시 형식검증·서버 재검증).
+// instant client-side format check (the server re-validates).
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /** Validate the login form; returns a per-field error map (empty when valid). */

--- a/apps/hobom-angel/src/pages/signup/index.ts
+++ b/apps/hobom-angel/src/pages/signup/index.ts
@@ -1,0 +1,1 @@
+export { SignupPage } from "./ui/SignupPage";

--- a/apps/hobom-angel/src/pages/signup/ui/SignupPage.tsx
+++ b/apps/hobom-angel/src/pages/signup/ui/SignupPage.tsx
@@ -1,0 +1,4 @@
+import { SignupFunnel } from "@/features/signup";
+
+/** Signup page — composes the signup feature. */
+export const SignupPage = () => <SignupFunnel />;

--- a/apps/hobom-angel/src/shared/api/http-client.api.ts
+++ b/apps/hobom-angel/src/shared/api/http-client.api.ts
@@ -15,13 +15,15 @@ interface HttpClient {
 }
 
 /**
- * 미들웨어 기반 HTTP 클라이언트 팩토리.
+ * Middleware-based HTTP client factory.
  *
- * - 모든 요청에 `Content-Type: application/json`, `X-Hobom-Api-Key`, `credentials: "include"` 자동 부여
- * - `timeout` 기본값 30초. 초과 시 `AbortError` 발생
- * - `retry` 옵션으로 실패 시 재시도 횟수 지정 가능
- * - 204 응답은 body 파싱 없이 `undefined` 반환
- * - 미들웨어 훅 실행 순서: `onRequest` → fetch → `onResponse` (또는 `onError`), 등록 순으로 순차 실행
+ * - Every request gets `Content-Type: application/json`, `X-Hobom-Api-Key`, and
+ *   `credentials: "include"` automatically.
+ * - `timeout` defaults to 30s; an `AbortError` is thrown when exceeded.
+ * - `retry` sets how many times to retry on failure.
+ * - A 204 response returns `undefined` without parsing a body.
+ * - Middleware hook order: `onRequest` → fetch → `onResponse` (or `onError`),
+ *   run sequentially in registration order.
  */
 export const createHttpClient = (baseUrl = ""): HttpClient => {
   const middlewares: Middleware[] = [];

--- a/apps/hobom-angel/src/shared/api/http-error.api.ts
+++ b/apps/hobom-angel/src/shared/api/http-error.api.ts
@@ -1,6 +1,7 @@
 /**
- * HTTP 응답 에러. `status`는 HTTP 상태 코드, `serverMessage`는 응답 body의 `message` 필드.
- * `Error.message`에 `serverMessage`가 있으면 그 값을, 없으면 `"HTTP error! status: {code}"`를 넣는다.
+ * An HTTP response error. `status` is the HTTP status code, `serverMessage` the
+ * response body's `message` field. `Error.message` uses `serverMessage` when
+ * present, otherwise `"HTTP error! status: {code}"`.
  */
 export class HttpError extends Error {
   readonly status: number;

--- a/apps/hobom-angel/src/shared/api/http-options.type.ts
+++ b/apps/hobom-angel/src/shared/api/http-options.type.ts
@@ -3,6 +3,6 @@ export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 export interface RequestOptions extends Omit<RequestInit, "method" | "body"> {
   json?: unknown;
   retry?: number;
-  /** 요청 타임아웃 (ms). 기본값 30000 */
+  /** Request timeout (ms). Defaults to 30000. */
   timeout?: number;
 }

--- a/apps/hobom-angel/src/shared/api/middleware.type.ts
+++ b/apps/hobom-angel/src/shared/api/middleware.type.ts
@@ -1,15 +1,15 @@
 export interface MiddlewareContext {
-  /** 요청 URL. `onRequest`에서 수정 가능. */
+  /** Request URL. Mutable in `onRequest`. */
   input: RequestInfo;
-  /** fetch init 옵션. `onRequest`에서 수정 가능. */
+  /** fetch init options. Mutable in `onRequest`. */
   init: RequestInit;
-  /** fetch 완료 후에만 존재. `onResponse`/`onError`에서 접근 가능. */
+  /** Present only after fetch completes; accessible in `onResponse`/`onError`. */
   response?: Response;
-  /** 에러 발생 후에만 존재. `onError`에서 접근 가능. */
+  /** Present only after an error; accessible in `onError`. */
   error?: unknown;
 }
 
-/** HTTP 클라이언트 미들웨어. 훅은 등록 순서대로 순차 실행된다. */
+/** HTTP client middleware. Hooks run sequentially in registration order. */
 export interface Middleware {
   onRequest?: (ctx: MiddlewareContext) => Promise<void> | void;
   onResponse?: (ctx: MiddlewareContext) => Promise<void> | void;

--- a/apps/hobom-angel/src/shared/api/parse-response.api.ts
+++ b/apps/hobom-angel/src/shared/api/parse-response.api.ts
@@ -2,14 +2,15 @@ import { reportError } from "@/shared/lib/report-error.lib";
 import type { Schema } from "hobom-schema";
 
 /**
- * 응답 페이로드를 스키마로 검증하는 경계 파서.
+ * Boundary parser that validates a response payload against a schema.
  *
- * 불일치해도 throw하지 않는다 — `reportError`로 계약 위반을 보고하고 원본 데이터를
- * 그대로 통과시켜, 백엔드 드리프트가 화면을 깨뜨리지 않게 한다. 로깅된 불일치를
- * 근거로 스키마/타입을 점진적으로 실제 계약에 맞춰간다 (advisory validation).
+ * It never throws on a mismatch — it reports the contract violation via
+ * `reportError` and passes the raw data through, so backend drift doesn't break
+ * the screen. The logged mismatches guide bringing the schema/types in line
+ * with the real contract over time (advisory validation).
  *
- * @param schema  기대하는 페이로드 스키마
- * @param context 보고 메시지에 붙일 식별자 (예: `"GET /labels"`)
+ * @param schema  the expected payload schema
+ * @param context an identifier for the report message (e.g. `"GET /labels"`)
  */
 export const parseResponse =
   <T>(schema: Schema<T>, context: string) =>

--- a/apps/hobom-angel/src/shared/lib/assert.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/assert.lib.ts
@@ -1,0 +1,11 @@
+/**
+ * TypeScript assertion function. Throws on a falsy value and, on success,
+ * narrows the type to `NonNullable<T>`.
+ *
+ * Using it instead of `if (!value) throw` removes later null/undefined checks.
+ */
+export function assertCondition<T>(value: T, message?: string): asserts value is NonNullable<T> {
+  if (!value) {
+    throw new Error(`Assertion failed: ${message != null ? message : ""}`);
+  }
+}

--- a/apps/hobom-angel/src/shared/lib/funnel.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/funnel.lib.ts
@@ -1,0 +1,58 @@
+type FunnelStateId = `funnel-state-id__${string}`;
+
+const FUNNEL_STATE_ID = `funnel-state-id__`;
+
+export interface FunnelStorage<T> {
+  get: () => Promise<Partial<T> | null>;
+  set: (value: Partial<T>) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+/** Builds a unique storage key for `useFunnel`, prefixed with `funnel-state-id__`. */
+export const createFunnelStateId = (id: string): FunnelStateId => {
+  return `${FUNNEL_STATE_ID}${id}`;
+};
+
+/**
+ * Creates storage that persists multi-step (funnel) form state.
+ * Defaults to `sessionStorage`, which clears itself when the tab closes.
+ * On a JSON parse failure it removes the key and returns `null`.
+ */
+export const createFunnelStorage = <T>(
+  funnelStateId: FunnelStateId,
+  storageType = "sessionStorage",
+): FunnelStorage<T> => {
+  switch (storageType) {
+    case "sessionStorage":
+      return {
+        get: () => {
+          const d = sessionStorage.getItem(funnelStateId);
+
+          if (d === null) {
+            return Promise.resolve(null);
+          }
+
+          try {
+            return Promise.resolve(JSON.parse(d) as Partial<T>);
+          } catch {
+            sessionStorage.removeItem(funnelStateId);
+
+            return Promise.resolve(null);
+          }
+        },
+        set: (value: Partial<T>) => {
+          sessionStorage.setItem(funnelStateId, JSON.stringify(value));
+
+          return Promise.resolve();
+        },
+        clear: () => {
+          sessionStorage.removeItem(funnelStateId);
+
+          return Promise.resolve();
+        },
+      };
+
+    default:
+      throw new Error("Please check your funnel storage type");
+  }
+};

--- a/apps/hobom-angel/src/shared/lib/index.ts
+++ b/apps/hobom-angel/src/shared/lib/index.ts
@@ -1,1 +1,4 @@
 export { reportError } from "./report-error.lib";
+export { assertCondition } from "./assert.lib";
+export { createFunnelStateId, createFunnelStorage } from "./funnel.lib";
+export type { FunnelStorage } from "./funnel.lib";

--- a/apps/hobom-angel/src/shared/lib/report-error.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/report-error.lib.ts
@@ -1,9 +1,10 @@
 import { HttpError } from "../api/http-error.api";
 
 /**
- * 에러 리포터. 현재는 콘솔 로깅만 — Angel 백엔드에 에러 수집 엔드포인트가 생기면
- * fire-and-forget 원격 캡처를 붙인다(hobom-system의 captureError 패턴). 서버 응답
- * 에러와 클라이언트 로직 에러를 구분해 둔다.
+ * Error reporter. Console-only for now — once the Angel backend exposes an
+ * error-collection endpoint, add fire-and-forget remote capture (mirroring the
+ * back-office captureError pattern). Server-response and client-logic errors
+ * are distinguished up front.
  */
 export const reportError = (error: Error, errorInfo?: Record<string, unknown>) => {
   const errorType = error instanceof HttpError ? "SERVER_RESPONSE" : "CLIENT_LOGIC";

--- a/apps/hobom-angel/src/shared/model/index.ts
+++ b/apps/hobom-angel/src/shared/model/index.ts
@@ -1,0 +1,1 @@
+export { useFunnel } from "./useFunnel";

--- a/apps/hobom-angel/src/shared/model/useFunnel.tsx
+++ b/apps/hobom-angel/src/shared/model/useFunnel.tsx
@@ -1,0 +1,223 @@
+import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Funnel, Step, type FunnelProps, type StepProps } from "hobom-design-system";
+import { assertCondition } from "@/shared/lib";
+import { useFunnelState } from "./useFunnelState";
+
+const DEFAULT_STEP_QUERY_KEY = "funnel-step";
+
+type NonEmptyArray<T> = readonly [T, ...T[]];
+
+type RouteFunnelProps<Steps extends NonEmptyArray<string>> = Omit<
+  FunnelProps<Steps>,
+  "steps" | "step"
+>;
+
+type FunnelComponent<Steps extends NonEmptyArray<string>> = ((
+  props: RouteFunnelProps<Steps>,
+) => JSX.Element) & {
+  Step: (props: StepProps<Steps>) => JSX.Element;
+};
+
+interface SetStepOptions {
+  stepChangeType?: "push" | "replace";
+}
+
+type UseFunnelReturn<Steps extends NonEmptyArray<string>> = readonly [
+  FunnelComponent<Steps>,
+  (step: Steps[number], options?: SetStepOptions) => void,
+] & {
+  withState: <StateExcludeStep extends Record<string, unknown>>(
+    initialState: StateExcludeStep,
+  ) => [
+    FunnelComponent<Steps>,
+    StateExcludeStep,
+    (
+      next:
+        | Partial<StateExcludeStep & { step: Steps[number] }>
+        | ((
+            next: Partial<StateExcludeStep & { step: Steps[number] }>,
+          ) => StateExcludeStep & { step: Steps[number] }),
+    ) => void,
+  ];
+};
+
+/**
+ * Multi-step funnel (wizard) hook. Syncs the current step to a URL query param.
+ *
+ * The default return is a `[FunnelComponent, setStep]` tuple; calling
+ * `.withState(initialState)` also manages state shared across the whole funnel.
+ *
+ * @example
+ * ```tsx
+ * const [Funnel, setStep] = useFunnel(["info", "confirm", "done"] as const);
+ *
+ * // with shared state
+ * const [Funnel, state, setState] = useFunnel(["info", "confirm"] as const)
+ *   .withState({ name: "", email: "" });
+ * ```
+ */
+export const useFunnel = <Steps extends NonEmptyArray<string>>(
+  steps: Steps,
+  options?: {
+    stepQueryKey?: string;
+    initialStep?: Steps[number];
+    onStepChange?: (name: Steps[number]) => void;
+  },
+): UseFunnelReturn<Steps> => {
+  const stepQueryKey = options?.stepQueryKey ?? DEFAULT_STEP_QUERY_KEY;
+
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  assertCondition(steps.length > 0, "The steps is empty !");
+
+  const FunnelComponent = useMemo(
+    () =>
+      Object.assign(
+        function RouteFunnel(props: RouteFunnelProps<Steps>) {
+          const { qsValue } = useQueryString(stepQueryKey);
+
+          const currentStep = qsValue ?? options?.initialStep;
+
+          if (currentStep == null) {
+            throw new Error(
+              `Assertion failed: Cannot expression current step. Please check the current step value ${currentStep} again !`,
+            );
+          }
+
+          return <Funnel<Steps> steps={steps} step={currentStep} {...props} />;
+        },
+        { Step },
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const setStep = useCallback(
+    (step: Steps[number], setStepOptions?: SetStepOptions) => {
+      const searchParams = new URLSearchParams(location.search);
+
+      searchParams.set(stepQueryKey, step);
+
+      const newSearch = searchParams.toString();
+
+      options?.onStepChange?.(step);
+
+      void navigate(
+        {
+          pathname: location.pathname,
+          search: `?${newSearch}`,
+        },
+        {
+          replace: setStepOptions?.stepChangeType === "replace",
+        },
+      );
+    },
+    [location.search, location.pathname, stepQueryKey, options, navigate],
+  );
+
+  type FunnelState = Record<string, unknown>;
+
+  type StepName = Steps[number];
+
+  type NextState = FunnelState & { step?: StepName };
+
+  const [state, _setState] = useFunnelState<FunnelState>({});
+
+  const nextPendingStepRef = useRef<StepName | null>(null);
+  const nextStateRef = useRef<Partial<FunnelState> | null>(null);
+
+  const setState = useCallback(
+    (next: Partial<NextState> | ((next: Partial<NextState>) => NextState)) => {
+      let nextStepValue: Partial<NextState>;
+
+      if (typeof next === "function") {
+        nextStepValue = next(state);
+      } else {
+        nextStepValue = next;
+      }
+
+      if (nextStepValue.step) {
+        nextPendingStepRef.current = nextStepValue.step;
+      }
+
+      nextStateRef.current = nextStepValue;
+
+      _setState(next);
+    },
+    [_setState, state],
+  );
+
+  useEffect(() => {
+    if (nextPendingStepRef.current == null) {
+      return;
+    }
+
+    setStep(nextPendingStepRef.current);
+
+    nextPendingStepRef.current = null;
+  }, [setStep, state]);
+
+  const initializedRef = useRef(false);
+
+  function withState<State extends Record<string, unknown>>(
+    initialState: State,
+  ): [
+    FunnelComponent<Steps>,
+    State,
+    (
+      next:
+        | Partial<State & { step: Steps[number] }>
+        | ((next: Partial<State & { step: Steps[number] }>) => State & { step: Steps[number] }),
+    ) => void,
+  ] {
+    if (!initializedRef.current) {
+      setState(initialState);
+      initializedRef.current = true;
+    }
+
+    return [
+      FunnelComponent,
+      state as State,
+      setState as (
+        next:
+          | Partial<State & { step: Steps[number] }>
+          | ((next: Partial<State & { step: Steps[number] }>) => State & { step: Steps[number] }),
+      ) => void,
+    ];
+  }
+
+  return Object.assign(
+    [FunnelComponent, setStep] as readonly [
+      FunnelComponent<Steps>,
+      (step: Steps[number], options?: SetStepOptions) => void,
+    ],
+    { withState },
+  );
+};
+
+const useQueryString = (name: string) => {
+  const [value, setValue] = useState<{ [key: string]: string }>({});
+
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { search } = location;
+
+  useEffect(() => {
+    const values = Object.fromEntries(new URLSearchParams(search));
+
+    setValue(values);
+  }, [search]);
+
+  return {
+    qsValue: value[name],
+    set: (params: Record<string, string>) => {
+      void navigate({
+        pathname: `${location.pathname}`,
+        search: new URLSearchParams({ ...value, ...params }).toString(),
+      });
+    },
+  };
+};

--- a/apps/hobom-angel/src/shared/model/useFunnelState.ts
+++ b/apps/hobom-angel/src/shared/model/useFunnelState.ts
@@ -1,0 +1,38 @@
+import { type SetStateAction, useCallback, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { createFunnelStateId, createFunnelStorage, type FunnelStorage } from "@/shared/lib";
+
+export const useFunnelState = <T extends Record<string, unknown>>(
+  defaultValue: Partial<T>,
+  options?: { storage?: FunnelStorage<T> },
+) => {
+  const location = useLocation();
+  const { pathname, search } = location;
+
+  const storage =
+    options?.storage ?? createFunnelStorage<T>(createFunnelStateId(`${pathname}${search}`));
+
+  const persistentStorage = useRef(storage).current;
+
+  const [_state, _setState] = useState<Partial<T>>(defaultValue);
+
+  const setState = useCallback(
+    (state: SetStateAction<Partial<T>>) => {
+      _setState((prev) => {
+        if (typeof state === "function") {
+          const newState = state(prev);
+
+          void persistentStorage.set(newState);
+
+          return newState;
+        }
+        void persistentStorage.set(state);
+
+        return state;
+      });
+    },
+    [persistentStorage],
+  );
+
+  return [_state, setState] as const;
+};

--- a/apps/hobom-angel/src/shared/ui/ErrorState.tsx
+++ b/apps/hobom-angel/src/shared/ui/ErrorState.tsx
@@ -7,7 +7,7 @@ interface ErrorStateProps {
   onRetry?: () => void;
 }
 
-/** Generic error state — matches the design's "일시적인 오류" recovery card. */
+/** Generic error state matching the design's error-recovery card. */
 export const ErrorState = ({ onRetry }: ErrorStateProps) => (
   <div {...stylex.props(styles.root)} role="alert">
     <span {...stylex.props(styles.icon)} aria-hidden="true">

--- a/apps/hobom-angel/src/shared/ui/NotFoundState.tsx
+++ b/apps/hobom-angel/src/shared/ui/NotFoundState.tsx
@@ -3,7 +3,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { styles } from "./NotFoundState.styles";
 
-/** 404 route state — matches the design's "페이지를 찾을 수 없어요" card. */
+/** 404 route state matching the design's not-found card. */
 export const NotFoundState = () => {
   const navigate = useNavigate();
 


### PR DESCRIPTION
The signup screen (§0.7) as a five-step funnel: **agreement → email → code → profile → done**. Copy is verbatim from the spec.

## FSD, done properly
- **Business logic in `features/signup`** (steps, validation, funnel wiring); **`pages/signup` only composes** it (`<SignupFunnel />`). Every slice exposes a **public API via `index.ts`**; no deep imports.
- Uses the **`useFunnel`** hook — ported to `shared/model` with its funnel-state utilities (`assert`, `funnel.lib`). The current step **syncs to a URL query param**, and `.withState` carries the gathered data across steps.
- **Pure validation** (email / 6-digit code / profile) extracted to `lib` with **unit tests (TDD)** — 7 tests.

## UX
- **Smooth step transitions** — each step fades and lifts in on enter, **stilled under `prefers-reduced-motion`** (spec §9).
- Faithful to the design: agreement (전체 동의 + required/optional rows), email, a six-box code input with active-cell highlight, profile (닉네임 + 중복확인, 실명·휴대폰 optional, 비밀번호), and the done state.
- Route-level **code splitting** for `/signup`; the login page's signup link points here.

Also: translated the remaining **Korean comments across the Angel app to English**.

Verified: workspace typecheck clean, app lint clean, 12 unit tests, production build (signup code-split), clicked through every step (URL step-sync confirmed).