### PR TITLE
Add a security scanning workflow (Trivy, Gitleaks, CodeQL)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,59 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+# Least privilege by default; CodeQL widens its own job below.
+permissions:
+  contents: read
+
+jobs:
+  # Dependency CVE scan via the official Trivy image (avoids action-version drift).
+  trivy:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Trivy scan (fail on HIGH/CRITICAL)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" aquasec/trivy:latest \
+            fs /repo \
+            --scanners vuln \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1
+
+  # Secret scan via the free gitleaks CLI image. The gitleaks *action* requires a
+  # paid license for organizations; the CLI itself does not.
+  gitleaks:
+    name: Gitleaks secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Gitleaks scan
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" \
+            ghcr.io/gitleaks/gitleaks:latest \
+            dir /repo --redact --exit-code 1
+
+  # Static analysis (SAST). Free on public repos; results land in the Security tab.
+  codeql:
+    name: CodeQL analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # Prioritise the security-focused query pack over the default set.
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Adds `.github/workflows/security.yml`, running on PRs and pushes to `main`/`develop`:

- **Trivy** filesystem scan — fails on **fixable HIGH/CRITICAL** dependency CVEs (`--ignore-unfixed`), from the official image so there's no action-version drift.
- **Gitleaks** — scans the working tree for committed secrets. (The gitleaks *action* needs an org license; the CLI image doesn't.) Confirmed `.env` is gitignored, so the local dev key isn't in scope.
- **CodeQL** — `security-extended` SAST for JS/TS; **free on this public repo**, results land in the Security tab.

All three run as independent jobs with least-privilege `permissions` (CodeQL widens only its own job to `security-events: write`).

Heads-up: Trivy can legitimately go red if the lockfile carries a fixable HIGH/CRITICAL CVE — that's the scan doing its job, and we'd bump the dependency rather than silence it.