### PR TITLE
Optimize CSR first load, prefetch routes, and add per-route SEO metadata

### DIFF
--- a/apps/hobom-angel/index.html
+++ b/apps/hobom-angel/index.html
@@ -11,9 +11,10 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#1f9d55" />
 
     <!-- SEO: the landing is the only public surface, so it's indexable; auth-gated
-         routes set noindex at runtime once they exist. -->
+         routes set noindex at runtime (see useRouteMeta). -->
     <title>HoBom Angel</title>
     <meta
       name="description"
@@ -30,9 +31,54 @@
     <meta property="og:locale" content="ko_KR" />
     <meta name="twitter:card" content="summary_large_image" />
     <!-- TODO: add absolute og:url + og:image once the domain and OG asset are set. -->
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "HoBom Angel",
+        "alternateName": "호봄엔젤",
+        "description": "임시보호와 입양으로 한 생명에게 새로운 봄을. 전국 보호소의 강아지·고양이를 만나고, 봉사에 참여하세요."
+      }
+    </script>
+
+    <!-- First-paint fallback: shown before the app JS mounts so CSR never flashes
+         a blank screen. React replaces #root once it renders. -->
+    <style>
+      #app-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f6f8f5;
+      }
+      #app-splash .spinner {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 3px solid rgba(31, 157, 85, 0.2);
+        border-top-color: #1f9d55;
+        animation: app-splash-spin 0.7s linear infinite;
+      }
+      @keyframes app-splash-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-splash .spinner {
+          animation-duration: 2s;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="app-splash" aria-hidden="true">
+        <div class="spinner"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/hobom-angel/public/robots.txt
+++ b/apps/hobom-angel/public/robots.txt
@@ -1,0 +1,6 @@
+# HoBom Angel — the public landing is indexable; auth-gated routes are not.
+User-agent: *
+Allow: /
+Disallow: /login
+Disallow: /signup
+Disallow: /reset

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ROUTES } from "@/shared/config";
+import { useRouteMeta } from "@/shared/model";
 import { LoadingState, NotFoundState } from "@/shared/ui";
 
 // Route-level code splitting — each page ships as its own chunk, loaded on
@@ -15,17 +16,33 @@ const SignupPage = lazy(() =>
   import("@/pages/signup").then((module) => ({ default: module.SignupPage })),
 );
 
+// Warm the auth route chunks during idle time so navigating to them is instant.
+const prefetchRoutes = () => {
+  void import("@/pages/login");
+  void import("@/pages/signup");
+};
+
 /**
  * Public routing. Only the landing page is open to guests; the rest of the
  * product will live behind auth as later phases land.
  */
-export const AppRouter = () => (
-  <Suspense fallback={<LoadingState fullScreen />}>
-    <Routes>
-      <Route path={ROUTES.HOME} element={<LandingPage />} />
-      <Route path={ROUTES.LOGIN} element={<LoginPage />} />
-      <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
-      <Route path="*" element={<NotFoundState />} />
-    </Routes>
-  </Suspense>
-);
+export const AppRouter = () => {
+  useRouteMeta();
+
+  useEffect(() => {
+    const id = requestIdleCallback(prefetchRoutes);
+
+    return () => cancelIdleCallback(id);
+  }, []);
+
+  return (
+    <Suspense fallback={<LoadingState fullScreen />}>
+      <Routes>
+        <Route path={ROUTES.HOME} element={<LandingPage />} />
+        <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+        <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+        <Route path="*" element={<NotFoundState />} />
+      </Routes>
+    </Suspense>
+  );
+};

--- a/apps/hobom-angel/src/main.tsx
+++ b/apps/hobom-angel/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { startMocks } from "@/mocks";
+import { warmApiOrigin } from "@/shared/lib";
 import App from "./App";
 
 import "./index.css";
@@ -8,6 +9,9 @@ import "./index.css";
 const rootElement = document.getElementById("root");
 
 if (!rootElement) throw new Error("root element not found");
+
+// Open the connection to the API origin early, in parallel with app bootstrap.
+warmApiOrigin();
 
 // Start the mock worker (when enabled) before the first render so no request
 // escapes to a live backend during local dev or e2e.

--- a/apps/hobom-angel/src/shared/config/index.ts
+++ b/apps/hobom-angel/src/shared/config/index.ts
@@ -1,2 +1,3 @@
 export { env } from "./env";
 export { ROUTES } from "./routes";
+export { ROUTE_META, DEFAULT_META } from "./route-meta";

--- a/apps/hobom-angel/src/shared/config/route-meta.ts
+++ b/apps/hobom-angel/src/shared/config/route-meta.ts
@@ -1,0 +1,23 @@
+import { ROUTES } from "./routes";
+
+interface RouteMeta {
+  title: string;
+  description?: string;
+  /** Keep auth-gated / transient routes out of the search index. */
+  noindex?: boolean;
+}
+
+const SITE_NAME = "HoBom Angel";
+const LANDING_DESCRIPTION =
+  "임시보호와 입양으로 한 생명에게 새로운 봄을. 전국 보호소의 강아지·고양이를 만나고, 봉사에 참여하세요.";
+
+/** Per-route document metadata; unknown paths fall back to DEFAULT_META. */
+export const ROUTE_META: Record<string, RouteMeta> = {
+  [ROUTES.HOME]: { title: SITE_NAME, description: LANDING_DESCRIPTION },
+  [ROUTES.LOGIN]: { title: `로그인 · ${SITE_NAME}`, noindex: true },
+  [ROUTES.SIGNUP]: { title: `회원가입 · ${SITE_NAME}`, noindex: true },
+  [ROUTES.PASSWORD_RESET]: { title: `비밀번호 찾기 · ${SITE_NAME}`, noindex: true },
+};
+
+/** 404 and other unmapped routes: titled but kept out of the index. */
+export const DEFAULT_META: RouteMeta = { title: SITE_NAME, noindex: true };

--- a/apps/hobom-angel/src/shared/lib/index.ts
+++ b/apps/hobom-angel/src/shared/lib/index.ts
@@ -2,3 +2,4 @@ export { reportError } from "./report-error.lib";
 export { assertCondition } from "./assert.lib";
 export { createFunnelStateId, createFunnelStorage } from "./funnel.lib";
 export type { FunnelStorage } from "./funnel.lib";
+export { warmApiOrigin } from "./warm-api-origin";

--- a/apps/hobom-angel/src/shared/lib/warm-api-origin.ts
+++ b/apps/hobom-angel/src/shared/lib/warm-api-origin.ts
@@ -1,0 +1,26 @@
+import { env } from "@/shared/config";
+
+/**
+ * Preconnect (+ dns-prefetch fallback) to the API origin so the first backend
+ * request skips DNS/TLS setup. No-op when the API is same-origin or relative.
+ */
+export const warmApiOrigin = () => {
+  let origin: string;
+
+  try {
+    origin = new URL(env.API_BASE_URL, window.location.origin).origin;
+  } catch {
+    return;
+  }
+
+  if (origin === window.location.origin) return;
+
+  for (const rel of ["preconnect", "dns-prefetch"]) {
+    const link = document.createElement("link");
+
+    link.rel = rel;
+    link.href = origin;
+    link.crossOrigin = "anonymous";
+    document.head.appendChild(link);
+  }
+};

--- a/apps/hobom-angel/src/shared/model/index.ts
+++ b/apps/hobom-angel/src/shared/model/index.ts
@@ -1,2 +1,3 @@
 export { useFunnel } from "./useFunnel";
 export { useToast } from "./useToast";
+export { useRouteMeta } from "./useRouteMeta";

--- a/apps/hobom-angel/src/shared/model/useRouteMeta.ts
+++ b/apps/hobom-angel/src/shared/model/useRouteMeta.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { DEFAULT_META, ROUTE_META } from "@/shared/config";
+
+const setMetaTag = (name: string, content: string) => {
+  let tag = document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+
+  if (!tag) {
+    tag = document.createElement("meta");
+    tag.name = name;
+    document.head.appendChild(tag);
+  }
+
+  tag.content = content;
+};
+
+/**
+ * Sync document title + description + robots to the current route. CSR ships one
+ * static <head>, so per-route metadata has to be set at runtime for crawlers and
+ * shared-link previews.
+ */
+export const useRouteMeta = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const meta = ROUTE_META[pathname] ?? DEFAULT_META;
+
+    document.title = meta.title;
+    if (meta.description) setMetaTag("description", meta.description);
+    setMetaTag("robots", meta.noindex ? "noindex, nofollow" : "index, follow");
+  }, [pathname]);
+};

--- a/apps/hobom-angel/vite.config.ts
+++ b/apps/hobom-angel/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
   },
   build: {
     chunkSizeWarningLimit: 600,
+    // Skip the gzip-size report — it's pure build-time overhead we don't read in CI.
+    reportCompressedSize: false,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
Proactive, code-level optimization for the CSR SPA (first paint, navigation, SEO, build time).

## First paint
- **Inline branded splash** in `#root` — no blank flash before the app JS mounts; React replaces it on first render.
- **API preconnect** injected at boot (`warmApiOrigin`, from the runtime API origin) so the first backend request skips DNS/TLS setup. No-op when same-origin.

## Navigation
- **Idle prefetch** of the auth route chunks (`requestIdleCallback`) so moving off the landing is instant. (Route-level code splitting was already in place.)

## SEO (CSR-appropriate)
- **Per-route metadata at runtime** — `useRouteMeta` sets `title` / `description` / `robots` from a `ROUTE_META` map, since CSR ships one static `<head>`. Auth routes go **noindex**.
- **Organization JSON-LD**, **theme-color**, and **robots.txt**. (Rich OG/Twitter meta were already present.)

## Build
- `reportCompressedSize: false` — drops the gzip-size pass to cut build time (also speeds the e2e build).

Verified: typecheck 0, lint 0, 13 unit, 6 e2e, production build. framework/vendor chunking unchanged.