### PR TITLE
Record ADRs 0004–0009 for the Angel app decisions

### DIFF
--- a/docs/adr/0004-product-apps-theme-the-design-system.md
+++ b/docs/adr/0004-product-apps-theme-the-design-system.md
@@ -1,0 +1,42 @@
+# 4. Product apps theme the design system rather than fork it
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+A second product (HoBom Angel) joined the monorepo with its own brand — a green
+accent, rounder controls, its own typeface. The first instinct was to build
+product-specific components (an `AngelButton`, an Angel card) that looked right.
+That quickly produced parallel component trees: the design system had a `Button`
+and Angel had its own, drifting in props, a11y, and behavior. It also put a
+product name inside the shared design system, which is supposed to be
+brand-agnostic.
+
+## Decision
+
+**The design system holds only brand-neutral, tokenized primitives. A product
+brands the app by overriding design tokens and composing the same `Hb.*`
+primitives — never by forking them.**
+
+- Primitives read their visual values from CSS custom properties
+  (`--hb-color-accent`, `--hb-radius-control`, …). They ship a neutral default.
+- A product provides a thin theme layer (e.g. Angel's `AngelThemeVars`) that
+  overrides those tokens at the root, plus product-specific composition and copy.
+- No product name appears in the design system. Anything genuinely reusable is
+  harvested back into the system on the rule of three, as a neutral primitive.
+- Product-specific, non-primitive UI (e.g. an animal card) lives in that
+  product's `entities`/`features`, not in the design system.
+
+## Consequences
+
+- One implementation of each primitive — a11y, keyboard behavior, and API stay
+  consistent across products; a fix lands everywhere at once.
+- Re-theming is a token change, not a component rewrite; a third product is a new
+  token set, not a new component library.
+- Cost: a primitive must be parameterized through tokens/props up front, which is
+  slightly more work than hardcoding one brand's look. That discipline is the
+  point — it keeps the shared layer shared.
+- A primitive that can't be expressed through tokens is a signal the token set is
+  missing a variable, not that the product should fork the component.

--- a/docs/adr/0005-build-to-the-backend-contract-with-anti-corruption-in-entities.md
+++ b/docs/adr/0005-build-to-the-backend-contract-with-anti-corruption-in-entities.md
@@ -1,0 +1,45 @@
+# 5. Build to the backend contract, with anti-corruption in entities
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+Screens were first built against a static design mock. When the real backend
+arrived it disagreed with the mock in ways that mattered: the signup/login flow
+was designed as email + verification code + password, but the backend
+authenticated by identity verification (a `verificationToken`), then later
+switched again to email + password with a different field set. Wiring UI
+straight to whichever shape was in front of us produced dead inputs (fields with
+no endpoint) and churn every time either side moved.
+
+We also kept reaching for raw response shapes directly in components, so a rename
+in a DTO rippled into JSX.
+
+## Decision
+
+**The backend contract is the source of truth for behavior, and `entities` is
+the anti-corruption layer between the wire and the UI.**
+
+- When the design mock and the live API disagree, the API wins. UI that has no
+  endpoint behind it is not built; the screen is reshaped to what the backend
+  actually supports (this is why the signup funnel was rebuilt twice).
+- An entity's `api` segment owns the network call and immediately **converts the
+  raw response into a UI model** (a pure, tested `to*` function in the entity's
+  `lib`). Components and features consume the UI model, never the raw DTO.
+- Client-side validation **mirrors** the server's rules (e.g. the nickname value
+  object's charset, the phone format) as an instant UX guard, with the server as
+  the real authority.
+- Environment-invariant contract details live in code, not per-env config — e.g.
+  the fixed backend path prefix that sits behind the gateway is a constant in the
+  API base, not part of the gateway env var.
+
+## Consequences
+
+- A DTO change is absorbed in one converter, not across the UI.
+- Screens can't drift into rendering inputs the backend will reject.
+- Cost: an explicit model + converter per entity, even when it currently looks
+  like a pass-through. That seam is what makes the raw shape safe to change.
+- Reconciling against a moving backend is expected; the cost of a reshape is
+  contained to one feature because the contract lives in one place.

--- a/docs/adr/0006-forms-and-server-mutations.md
+++ b/docs/adr/0006-forms-and-server-mutations.md
@@ -1,0 +1,43 @@
+# 6. Forms with react-hook-form; mutations via option factories with centralized feedback
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+The first forms tracked every field with `useState`, hand-rolled validation, and
+inline submit-error state. Each form re-implemented the same wiring, monolithic
+components mixed field markup with orchestration, and success/error handling was
+copy-pasted per screen. The in-house data library already offered a
+`mutationOptions`/`queryOptions` pattern that the other app used, but the new app
+was calling `useMutation({ mutationFn })` inline and duplicating cache keys.
+
+## Decision
+
+**Forms use react-hook-form; server writes go through option factories; user
+feedback (toast + redirect) is centralized in the mutation hook.**
+
+- **Forms**: one `FormProvider` per form; each field is a small
+  `useFormContext` + `Controller` component (`EmailField`, `PasswordField`, …).
+  The container orchestrates (submit, step navigation); fields own their own
+  rule and, where relevant, local UI state (show/hide password). Validators stay
+  pure in `lib` and are unit-tested; the RHF rule references them.
+- **Mutations**: each entity exposes a `mutationOptions` factory
+  (`authMutations.login()`) carrying a stable `mutationKey` and `mutationFn`. A
+  feature hook consumes it: `useMutation(authMutations.login())`.
+- **Feedback**: success and failure live in that hook, not the form —
+  `onSuccess` fires a toast and redirects; `onError` toasts the server message.
+  Components call `mutate(...)` and stay declarative.
+
+## Consequences
+
+- Forms are consistent and decomposed; a new field is a small component, and a
+  multi-step flow reuses the same field components across steps.
+- Cache keys and side effects for a mutation have one definition, reused wherever
+  the mutation is called.
+- A screen doesn't repeat submit/success/error plumbing; the pattern is the same
+  everywhere, so it's predictable.
+- Cost: more small files (one per field, one per mutation factory) instead of a
+  single form component. The separation is deliberate — it's what keeps forms
+  testable and the feedback uniform.

--- a/docs/adr/0007-mock-the-network-with-msw-for-scenario-tests-only.md
+++ b/docs/adr/0007-mock-the-network-with-msw-for-scenario-tests-only.md
@@ -1,0 +1,42 @@
+# 7. Mock the network with MSW for scenario tests only
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+We wanted end-to-end coverage of the auth flows without hitting a live backend
+(the identity-verification vendor was stubbed, and e2e must be deterministic and
+offline). MSW was the obvious tool, but it can be applied at every level, and
+applied indiscriminately it slows unit tests and couples pure logic to a fake
+network it never touches.
+
+## Decision
+
+**MSW mocks the network only at the scenario level — end-to-end and integration
+tests. Unit tests stay pure.**
+
+- **Unit**: pure functions and logic only (validators, converters). No network,
+  no MSW.
+- **Integration**: a hook or feature slice exercised against a mocked HTTP
+  boundary via `msw/node` `setupServer` + `renderHook` — for convert logic, error
+  mapping, and success paths where the request/response round-trip is the point.
+- **E2E**: the real browser flow against an MSW **browser worker**, started only
+  when `VITE_ENABLE_MSW=true`. Playwright's web server sets that flag; nothing
+  sets it in normal `dev` or in production.
+- The worker lives under a top-level `src/mocks` (test/dev infrastructure), not in
+  a `shared` segment. Handlers are split per domain so the mock surface scales.
+- Because the flag is a build-time constant, the mock code is **tree-shaken out
+  of the production bundle** entirely.
+
+## Consequences
+
+- MSW's value — network-boundary fidelity — is spent where a boundary actually
+  exists; unit tests stay fast and decoupled.
+- E2E can assert the real request path and body (via `waitForRequest`) while
+  never leaving the machine.
+- Production never ships mock code, and normal `dev` talks to the real backend
+  unless a developer opts in.
+- Cost: three testing tiers to keep straight. The rule ("no MSW in unit tests")
+  is the guardrail that keeps them from blurring.

--- a/docs/adr/0008-automated-security-scanning-in-ci.md
+++ b/docs/adr/0008-automated-security-scanning-in-ci.md
@@ -1,0 +1,41 @@
+# 8. Automated security scanning in CI
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+CI checked build, types, lint, and tests, but nothing looked at security:
+dependency CVEs, accidentally committed secrets, or vulnerable code patterns.
+These are cheap to catch on every pull request and expensive to find later.
+GitHub's first-party options have licensing friction — the Gitleaks *action*
+requires a paid license for organizations, and some scanners drift across action
+versions.
+
+## Decision
+
+**A dedicated `Security` workflow runs three scanners on every pull request and
+on pushes to `main`/`develop`, each as an independent job with least-privilege
+permissions.**
+
+- **Trivy** (filesystem scan) fails the build on **fixable** HIGH/CRITICAL
+  dependency CVEs (`--ignore-unfixed`).
+- **Gitleaks** scans the tree for committed secrets. (`.env` is gitignored, so
+  local keys are out of scope.)
+- **CodeQL** runs `security-extended` static analysis for JS/TS; results surface
+  in the Security tab.
+- Trivy and Gitleaks run from their **official CLI images** rather than
+  Marketplace actions, to avoid version drift and the action's org licensing.
+  CodeQL is free on this public repository.
+
+## Consequences
+
+- Every PR is gated on dependency, secret, and SAST checks; regressions surface
+  at review time, not in production.
+- A red Trivy run is a real signal to bump a dependency, not something to
+  silence.
+- Using CLI images keeps the workflow portable and licensing-clean, at the cost
+  of a little more YAML than a one-line action.
+- CodeQL's SAST depth depends on the repository staying public or on GitHub
+  Advanced Security; if that changes, the CodeQL job is the part to revisit.

--- a/docs/adr/0009-csr-first-load-and-seo-at-the-code-level.md
+++ b/docs/adr/0009-csr-first-load-and-seo-at-the-code-level.md
@@ -1,0 +1,45 @@
+# 9. CSR first load and SEO handled at the code level
+
+- Status: Accepted
+- Date: 2026-07-13
+- Deciders: HoBom frontend
+
+## Context
+
+The app is a client-rendered Vite SPA served under a base path. CSR ships an
+empty shell and renders on the client, which costs first paint (a blank screen
+until the JS mounts) and hurts crawlers and link-preview bots that read a single
+static `<head>`. Server-side rendering or prerendering would address both but is
+a large change — a different build/runtime model and infrastructure — that we are
+not ready to take on for a mostly auth-gated product.
+
+## Decision
+
+**Keep CSR for now, and pre-empt its first-load and SEO costs at the code
+level.**
+
+- **First paint**: an inline branded splash lives in `#root`, so the shell never
+  flashes blank before the app JS mounts; React replaces it on first render. A
+  preconnect to the API origin is injected at boot so the first backend request
+  skips DNS/TLS setup.
+- **Navigation**: route-level code splitting per page, plus an idle-time prefetch
+  of the likely-next chunks so in-app navigation is instant.
+- **SEO**: rich static meta and Organization JSON-LD in `index.html`, and
+  **runtime per-route metadata** — a hook sets `title`/`description`/`robots`
+  from a route→metadata map on each navigation, since CSR has one static head.
+  Auth/transient routes go `noindex`.
+- **Build**: skip the gzip-size report to cut build (and e2e-build) time.
+
+SSR/prerendering is explicitly deferred, not rejected — it is the next lever if
+the public surface grows and organic discovery matters.
+
+## Consequences
+
+- Perceived load and in-app navigation improve without changing the rendering
+  model or adding infrastructure.
+- Crawlers and share cards get per-route titles/descriptions instead of one
+  generic head.
+- Cost: this is mitigation, not a cure — bots that don't execute JS still see the
+  shell first, and the runtime metadata can't beat a server-rendered document.
+  When that ceiling is reached, prerender the public landing (a superseding ADR),
+  rather than piling on more client-side workarounds.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,12 @@ the moment it was made.
 | [0001](./0001-in-house-data-and-schema-libraries.md) | In-house data-fetching and schema libraries | Accepted |
 | [0002](./0002-slice-public-api-and-import-boundaries.md) | Slice public API and import boundaries | Accepted |
 | [0003](./0003-build-tooling-references-and-turborepo.md) | TypeScript project references without composite; no Turborepo | Accepted |
+| [0004](./0004-product-apps-theme-the-design-system.md) | Product apps theme the design system rather than fork it | Accepted |
+| [0005](./0005-build-to-the-backend-contract-with-anti-corruption-in-entities.md) | Build to the backend contract, with anti-corruption in entities | Accepted |
+| [0006](./0006-forms-and-server-mutations.md) | Forms with react-hook-form; mutations via option factories with centralized feedback | Accepted |
+| [0007](./0007-mock-the-network-with-msw-for-scenario-tests-only.md) | Mock the network with MSW for scenario tests only | Accepted |
+| [0008](./0008-automated-security-scanning-in-ci.md) | Automated security scanning in CI | Accepted |
+| [0009](./0009-csr-first-load-and-seo-at-the-code-level.md) | CSR first load and SEO handled at the code level | Accepted |
 
 New ADRs are numbered sequentially and never edited once accepted — supersede
 them with a new record instead.


### PR DESCRIPTION
Documents the significant, hard-to-reverse decisions taken while building the HoBom Angel app, following the existing `docs/adr` convention (sequential, conceptual, never edited once accepted).

| # | Decision |
| --- | --- |
| 0004 | Product apps **theme** the design system rather than fork it (DS-neutral primitives + token theme + `Hb.*` composition) |
| 0005 | Build to the **backend contract**; `entities` is the anti-corruption layer (raw→UI convert, mirror server validation) |
| 0006 | Forms with **react-hook-form** (FormProvider + field components); mutations via **`mutationOptions`** factories with toast + redirect centralized in the hook |
| 0007 | Mock the network with **MSW for e2e/integration only**; units stay pure; tree-shaken from prod |
| 0008 | **Security scanning** in CI (Trivy, Gitleaks, CodeQL) |
| 0009 | **CSR first-load + SEO** at the code level (splash, idle prefetch, runtime per-route metadata; SSR deferred) |

Docs only — no code changes.