### PR TITLE
Add the animal browse screen

### DIFF
--- a/apps/hobom-angel/.gitignore
+++ b/apps/hobom-angel/.gitignore
@@ -3,3 +3,4 @@
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/e2e-artifacts/

--- a/apps/hobom-angel/e2e/browse-animals.spec.ts
+++ b/apps/hobom-angel/e2e/browse-animals.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§01 browse animals", () => {
+  test("renders the search bar, species filter, and result cards", async ({ page }) => {
+    await login(page);
+    await page.getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    await expect(page.getByPlaceholder("이름 · 품종 · 지역으로 검색")).toBeVisible();
+    await expect(page.getByRole("button", { name: "강아지" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "입양가능만" })).toBeVisible();
+
+    // Cards load (mock returns a first page): a result count and status chips.
+    await expect(page.getByText(/\d+마리/)).toBeVisible();
+    await expect(page.getByText("입양가능", { exact: true }).first()).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/browse-default.png", fullPage: true });
+  });
+
+  test("stays on the animals page after a hard reload", async ({ page }) => {
+    await login(page);
+    await page.getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    // A reload re-probes the session; the protected route must wait for that
+    // probe instead of treating the first frame as a guest (which bounced home).
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/animals$/);
+    await expect(page.getByPlaceholder("이름 · 품종 · 지역으로 검색")).toBeVisible();
+  });
+
+  test("filters by species and reflects it in the URL", async ({ page }) => {
+    await login(page);
+    await page.getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    await page.getByRole("button", { name: "고양이" }).click();
+    await expect(page).toHaveURL(/species=CAT/);
+
+    // The active-filter chips + reset appear once a filter is applied.
+    await expect(page.getByText("고양이").last()).toBeVisible();
+    await expect(page.getByRole("button", { name: "초기화" })).toBeVisible();
+    await page.screenshot({ path: "e2e-artifacts/browse-cat.png", fullPage: true });
+  });
+
+  test("keyword search updates the query string", async ({ page }) => {
+    await login(page);
+    await page.getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    await page.getByPlaceholder("이름 · 품종 · 지역으로 검색").fill("콩");
+    await page.getByRole("button", { name: "검색" }).click();
+    await expect(page).toHaveURL(/q=%EC%BD%A9/);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ROUTES } from "@/shared/config";
 import { useRouteMeta } from "@/shared/model";
-import { LoadingState, NotFoundState } from "@/shared/ui";
+import { ErrorBoundary, LoadingState, NotFoundState } from "@/shared/ui";
 import { ComingSoonPage } from "@/pages/coming-soon";
 import { ConsumerShellLayout } from "./ConsumerShellLayout";
 import { GuestOnlyRoute } from "./GuestOnlyRoute";
@@ -18,6 +18,9 @@ const LoginPage = lazy(() =>
 const SignupPage = lazy(() =>
   import("@/pages/signup").then((module) => ({ default: module.SignupPage })),
 );
+const AnimalsPage = lazy(() =>
+  import("@/pages/animals").then((module) => ({ default: module.AnimalsPage })),
+);
 
 // Warm the auth route chunks during idle time so navigating to them is instant.
 const prefetchRoutes = () => {
@@ -25,9 +28,8 @@ const prefetchRoutes = () => {
   void import("@/pages/signup");
 };
 
-// Consumer sections share the ComingSoon placeholder until their screens land.
+// Sections still on the ComingSoon placeholder until their screens land.
 const SECTION_ROUTES = [
-  ROUTES.ANIMALS,
   ROUTES.FOSTER,
   ROUTES.VOLUNTEER,
   ROUTES.SHELTERS,
@@ -46,26 +48,29 @@ export const AppRouter = () => {
   }, []);
 
   return (
-    <Suspense fallback={<LoadingState fullScreen />}>
-      <Routes>
-        {/* Consumer screens render inside the global nav chrome. */}
-        <Route element={<ConsumerShellLayout />}>
-          <Route path={ROUTES.HOME} element={<LandingPage />} />
-          <Route element={<ProtectedRoute />}>
-            {SECTION_ROUTES.map((path) => (
-              <Route key={path} path={path} element={<ComingSoonPage />} />
-            ))}
+    <ErrorBoundary>
+      <Suspense fallback={<LoadingState fullScreen />}>
+        <Routes>
+          {/* Consumer screens render inside the global nav chrome. */}
+          <Route element={<ConsumerShellLayout />}>
+            <Route path={ROUTES.HOME} element={<LandingPage />} />
+            <Route element={<ProtectedRoute />}>
+              <Route path={ROUTES.ANIMALS} element={<AnimalsPage />} />
+              {SECTION_ROUTES.map((path) => (
+                <Route key={path} path={path} element={<ComingSoonPage />} />
+              ))}
+            </Route>
           </Route>
-        </Route>
 
-        {/* Auth screens have no nav chrome and are guest-only. */}
-        <Route element={<GuestOnlyRoute />}>
-          <Route path={ROUTES.LOGIN} element={<LoginPage />} />
-          <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
-        </Route>
+          {/* Auth screens have no nav chrome and are guest-only. */}
+          <Route element={<GuestOnlyRoute />}>
+            <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+            <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+          </Route>
 
-        <Route path="*" element={<NotFoundState />} />
-      </Routes>
-    </Suspense>
+          <Route path="*" element={<NotFoundState />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/apps/hobom-angel/src/apps/ui/ConsumerShellLayout.tsx
+++ b/apps/hobom-angel/src/apps/ui/ConsumerShellLayout.tsx
@@ -1,9 +1,12 @@
 import { Outlet } from "react-router-dom";
 import { GlobalNav } from "@/widgets/global-nav";
+import { RouteBoundary } from "@/shared/ui";
 
 /** Wraps the consumer screens in the global navigation chrome (§0.5). */
 export const ConsumerShellLayout = () => (
   <GlobalNav>
-    <Outlet />
+    <RouteBoundary>
+      <Outlet />
+    </RouteBoundary>
   </GlobalNav>
 );

--- a/apps/hobom-angel/src/apps/ui/GuestOnlyRoute.tsx
+++ b/apps/hobom-angel/src/apps/ui/GuestOnlyRoute.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { ROUTES } from "@/shared/config";
 import { useCurrentUser } from "@/entities/user";
+import { RouteBoundary } from "@/shared/ui";
 
 /**
  * Guards guest-only routes (login/signup): a signed-in user is redirected home.
@@ -11,5 +12,11 @@ import { useCurrentUser } from "@/entities/user";
 export const GuestOnlyRoute = () => {
   const { isAuthenticated } = useCurrentUser();
 
-  return isAuthenticated ? <Navigate to={ROUTES.HOME} replace /> : <Outlet />;
+  if (isAuthenticated) return <Navigate to={ROUTES.HOME} replace />;
+
+  return (
+    <RouteBoundary>
+      <Outlet />
+    </RouteBoundary>
+  );
 };

--- a/apps/hobom-angel/src/entities/animal/api/animal.api.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.api.ts
@@ -1,0 +1,29 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toQueryString } from "@/shared/lib";
+import { toAnimal } from "../lib/to-animal.lib";
+import { animalPageSchema } from "./animal.schema";
+import type { Animal } from "../model/animal.model";
+import type { AnimalSearchParams } from "./animal.type";
+
+/** A converted page of animals plus the cursor to the next one. */
+export interface AnimalPageResult {
+  animals: Animal[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+const parsePage = parseResponse(animalPageSchema, "GET /animals");
+
+/** Search/browse animals (filters + cursor pagination). */
+export const searchAnimals = (
+  params: AnimalSearchParams,
+  signal?: AbortSignal,
+): Promise<AnimalPageResult> =>
+  httpClient
+    .get(`/animals${toQueryString(params)}`, { signal })
+    .then(parsePage)
+    .then((page) => ({
+      animals: page.items.map(toAnimal),
+      nextCursor: page.nextCursor,
+      hasNext: page.hasNext,
+    }));

--- a/apps/hobom-angel/src/entities/animal/api/animal.queries.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.queries.ts
@@ -1,0 +1,19 @@
+import { infiniteQueryOptions } from "hobom-data";
+import { searchAnimals } from "./animal.api";
+import type { AnimalSearchParams } from "./animal.type";
+
+/** Everything except the cursor — the cursor is managed by the infinite query. */
+export type AnimalFilters = Omit<AnimalSearchParams, "cursor">;
+
+export const animalQueries = {
+  all: () => ["animals"] as const,
+
+  list: (filters: AnimalFilters) =>
+    infiniteQueryOptions({
+      queryKey: [...animalQueries.all(), "list", filters] as const,
+      queryFn: ({ pageParam, signal }) => searchAnimals({ ...filters, cursor: pageParam }, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+      initialPageParam: undefined as string | undefined,
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
@@ -1,0 +1,30 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { AnimalPage, RawAnimal } from "./animal.type";
+
+const animalSchema: Schema<RawAnimal> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  shelterId: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  species: HoBomSchema.enum(["DOG", "CAT", "OTHER"]),
+  description: HoBomSchema.string(),
+  status: HoBomSchema.enum(["AVAILABLE", "RESERVED", "FOSTERED", "ADOPTED", "RETURNED"]),
+  traits: HoBomSchema.object({
+    sex: HoBomSchema.enum(["MALE", "FEMALE", "UNKNOWN"]),
+    size: HoBomSchema.enum(["SMALL", "MEDIUM", "LARGE"]),
+    ageMonths: HoBomSchema.number().nullable(),
+    breed: HoBomSchema.string().nullable(),
+    color: HoBomSchema.string().nullable(),
+    personality: HoBomSchema.string().nullable(),
+  }),
+  photos: HoBomSchema.array(
+    HoBomSchema.object({ objectKey: HoBomSchema.string(), caption: HoBomSchema.string().optional() }),
+  ),
+});
+
+/** `GET /animals` response schema — validates the wire contract at the boundary. */
+export const animalPageSchema: Schema<AnimalPage> = HoBomSchema.object({
+  items: HoBomSchema.array(animalSchema),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});

--- a/apps/hobom-angel/src/entities/animal/api/animal.type.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.type.ts
@@ -1,0 +1,39 @@
+import type { AnimalSex, AnimalSize, AnimalSpecies, AnimalStatusCode } from "../model/animal.model";
+
+interface RawAnimalTraits {
+  sex: AnimalSex;
+  size: AnimalSize;
+  ageMonths: number | null;
+  breed: string | null;
+  color: string | null;
+  personality: string | null;
+}
+
+/** `GET /animals` item — the fields the list/detail actually use. */
+export interface RawAnimal {
+  id: string;
+  shelterId: string;
+  name: string;
+  species: AnimalSpecies;
+  description: string;
+  status: AnimalStatusCode;
+  traits: RawAnimalTraits;
+  photos: { objectKey: string; caption?: string }[];
+}
+
+/** Cursor page envelope for the animal list. */
+export interface AnimalPage {
+  items: RawAnimal[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface AnimalSearchParams {
+  species?: AnimalSpecies;
+  size?: AnimalSize;
+  sex?: AnimalSex;
+  status?: AnimalStatusCode;
+  keyword?: string;
+  cursor?: string;
+  limit?: number;
+}

--- a/apps/hobom-angel/src/entities/animal/index.ts
+++ b/apps/hobom-angel/src/entities/animal/index.ts
@@ -1,2 +1,18 @@
 export { AnimalCard } from "./ui/AnimalCard";
-export type { AnimalStatus } from "./ui/AnimalCard";
+export { animalQueries } from "./api/animal.queries";
+export type { AnimalFilters } from "./api/animal.queries";
+export {
+  SPECIES_LABEL,
+  SIZE_LABEL,
+  STATUS_LABEL,
+  formatAge,
+  animalMeta,
+} from "./model/animal.model";
+export type {
+  Animal,
+  AnimalSpecies,
+  AnimalSex,
+  AnimalSize,
+  AnimalStatusCode,
+  AnimalStatusLabel,
+} from "./model/animal.model";

--- a/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { toAnimal } from "./to-animal.lib";
+
+describe("toAnimal", () => {
+  it("flattens traits and takes the first photo", () => {
+    const animal = toAnimal({
+      id: "a1",
+      shelterId: "s1",
+      name: "콩이",
+      species: "DOG",
+      description: "사람을 좋아해요",
+      status: "AVAILABLE",
+      traits: {
+        sex: "MALE",
+        size: "MEDIUM",
+        ageMonths: 24,
+        breed: "믹스",
+        color: "갈색",
+        personality: "활발",
+      },
+      photos: [{ objectKey: "cover.jpg" }, { objectKey: "second.jpg" }],
+    });
+
+    expect(animal).toEqual({
+      id: "a1",
+      shelterId: "s1",
+      name: "콩이",
+      species: "DOG",
+      status: "AVAILABLE",
+      sex: "MALE",
+      size: "MEDIUM",
+      ageMonths: 24,
+      breed: "믹스",
+      description: "사람을 좋아해요",
+      photoUrl: "cover.jpg",
+    });
+  });
+
+  it("leaves photoUrl undefined when there are no photos", () => {
+    const animal = toAnimal({
+      id: "a2",
+      shelterId: "s1",
+      name: "보리",
+      species: "CAT",
+      description: "",
+      status: "RESERVED",
+      traits: { sex: "FEMALE", size: "SMALL", ageMonths: null, breed: null, color: null, personality: null },
+      photos: [],
+    });
+
+    expect(animal.photoUrl).toBeUndefined();
+    expect(animal.ageMonths).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.ts
+++ b/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.ts
@@ -1,0 +1,17 @@
+import type { RawAnimal } from "../api/animal.type";
+import type { Animal } from "../model/animal.model";
+
+/** Anti-corruption: flatten the API animal (nested traits) into the UI model. */
+export const toAnimal = (raw: RawAnimal): Animal => ({
+  id: raw.id,
+  shelterId: raw.shelterId,
+  name: raw.name,
+  species: raw.species,
+  status: raw.status,
+  sex: raw.traits.sex,
+  size: raw.traits.size,
+  ageMonths: raw.traits.ageMonths,
+  breed: raw.traits.breed,
+  description: raw.description,
+  photoUrl: raw.photos[0]?.objectKey,
+});

--- a/apps/hobom-angel/src/entities/animal/model/animal.model.ts
+++ b/apps/hobom-angel/src/entities/animal/model/animal.model.ts
@@ -1,0 +1,57 @@
+export type AnimalSpecies = "DOG" | "CAT" | "OTHER";
+export type AnimalSex = "MALE" | "FEMALE" | "UNKNOWN";
+export type AnimalSize = "SMALL" | "MEDIUM" | "LARGE";
+export type AnimalStatusCode = "AVAILABLE" | "RESERVED" | "FOSTERED" | "ADOPTED" | "RETURNED";
+
+/** The animal the UI renders — a flattened, display-ready view of the API model. */
+export interface Animal {
+  id: string;
+  shelterId: string;
+  name: string;
+  species: AnimalSpecies;
+  status: AnimalStatusCode;
+  sex: AnimalSex;
+  size: AnimalSize;
+  ageMonths: number | null;
+  breed: string | null;
+  description: string;
+  photoUrl?: string;
+}
+
+export const SPECIES_LABEL: Record<AnimalSpecies, string> = {
+  DOG: "강아지",
+  CAT: "고양이",
+  OTHER: "기타",
+};
+
+export const SIZE_LABEL: Record<AnimalSize, string> = {
+  SMALL: "소형",
+  MEDIUM: "중형",
+  LARGE: "대형",
+};
+
+/** Display label for a status; matches the AnimalCard chip labels. */
+export type AnimalStatusLabel = "입양가능" | "예약중" | "임보중" | "입양완료" | "반환";
+
+export const STATUS_LABEL: Record<AnimalStatusCode, AnimalStatusLabel> = {
+  AVAILABLE: "입양가능",
+  RESERVED: "예약중",
+  FOSTERED: "임보중",
+  ADOPTED: "입양완료",
+  RETURNED: "반환",
+};
+
+/** Age in months → a friendly Korean label. */
+export const formatAge = (months: number | null): string => {
+  if (months == null) return "나이 미상";
+  if (months < 12) return `${months}개월`;
+
+  return `${Math.floor(months / 12)}살`;
+};
+
+/** The card's attribute line per §01, e.g. "푸들 · 2살 · 소형" (breed · age · size).
+ *  Region is added once the shelter join is available. */
+export const animalMeta = (animal: Animal): string =>
+  [animal.breed, formatAge(animal.ageMonths), SIZE_LABEL[animal.size]]
+    .filter(Boolean)
+    .join(" · ");

--- a/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
@@ -1,18 +1,23 @@
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { styles } from "./AnimalCard.styles";
-
-export type AnimalStatus = "입양가능" | "예약중";
+import type { AnimalStatusLabel } from "../model/animal.model";
 
 interface AnimalCardProps {
   name: string;
-  status: AnimalStatus;
+  status: AnimalStatusLabel;
   /** Attribute line, e.g. "dog · 2yr · Seoul". */
   meta: string;
   imageUrl?: string;
 }
 
-const STATUS_COLOR = { 입양가능: "primary", 예약중: "warning" } as const;
+const STATUS_COLOR = {
+  입양가능: "primary",
+  예약중: "warning",
+  임보중: "secondary",
+  입양완료: "success",
+  반환: "default",
+} as const;
 
 /** A shelter animal preview card — used on the landing, list, and shelter pages. */
 export const AnimalCard = ({ name, status, meta, imageUrl }: AnimalCardProps) => (

--- a/apps/hobom-angel/src/entities/user/model/useCurrentUser.ts
+++ b/apps/hobom-angel/src/entities/user/model/useCurrentUser.ts
@@ -6,7 +6,12 @@ import { userQueries } from "../api/user.queries";
  * by a cached query, so it survives reloads as long as the session cookie does.
  */
 export const useCurrentUser = () => {
-  const { data, isSuccess, isLoading } = useQuery(userQueries.me());
+  const { data, isSuccess, status } = useQuery(userQueries.me());
 
-  return { user: data, isAuthenticated: isSuccess, isLoading };
+  // Gate on the "pending" status, not `isLoading` — on the very first render the
+  // fetch hasn't started yet (fetchStatus is still "idle"), so `isLoading` is
+  // false even though the session is undetermined. Treating that frame as
+  // "guest" bounces a reload on a protected route to /login and then home.
+  // `pending` stays true until the probe settles, and is off for refetches.
+  return { user: data, isAuthenticated: isSuccess, isLoading: status === "pending" };
 };

--- a/apps/hobom-angel/src/features/browse-animals/index.ts
+++ b/apps/hobom-angel/src/features/browse-animals/index.ts
@@ -1,0 +1,1 @@
+export { BrowseAnimals } from "./ui/BrowseAnimals";

--- a/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.spec.ts
+++ b/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { filtersFromParams, paramsFromFilters } from "./animal-filter-params.lib";
+
+describe("filtersFromParams", () => {
+  it("defaults to the AVAILABLE view when the query is empty", () => {
+    expect(filtersFromParams(new URLSearchParams())).toEqual({
+      species: undefined,
+      keyword: undefined,
+      status: "AVAILABLE",
+      limit: 20,
+    });
+  });
+
+  it("reads species, keyword, and the explicit 'all' status", () => {
+    const params = new URLSearchParams("species=DOG&q=콩이&status=all");
+
+    expect(filtersFromParams(params)).toEqual({
+      species: "DOG",
+      keyword: "콩이",
+      status: undefined,
+      limit: 20,
+    });
+  });
+
+  it("ignores an unknown species", () => {
+    expect(filtersFromParams(new URLSearchParams("species=DINOSAUR")).species).toBeUndefined();
+  });
+
+  it("treats a blank keyword as absent", () => {
+    expect(filtersFromParams(new URLSearchParams("q=%20%20")).keyword).toBeUndefined();
+  });
+});
+
+describe("paramsFromFilters", () => {
+  it("omits defaults for the AVAILABLE view", () => {
+    expect(paramsFromFilters({ status: "AVAILABLE", limit: 20 }).toString()).toBe("");
+  });
+
+  it("serializes species and keyword", () => {
+    const params = paramsFromFilters({ species: "CAT", keyword: "나비", status: "AVAILABLE", limit: 20 });
+
+    expect(params.get("species")).toBe("CAT");
+    expect(params.get("q")).toBe("나비");
+  });
+
+  it("marks the off state as status=all", () => {
+    expect(paramsFromFilters({ limit: 20 }).get("status")).toBe("all");
+  });
+
+  it("round-trips through the query string", () => {
+    const filters = filtersFromParams(new URLSearchParams("species=OTHER&q=토토&status=all"));
+
+    expect(filtersFromParams(paramsFromFilters(filters))).toEqual(filters);
+  });
+});

--- a/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.ts
+++ b/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.ts
@@ -1,0 +1,41 @@
+import type { AnimalFilters, AnimalSpecies } from "@/entities/animal";
+import type { SearchParamsCodec } from "@/shared/model";
+
+const SPECIES = new Set<AnimalSpecies>(["DOG", "CAT", "OTHER"]);
+const PAGE_SIZE = 20;
+
+/**
+ * Decode the URL query into browse filters. Keeping filters in the query string
+ * makes the list shareable, bookmarkable, and back-button friendly.
+ *
+ * An absent `status` defaults to the "입양가능만" view (AVAILABLE); `status=all`
+ * is the explicit off state so the two are distinguishable in the URL.
+ */
+export const filtersFromParams = (params: URLSearchParams): AnimalFilters => {
+  const species = params.get("species");
+  const keyword = params.get("q")?.trim();
+
+  return {
+    species: species && SPECIES.has(species as AnimalSpecies) ? (species as AnimalSpecies) : undefined,
+    keyword: keyword || undefined,
+    status: params.get("status") === "all" ? undefined : "AVAILABLE",
+    limit: PAGE_SIZE,
+  };
+};
+
+/** Encode filters back into a minimal query — defaults are omitted. */
+export const paramsFromFilters = (filters: AnimalFilters): URLSearchParams => {
+  const params = new URLSearchParams();
+
+  if (filters.species) params.set("species", filters.species);
+  if (filters.keyword) params.set("q", filters.keyword);
+  if (!filters.status) params.set("status", "all");
+
+  return params;
+};
+
+/** The nuqs-style codec that binds animal filters to the URL query. */
+export const animalFilterCodec: SearchParamsCodec<AnimalFilters> = {
+  decode: filtersFromParams,
+  encode: paramsFromFilters,
+};

--- a/apps/hobom-angel/src/features/browse-animals/model/useAnimalList.ts
+++ b/apps/hobom-angel/src/features/browse-animals/model/useAnimalList.ts
@@ -1,0 +1,17 @@
+import { useSuspenseInfiniteQuery } from "hobom-data";
+import { animalQueries } from "@/entities/animal";
+import type { Animal, AnimalFilters } from "@/entities/animal";
+
+/**
+ * Suspense-backed animal list for the given filters (cursor pagination).
+ * Loading suspends to the nearest boundary (skeleton); errors bubble to the
+ * route ErrorBoundary — so this hook only ever deals with loaded data.
+ */
+export const useAnimalList = (filters: AnimalFilters) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSuspenseInfiniteQuery(animalQueries.list(filters));
+
+  const animals: Animal[] = data.pages.flatMap((page) => page.animals);
+
+  return { animals, fetchNextPage, hasNextPage, isFetchingNextPage };
+};

--- a/apps/hobom-angel/src/features/browse-animals/model/useBrowseAnimals.ts
+++ b/apps/hobom-angel/src/features/browse-animals/model/useBrowseAnimals.ts
@@ -1,0 +1,39 @@
+import { Bom } from "hobom-utils";
+import { SPECIES_LABEL } from "@/entities/animal";
+import { useSearchParamsState } from "@/shared/model";
+import { animalFilterCodec } from "../lib/animal-filter-params.lib";
+
+/** A removable active-filter chip shown above the results. */
+export interface ActiveFilterChip {
+  label: string;
+  onRemove: () => void;
+}
+
+/**
+ * Browse filter controls: the URL-backed filter state plus the derived
+ * active-filter chips. Data fetching lives in the Suspense boundary below
+ * (see `useAnimalList`), so toggling a filter never suspends the filter bar.
+ */
+export const useBrowseAnimals = () => {
+  const [filters, setFilters, resetFilters] = useSearchParamsState(animalFilterCodec);
+
+  const activeChips: ActiveFilterChip[] = [
+    filters.species
+      ? {
+          label: SPECIES_LABEL[filters.species],
+          onRemove: () => setFilters({ ...filters, species: undefined }),
+        }
+      : undefined,
+    filters.status === "AVAILABLE"
+      ? { label: "입양가능", onRemove: () => setFilters({ ...filters, status: undefined }) }
+      : undefined,
+    filters.keyword
+      ? {
+          label: `"${filters.keyword}"`,
+          onRemove: () => setFilters({ ...filters, keyword: undefined }),
+        }
+      : undefined,
+  ].filter(Bom.isDefined);
+
+  return { filters, setFilters, resetFilters, activeChips };
+};

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.styles.ts
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.styles.ts
@@ -1,0 +1,38 @@
+import * as stylex from "@stylexjs/stylex";
+
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  // Pinned to the top of the scrolling content region so the animal grid
+  // scrolls underneath it (design: "스크롤 시 그림자 상승").
+  root: {
+    position: "sticky",
+    top: 0,
+    zIndex: 5,
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+    backgroundColor: "var(--hb-color-surface)",
+    paddingBlockStart: 20,
+    paddingBlockEnd: 12,
+    boxShadow: "0 6px 12px -12px rgba(30,45,55,0.5)",
+  },
+  searchRow: {
+    display: "flex",
+    gap: 10,
+  },
+  bar: {
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  // Sort + view-mode are desktop-only niceties; below 1024 they'd crowd the
+  // filter row (and are placeholders for now), so hide them on small screens.
+  right: {
+    display: { default: "none", [DESKTOP]: "flex" },
+    alignItems: "center",
+    gap: 10,
+    marginInlineStart: "auto",
+  },
+});

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.tsx
@@ -1,0 +1,93 @@
+import { useState, type FormEvent } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { SearchOutlined } from "hobom-design-system/icons";
+import { SPECIES_LABEL } from "@/entities/animal";
+import type { AnimalFilters as Filters, AnimalSpecies } from "@/entities/animal";
+import { styles } from "./AnimalFilters.styles";
+
+const SPECIES: AnimalSpecies[] = ["DOG", "CAT", "OTHER"];
+
+interface AnimalFiltersProps {
+  filters: Filters;
+  onChange: (next: Filters) => void;
+}
+
+/**
+ * §01 filter bar: full-width keyword search, a species segmented control, and
+ * the "입양가능만" toggle — all on design-system primitives. (지역·나이·크기
+ * dropdowns, 정렬, 지도 토글 follow in later PRs.)
+ */
+export const AnimalFilters = ({ filters, onChange }: AnimalFiltersProps) => {
+  const [keyword, setKeyword] = useState(filters.keyword ?? "");
+  const availableOnly = filters.status === "AVAILABLE";
+
+  const submitKeyword = (event: FormEvent) => {
+    event.preventDefault();
+    onChange({ ...filters, keyword: keyword.trim() || undefined });
+  };
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <form {...stylex.props(styles.searchRow)} onSubmit={submitKeyword} role="search">
+        <Hb.TextField
+          fullWidth
+          placeholder="이름 · 품종 · 지역으로 검색"
+          aria-label="검색"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          slotProps={{ input: { startAdornment: <SearchOutlined fontSize="small" /> } }}
+        />
+        <Hb.Button type="submit" variant="primary">
+          검색
+        </Hb.Button>
+      </form>
+
+      <div {...stylex.props(styles.bar)}>
+        <Hb.ToggleButtonGroup variant="segmented" aria-label="종">
+          {SPECIES.map((species) => {
+            const selected = filters.species === species;
+
+            return (
+              <Hb.ToggleButton
+                key={species}
+                variant="segmented"
+                value={species}
+                selected={selected}
+                onChange={() => onChange({ ...filters, species: selected ? undefined : species })}
+              >
+                {SPECIES_LABEL[species]}
+              </Hb.ToggleButton>
+            );
+          })}
+        </Hb.ToggleButtonGroup>
+
+        <Hb.Divider orientation="vertical" style={{ height: 24, alignSelf: "center" }} />
+
+        <Hb.ToggleButton
+          value="available"
+          selected={availableOnly}
+          onChange={() => onChange({ ...filters, status: availableOnly ? undefined : "AVAILABLE" })}
+        >
+          입양가능만{availableOnly ? " ✓" : ""}
+        </Hb.ToggleButton>
+
+        {/* Sort + view-mode are placeholders per §01: the backend only returns
+            newest-first, and the map view lands with the shelter work. */}
+        <div {...stylex.props(styles.right)}>
+          <Hb.Button variant="secondary" size="small">
+            최신순 ▾
+          </Hb.Button>
+          <Hb.ToggleButtonGroup variant="segmented" aria-label="보기 방식">
+            <Hb.ToggleButton variant="segmented" value="grid" selected>
+              그리드
+            </Hb.ToggleButton>
+            <Hb.ToggleButton variant="segmented" value="map">
+              지도
+            </Hb.ToggleButton>
+          </Hb.ToggleButtonGroup>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.styles.ts
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.styles.ts
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  grid: {
+    display: "grid",
+    // 2 columns on phones, 3 on tablets, 4 on desktop (design §01).
+    gridTemplateColumns: {
+      default: "repeat(2, 1fr)",
+      [TABLET]: "repeat(3, 1fr)",
+      [DESKTOP]: "repeat(4, 1fr)",
+    },
+    gap: { default: 12, [DESKTOP]: 16 },
+  },
+  empty: {
+    paddingBlock: 64,
+    textAlign: "center",
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.9375rem",
+  },
+  more: {
+    paddingBlock: 20,
+    textAlign: "center",
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.875rem",
+  },
+});

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.tsx
@@ -1,0 +1,45 @@
+import * as stylex from "@stylexjs/stylex";
+import { AnimalCard, STATUS_LABEL, animalMeta } from "@/entities/animal";
+import { useInfiniteScroll } from "@/shared/model";
+import type { Animal } from "@/entities/animal";
+import { styles } from "./AnimalGrid.styles";
+
+interface AnimalGridProps {
+  animals: Animal[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+/** The animal card grid with an infinite-scroll sentinel. Loading and error
+ *  states are owned by the surrounding Suspense / ErrorBoundary. */
+export const AnimalGrid = ({
+  animals,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: AnimalGridProps) => {
+  const sentinelRef = useInfiniteScroll({ hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  if (animals.length === 0) {
+    return <p {...stylex.props(styles.empty)}>조건에 맞는 친구가 아직 없어요.</p>;
+  }
+
+  return (
+    <>
+      <div {...stylex.props(styles.grid)}>
+        {animals.map((animal) => (
+          <AnimalCard
+            key={animal.id}
+            name={animal.name}
+            status={STATUS_LABEL[animal.status]}
+            meta={animalMeta(animal)}
+            imageUrl={animal.photoUrl}
+          />
+        ))}
+      </div>
+      <div ref={sentinelRef} />
+      {isFetchingNextPage && <p {...stylex.props(styles.more)}>더 불러오는 중…</p>}
+    </>
+  );
+};

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalGridSkeleton.styles.ts
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalGridSkeleton.styles.ts
@@ -1,0 +1,25 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  count: {
+    marginBlock: 16,
+  },
+  card: {
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: "var(--hb-angel-radius-card)",
+    overflow: "hidden",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  // Sizes the photo Skeleton to a square via intrinsic ratio.
+  photo: {
+    paddingTop: "100%",
+  },
+  body: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    padding: 12,
+  },
+});

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalGridSkeleton.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalGridSkeleton.tsx
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles as gridStyles } from "./AnimalGrid.styles";
+import { styles } from "./AnimalGridSkeleton.styles";
+
+const PLACEHOLDERS = Array.from({ length: 8 }, (_, index) => index);
+
+/** Skeleton for the result section while the first page loads (design-system
+ *  Skeleton primitives). */
+export const AnimalGridSkeleton = () => (
+  <div aria-hidden="true">
+    <div {...stylex.props(styles.count)}>
+      <Hb.Skeleton variant="text" width={72} />
+    </div>
+    <div {...stylex.props(gridStyles.grid)}>
+      {PLACEHOLDERS.map((index) => (
+        <div key={index} {...stylex.props(styles.card)}>
+          <Hb.Skeleton variant="rectangular" width="100%">
+            <div {...stylex.props(styles.photo)} />
+          </Hb.Skeleton>
+          <div {...stylex.props(styles.body)}>
+            <Hb.Skeleton variant="text" width="55%" />
+            <Hb.Skeleton variant="text" width="80%" />
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalResults.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalResults.tsx
@@ -1,0 +1,50 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { AnimalFilters } from "@/entities/animal";
+import { useAnimalList } from "../model/useAnimalList";
+import { AnimalGrid } from "./AnimalGrid";
+import { styles } from "./BrowseAnimals.styles";
+import type { ActiveFilterChip } from "../model/useBrowseAnimals";
+
+interface AnimalResultsProps {
+  filters: AnimalFilters;
+  activeChips: ActiveFilterChip[];
+  onReset: () => void;
+}
+
+/** Result count, active-filter chips, and the card grid — suspends while the
+ *  first page loads (skeleton fallback lives in the parent). */
+export const AnimalResults = ({ filters, activeChips, onReset }: AnimalResultsProps) => {
+  const { animals, fetchNextPage, hasNextPage, isFetchingNextPage } = useAnimalList(filters);
+
+  return (
+    <>
+      <div {...stylex.props(styles.resultRow)}>
+        <span {...stylex.props(styles.count)}>
+          {animals.length}마리{hasNextPage ? "+" : ""}
+        </span>
+        {activeChips.map((chip) => (
+          <Hb.Chip
+            key={chip.label}
+            label={chip.label}
+            size="small"
+            variant="outlined"
+            onDelete={chip.onRemove}
+          />
+        ))}
+        {activeChips.length > 0 && (
+          <Hb.Button variant="ghost" size="small" onClick={onReset}>
+            초기화
+          </Hb.Button>
+        )}
+      </div>
+
+      <AnimalGrid
+        animals={animals}
+        fetchNextPage={fetchNextPage}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+      />
+    </>
+  );
+};

--- a/apps/hobom-angel/src/features/browse-animals/ui/BrowseAnimals.styles.ts
+++ b/apps/hobom-angel/src/features/browse-animals/ui/BrowseAnimals.styles.ts
@@ -1,0 +1,24 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    // Top spacing comes from the sticky filter bar; keep only the bottom.
+    paddingBottom: 24,
+  },
+  resultRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: 8,
+    marginBlock: 16,
+  },
+  count: {
+    fontSize: "0.9375rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+    marginInlineEnd: 4,
+  },
+});

--- a/apps/hobom-angel/src/features/browse-animals/ui/BrowseAnimals.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/BrowseAnimals.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { useBrowseAnimals } from "../model/useBrowseAnimals";
+import { AnimalFilters } from "./AnimalFilters";
+import { AnimalGridSkeleton } from "./AnimalGridSkeleton";
+import { AnimalResults } from "./AnimalResults";
+import { styles } from "./BrowseAnimals.styles";
+
+export const BrowseAnimals = () => {
+  const { filters, setFilters, resetFilters, activeChips } = useBrowseAnimals();
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <AnimalFilters filters={filters} onChange={setFilters} />
+
+      <Suspense fallback={<AnimalGridSkeleton />}>
+        <AnimalResults filters={filters} activeChips={activeChips} onReset={resetFilters} />
+      </Suspense>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
@@ -1,0 +1,58 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+const NAMES = ["콩이", "보리", "초코", "나비", "깜냥", "단추", "호두", "모카", "감자", "구름", "별이", "달이"];
+const SPECIES = ["DOG", "CAT", "OTHER"] as const;
+const STATUSES = ["AVAILABLE", "AVAILABLE", "AVAILABLE", "RESERVED"] as const;
+const SEXES = ["MALE", "FEMALE", "UNKNOWN"] as const;
+const SIZES = ["SMALL", "MEDIUM", "LARGE"] as const;
+
+const ANIMALS = Array.from({ length: 42 }, (_, i) => ({
+  id: `animal-${i + 1}`,
+  shelterId: "shelter-1",
+  name: `${NAMES[i % NAMES.length] ?? "친구"}${i >= NAMES.length ? ` ${Math.floor(i / NAMES.length) + 1}` : ""}`,
+  species: SPECIES[i % SPECIES.length],
+  description: "사람을 좋아하는 순한 아이예요.",
+  status: STATUSES[i % STATUSES.length],
+  traits: {
+    sex: SEXES[i % SEXES.length],
+    size: SIZES[i % SIZES.length],
+    ageMonths: (i % 6) * 6 + 3,
+    breed: "믹스",
+    color: "갈색",
+    personality: "활발",
+  },
+  health: {},
+  intake: {},
+  photos: [{ objectKey: `https://picsum.photos/seed/hobom${i + 1}/400/300` }],
+}));
+
+/** Animal domain mock handlers — cursor-paginated /animals with filtering. */
+export const animalHandlers = [
+  http.get(mockUrl("/animals"), ({ request }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    const species = url.searchParams.get("species");
+    const status = url.searchParams.get("status");
+    const keyword = url.searchParams.get("keyword");
+    const limit = Number(url.searchParams.get("limit") ?? "20");
+    const cursor = Number(url.searchParams.get("cursor") ?? "0");
+
+    let filtered = ANIMALS;
+
+    if (species) filtered = filtered.filter((a) => a.species === species);
+    if (status) filtered = filtered.filter((a) => a.status === status);
+    if (keyword) filtered = filtered.filter((a) => a.name.includes(keyword));
+
+    const page = filtered.slice(cursor, cursor + limit);
+    const nextIndex = cursor + limit;
+    const hasNext = nextIndex < filtered.length;
+
+    return ok({ items: page, nextCursor: hasNext ? String(nextIndex) : null, hasNext });
+  }),
+];

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
 import { authHandlers } from "./auth.handlers";
 import { userHandlers } from "./user.handlers";
+import { animalHandlers } from "./animal.handlers";
 
 /** All MSW request handlers, aggregated per domain. Add new domains here. */
-export const handlers = [...authHandlers, ...userHandlers];
+export const handlers = [...authHandlers, ...userHandlers, ...animalHandlers];

--- a/apps/hobom-angel/src/pages/animals/index.ts
+++ b/apps/hobom-angel/src/pages/animals/index.ts
@@ -1,0 +1,1 @@
+export { AnimalsPage } from "./ui/AnimalsPage";

--- a/apps/hobom-angel/src/pages/animals/ui/AnimalsPage.tsx
+++ b/apps/hobom-angel/src/pages/animals/ui/AnimalsPage.tsx
@@ -1,0 +1,3 @@
+import { BrowseAnimals } from "@/features/browse-animals";
+
+export const AnimalsPage = () => <BrowseAnimals />;

--- a/apps/hobom-angel/src/pages/landing/model/landing.fixtures.ts
+++ b/apps/hobom-angel/src/pages/landing/model/landing.fixtures.ts
@@ -1,4 +1,4 @@
-import type { AnimalStatus } from "@/entities/animal";
+import type { AnimalStatusLabel } from "@/entities/animal";
 
 // Static mockup data — copy is verbatim from the 2a landing design.
 // Swapped for real queries in a later phase.
@@ -19,7 +19,7 @@ export const STATS = [
 
 export const ANIMAL_FILTERS = ["전체", "강아지", "고양이"];
 
-export const ANIMALS: { name: string; status: AnimalStatus; meta: string }[] = [
+export const ANIMALS: { name: string; status: AnimalStatusLabel; meta: string }[] = [
   { name: "콩이", status: "입양가능", meta: "강아지 · 2살 · 서울" },
   { name: "보리", status: "입양가능", meta: "고양이 · 1살 · 경기" },
   { name: "초코", status: "예약중", meta: "강아지 · 4살 · 부산" },

--- a/apps/hobom-angel/src/shared/lib/index.ts
+++ b/apps/hobom-angel/src/shared/lib/index.ts
@@ -3,3 +3,4 @@ export { assertCondition } from "./assert.lib";
 export { createFunnelStateId, createFunnelStorage } from "./funnel.lib";
 export type { FunnelStorage } from "./funnel.lib";
 export { warmApiOrigin } from "./warm-api-origin";
+export { toQueryString } from "./query-string.lib";

--- a/apps/hobom-angel/src/shared/lib/query-string.lib.spec.ts
+++ b/apps/hobom-angel/src/shared/lib/query-string.lib.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { toQueryString } from "./query-string.lib";
+
+describe("toQueryString", () => {
+  it("returns an empty string when there is nothing to send", () => {
+    expect(toQueryString({})).toBe("");
+    expect(toQueryString({ a: undefined, b: null, c: "" })).toBe("");
+  });
+
+  it("serializes the present values, prefixed with '?'", () => {
+    expect(toQueryString({ species: "DOG", limit: 20 })).toBe("?species=DOG&limit=20");
+  });
+
+  it("skips null, undefined, and empty strings but keeps 0 and false", () => {
+    expect(toQueryString({ keyword: "", page: 0, active: false, cursor: undefined })).toBe(
+      "?page=0&active=false",
+    );
+  });
+
+  it("encodes special characters", () => {
+    expect(toQueryString({ q: "콩 이" })).toBe("?q=%EC%BD%A9+%EC%9D%B4");
+  });
+});

--- a/apps/hobom-angel/src/shared/lib/query-string.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/query-string.lib.ts
@@ -1,0 +1,21 @@
+/**
+ * Serialize a flat params object into a URL query string (`?a=1&b=2`), skipping
+ * `null`/`undefined`/empty-string values. Returns `""` when nothing is left to
+ * send, so it can be appended to a path unconditionally.
+ *
+ * Takes a plain `object` (rather than `Record<string, …>`) so typed DTO
+ * interfaces pass without an index-signature dance; values are stringified.
+ */
+export const toQueryString = (params: object): string => {
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+
+    query.set(key, String(value));
+  }
+
+  const serialized = query.toString();
+
+  return serialized ? `?${serialized}` : "";
+};

--- a/apps/hobom-angel/src/shared/model/index.ts
+++ b/apps/hobom-angel/src/shared/model/index.ts
@@ -1,3 +1,6 @@
 export { useFunnel } from "./useFunnel";
 export { useToast } from "./useToast";
 export { useRouteMeta } from "./useRouteMeta";
+export { useInfiniteScroll } from "./useInfiniteScroll";
+export { useSearchParamsState } from "./useSearchParamsState";
+export type { SearchParamsCodec } from "./useSearchParamsState";

--- a/apps/hobom-angel/src/shared/model/useInfiniteScroll.ts
+++ b/apps/hobom-angel/src/shared/model/useInfiniteScroll.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from "react";
+
+interface UseInfiniteScrollParams {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+/**
+ * Attach the returned ref to a sentinel element at the end of a list; it calls
+ * `fetchNextPage` when the sentinel scrolls into view (window scroll).
+ */
+export const useInfiniteScroll = ({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: UseInfiniteScrollParams) => {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+
+    if (!el || !hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) fetchNextPage();
+      },
+      { rootMargin: "240px" },
+    );
+
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return sentinelRef;
+};

--- a/apps/hobom-angel/src/shared/model/useSearchParamsState.spec.tsx
+++ b/apps/hobom-angel/src/shared/model/useSearchParamsState.spec.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { useSearchParamsState, type SearchParamsCodec } from "./useSearchParamsState";
+
+interface Query {
+  q?: string;
+}
+
+const codec: SearchParamsCodec<Query> = {
+  decode: (params) => ({ q: params.get("q") ?? undefined }),
+  encode: ({ q }) => {
+    const params = new URLSearchParams();
+
+    if (q) params.set("q", q);
+
+    return params;
+  },
+};
+
+const renderAt = (entry: string) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[entry]}>{children}</MemoryRouter>
+  );
+
+  return renderHook(() => useSearchParamsState(codec), { wrapper });
+};
+
+describe("useSearchParamsState", () => {
+  it("decodes the initial query via the codec", () => {
+    const { result } = renderAt("/animals?q=hello");
+
+    expect(result.current[0]).toEqual({ q: "hello" });
+  });
+
+  it("writes the encoded value back to the query on set", () => {
+    const { result } = renderAt("/animals");
+
+    act(() => result.current[1]({ q: "world" }));
+
+    expect(result.current[0]).toEqual({ q: "world" });
+  });
+
+  it("clears the query on reset", () => {
+    const { result } = renderAt("/animals?q=hello");
+
+    act(() => result.current[2]());
+
+    expect(result.current[0]).toEqual({ q: undefined });
+  });
+});

--- a/apps/hobom-angel/src/shared/model/useSearchParamsState.ts
+++ b/apps/hobom-angel/src/shared/model/useSearchParamsState.ts
@@ -1,0 +1,36 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * A bidirectional codec between the URL query string and a typed value —
+ * the nuqs-style boundary that keeps `URLSearchParams` (stringly-typed) from
+ * leaking into components.
+ */
+export interface SearchParamsCodec<T> {
+  decode: (params: URLSearchParams) => T;
+  encode: (value: T) => URLSearchParams;
+}
+
+/**
+ * Keeps a typed value in the URL query string. State is derived from — and
+ * written back to — `?…`, so it is shareable, bookmarkable, and survives
+ * reloads / back-forward. Writes `replace` history to avoid stacking an entry
+ * per keystroke or toggle.
+ *
+ * The `codec` must be a stable reference (declare it at module scope), since it
+ * anchors the memoised value and setter.
+ */
+export const useSearchParamsState = <T>(codec: SearchParamsCodec<T>) => {
+  const [params, setParams] = useSearchParams();
+
+  const value = useMemo(() => codec.decode(params), [params, codec]);
+
+  const setValue = useCallback(
+    (next: T) => setParams(codec.encode(next), { replace: true }),
+    [setParams, codec],
+  );
+
+  const reset = useCallback(() => setParams(new URLSearchParams(), { replace: true }), [setParams]);
+
+  return [value, setValue, reset] as const;
+};

--- a/apps/hobom-angel/src/shared/ui/ErrorBoundary.tsx
+++ b/apps/hobom-angel/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ErrorState } from "./ErrorState";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Custom fallback; receives a `reset` to clear the error and re-render. */
+  fallback?: (reset: () => void) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Catches render-time errors in its subtree and shows a recoverable fallback,
+ * so one screen throwing never white-screens the whole app. Data-layer errors
+ * are handled inline at the query site — this is the net for the unexpected.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Unhandled render error", error, info.componentStack);
+  }
+
+  private reset = () => this.setState({ hasError: false });
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return this.props.fallback?.(this.reset) ?? <ErrorState onRetry={this.reset} />;
+  }
+}

--- a/apps/hobom-angel/src/shared/ui/LoadingState.styles.ts
+++ b/apps/hobom-angel/src/shared/ui/LoadingState.styles.ts
@@ -9,6 +9,8 @@ export const styles = stylex.create({
     gap: 16,
     paddingBlock: 48,
   },
-  fullScreen: { minHeight: "100vh" },
+  // Pin to the viewport so the initial/global fallback is truly centered,
+  // independent of whatever parent happens to be mounting.
+  fullScreen: { position: "fixed", inset: 0, backgroundColor: "var(--hb-color-surface)" },
   text: { fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
 });

--- a/apps/hobom-angel/src/shared/ui/RouteBoundary.tsx
+++ b/apps/hobom-angel/src/shared/ui/RouteBoundary.tsx
@@ -1,0 +1,24 @@
+import { Suspense, type ReactNode } from "react";
+import { useLocation } from "react-router-dom";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { LoadingState } from "./LoadingState";
+
+interface RouteBoundaryProps {
+  children: ReactNode;
+}
+
+/**
+ * Per-route boundary: isolates each screen so a render error or a slow lazy
+ * chunk shows a localized fallback within the surrounding chrome instead of
+ * tearing down the whole app. Keyed by pathname so navigating away clears a
+ * crashed screen.
+ */
+export const RouteBoundary = ({ children }: RouteBoundaryProps) => {
+  const { pathname } = useLocation();
+
+  return (
+    <ErrorBoundary key={pathname}>
+      <Suspense fallback={<LoadingState />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+};

--- a/apps/hobom-angel/src/shared/ui/index.ts
+++ b/apps/hobom-angel/src/shared/ui/index.ts
@@ -2,3 +2,5 @@ export { AngelThemeVars, ANGEL_THEME_CSS } from "./AngelThemeVars";
 export { LoadingState } from "./LoadingState";
 export { ErrorState } from "./ErrorState";
 export { NotFoundState } from "./NotFoundState";
+export { ErrorBoundary } from "./ErrorBoundary";
+export { RouteBoundary } from "./RouteBoundary";

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
@@ -3,11 +3,14 @@ import * as stylex from "@stylexjs/stylex";
 const DESKTOP = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
+  // App shell locked to the viewport: the top bar and (mobile) bottom tab stay
+  // fixed while only the content region scrolls.
   shell: {
-    minHeight: "100vh",
+    height: "100dvh",
+    overflow: "hidden",
     display: "flex",
     flexDirection: "column",
-    backgroundColor: "var(--hb-angel-surface-alt)",
+    backgroundColor: "var(--hb-color-surface)",
   },
 
   // ── Top bar (sticky) ────────────────────────────────────
@@ -153,7 +156,14 @@ export const styles = stylex.create({
   menuDivider: { height: 1, backgroundColor: "var(--hb-color-border)", marginBlock: 6 },
 
   // ── Content + mobile bottom tab ─────────────────────────
-  content: { flex: 1, paddingBottom: { default: 64, [DESKTOP]: 0 } },
+  // The only scroll region. `min-height: 0` lets it shrink inside the flex
+  // shell so its own overflow (not the body) scrolls.
+  content: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: "auto",
+    paddingBottom: { default: 64, [DESKTOP]: 0 },
+  },
   bottomTab: {
     display: { default: "flex", [DESKTOP]: "none" },
     position: "fixed",

--- a/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/hobom-design-system/src/components/ToggleButton/ToggleButton.tsx
@@ -15,6 +15,7 @@ const styles = stylex.create({
     borderWidth: 1,
     borderStyle: "solid",
     borderColor: "var(--hb-color-border)",
+    borderRadius: "var(--hb-radius-control, 8px)",
     backgroundColor: {
       default: "transparent",
       ":focus-visible": "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
@@ -40,7 +41,23 @@ const styles = stylex.create({
     borderColor: "var(--hb-color-accent)",
     backgroundColor: "color-mix(in srgb, var(--hb-color-accent) 8%, transparent)",
   },
+  // "segmented": a borderless pill meant to sit inside a ToggleButtonGroup
+  // track. Selected paints a raised white pill over the recessed track.
+  segmented: {
+    borderWidth: 0,
+    borderStyle: "none",
+    borderRadius: 9,
+    color: "var(--hb-color-text-secondary)",
+    fontWeight: 600,
+  },
+  segmentedSelected: {
+    color: "var(--hb-color-text-primary)",
+    backgroundColor: "var(--hb-color-surface)",
+    boxShadow: "0 2px 6px -3px rgba(30,45,55,0.4)",
+  },
 });
+
+type ToggleButtonVariant = "outlined" | "segmented";
 
 interface ToggleButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange" | "value"> {
@@ -48,6 +65,7 @@ interface ToggleButtonProps
   selected?: boolean;
   onChange?: (event: MouseEvent<HTMLButtonElement>, value: string) => void;
   size?: "small" | "medium";
+  variant?: ToggleButtonVariant;
   children?: ReactNode;
 }
 
@@ -56,16 +74,20 @@ export const ToggleButton = ({
   selected = false,
   onChange,
   size = "medium",
+  variant = "outlined",
   className,
   style,
   children,
   ...rest
 }: ToggleButtonProps) => {
+  const segmented = variant === "segmented";
+
   const sx = stylex.props(
     styles.reset,
     styles.root,
     size === "small" ? styles.small : styles.medium,
-    selected && styles.selected,
+    segmented && styles.segmented,
+    selected && (segmented ? styles.segmentedSelected : styles.selected),
   );
 
   return (

--- a/packages/hobom-design-system/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/packages/hobom-design-system/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -1,0 +1,51 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+
+const styles = stylex.create({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+  },
+  outlined: {
+    gap: 8,
+  },
+  // Recessed track that holds `variant="segmented"` ToggleButtons; the selected
+  // one raises a white pill above it.
+  segmented: {
+    gap: 0,
+    padding: 3,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 12,
+    backgroundColor: "var(--hb-color-canvas)",
+  },
+});
+
+interface ToggleButtonGroupProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: "outlined" | "segmented";
+  children?: ReactNode;
+}
+
+/** Groups related ToggleButtons. `variant="segmented"` renders the track that
+ *  the segmented ToggleButton pills sit inside. */
+export const ToggleButtonGroup = ({
+  variant = "outlined",
+  className,
+  style,
+  children,
+  ...rest
+}: ToggleButtonGroupProps) => {
+  const sx = stylex.props(styles.root, variant === "segmented" ? styles.segmented : styles.outlined);
+
+  return (
+    <div
+      role="group"
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/hobom-design-system/src/components/ToggleButton/index.ts
+++ b/packages/hobom-design-system/src/components/ToggleButton/index.ts
@@ -1,1 +1,2 @@
 export * from "./ToggleButton";
+export * from "./ToggleButtonGroup";

--- a/packages/hobom-design-system/src/components/index.ts
+++ b/packages/hobom-design-system/src/components/index.ts
@@ -24,7 +24,7 @@ import { Grid } from "./Grid";
 import { Collapse } from "./Collapse";
 import { InputBase } from "./InputBase";
 import { Drawer } from "./Drawer";
-import { ToggleButton } from "./ToggleButton";
+import { ToggleButton, ToggleButtonGroup } from "./ToggleButton";
 // Batch 2 — compound
 import { Progress } from "./Progress";
 import { Skeleton } from "./Skeleton";
@@ -67,6 +67,7 @@ export const Hb = {
   InputBase,
   Drawer,
   ToggleButton,
+  ToggleButtonGroup,
   // Batch 2 — compound
   Progress,
   Skeleton,


### PR DESCRIPTION
Adds the `/animals` browse screen — the first section screen for the consumer app.

## What
- Keyword search plus species and availability filters over `GET /animals` (cursor pagination with infinite scroll).
- Filters live in the URL query behind a typed search-params codec, so the list is shareable and survives reload and back/forward.
- Results load through Suspense with a skeleton fallback; the filter bar stays interactive while the grid streams in. Render errors are caught by a per-route boundary instead of white-screening the app.
- The species control and the availability toggle are built on the design system — a new segmented `ToggleButton` variant and a `ToggleButtonGroup` — rather than app-local markup.
- App-shell layout: the top bar and filter bar pin while only the content scrolls, over a 2/3/4-column grid across phone/tablet/desktop.

## Notes
- The sort control and the grid/map toggle are placeholders for now: the API only returns newest-first, and the map view will land with the shelter work.
- Fixes a reload bounce — a protected route now waits for the session probe (the query's `pending` status) instead of treating the first render as a guest, which previously kicked a reload on `/animals` to login and then home.

## Testing
- `pnpm --filter hobom-angel typecheck` / `lint` / `test` (30 unit)
- `pnpm --filter hobom-angel exec playwright test` (12 e2e: browse render, filter to URL, keyword search, reload stays on page)
- `pnpm --filter hobom-design-system typecheck` / `lint` / `test` (181)