### PR TITLE
Add the adoption application funnel

### DIFF
--- a/apps/hobom-angel/e2e/apply-adoption.spec.ts
+++ b/apps/hobom-angel/e2e/apply-adoption.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§03 adoption funnel", () => {
+  test("walks the survey step by step and submits", async ({ page }) => {
+    await login(page);
+    await page.goto("animals/animal-1");
+
+    await page.getByRole("button", { name: "입양 신청하기" }).click();
+    await expect(page).toHaveURL(/\/apply\/animal-1/);
+
+    // Q1 주거 (single choice, required)
+    await page.getByRole("button", { name: "아파트" }).click();
+    await page.getByRole("button", { name: "다음" }).click();
+
+    // Q2 반려동물 (boolean, required)
+    await page.getByRole("button", { name: "아니오" }).click();
+    await page.getByRole("button", { name: "다음" }).click();
+
+    // Q3 가족 구성원 (multi choice, optional) — skip
+    await page.getByRole("button", { name: "다음" }).click();
+
+    // Q4 이유 (text, required)
+    await page.getByPlaceholder("자유롭게 작성해주세요").fill("좋은 가족이 되고 싶어요.");
+    await page.getByRole("button", { name: "다음" }).click();
+
+    // Q5 함께하는 시간 (single choice, required)
+    await page.getByRole("button", { name: "6시간 이상" }).click();
+    await page.getByRole("button", { name: "다음" }).click();
+
+    // Review → submit
+    await expect(page.getByText("입력한 내용을 확인해주세요")).toBeVisible();
+    await page.getByRole("button", { name: "신청하기" }).click();
+
+    await expect(page).toHaveURL(/\/animals\/animal-1$/);
+  });
+
+  test("blocks advancing past a required question", async ({ page }) => {
+    await login(page);
+    await page.goto("apply/animal-1");
+
+    // First step is a required single choice; advancing without an answer stays.
+    await page.getByRole("button", { name: "다음" }).click();
+    await expect(page.getByText("주거 형태를 알려주세요.")).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -24,6 +24,9 @@ const AnimalsPage = lazy(() =>
 const AnimalDetailPage = lazy(() =>
   import("@/pages/animal-detail").then((module) => ({ default: module.AnimalDetailPage })),
 );
+const ApplyAdoptionPage = lazy(() =>
+  import("@/pages/apply-adoption").then((module) => ({ default: module.ApplyAdoptionPage })),
+);
 
 // Warm the auth route chunks during idle time so navigating to them is instant.
 const prefetchRoutes = () => {
@@ -60,6 +63,7 @@ export const AppRouter = () => {
             <Route element={<ProtectedRoute />}>
               <Route path={ROUTES.ANIMALS} element={<AnimalsPage />} />
             <Route path={ROUTES.ANIMAL_DETAIL} element={<AnimalDetailPage />} />
+            <Route path={ROUTES.APPLY} element={<ApplyAdoptionPage />} />
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />
               ))}

--- a/apps/hobom-angel/src/entities/adoption/api/adoption.api.ts
+++ b/apps/hobom-angel/src/entities/adoption/api/adoption.api.ts
@@ -1,0 +1,12 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { submitAdoptionSchema } from "./adoption.schema";
+import type { SubmitAdoptionRequest, SubmitAdoptionResult } from "./adoption.type";
+
+const parse = parseResponse(submitAdoptionSchema, "POST /animals/:id/adoption-applications");
+
+/** Submit an adoption application (with its survey answers) for an animal. */
+export const submitAdoptionApplication = (
+  animalId: string,
+  request: SubmitAdoptionRequest,
+): Promise<SubmitAdoptionResult> =>
+  httpClient.post(`/animals/${animalId}/adoption-applications`, request).then(parse);

--- a/apps/hobom-angel/src/entities/adoption/api/adoption.mutations.ts
+++ b/apps/hobom-angel/src/entities/adoption/api/adoption.mutations.ts
@@ -1,0 +1,10 @@
+import { mutationOptions } from "hobom-data";
+import { submitAdoptionApplication } from "./adoption.api";
+import type { SubmitAdoptionRequest } from "./adoption.type";
+
+export const adoptionMutations = {
+  submit: (animalId: string) =>
+    mutationOptions({
+      mutationFn: (request: SubmitAdoptionRequest) => submitAdoptionApplication(animalId, request),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/adoption/api/adoption.schema.ts
+++ b/apps/hobom-angel/src/entities/adoption/api/adoption.schema.ts
@@ -1,0 +1,8 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { SubmitAdoptionResult } from "./adoption.type";
+
+export const submitAdoptionSchema: Schema<SubmitAdoptionResult> = HoBomSchema.object({
+  applicationId: HoBomSchema.string(),
+  approvalId: HoBomSchema.string(),
+});

--- a/apps/hobom-angel/src/entities/adoption/api/adoption.type.ts
+++ b/apps/hobom-angel/src/entities/adoption/api/adoption.type.ts
@@ -1,0 +1,15 @@
+/** One submitted answer (values always a string array). */
+export interface AdoptionAnswer {
+  questionId: string;
+  values: string[];
+}
+
+export interface SubmitAdoptionRequest {
+  answers: AdoptionAnswer[];
+}
+
+/** `POST /animals/:id/adoption-applications` result. */
+export interface SubmitAdoptionResult {
+  applicationId: string;
+  approvalId: string;
+}

--- a/apps/hobom-angel/src/entities/adoption/index.ts
+++ b/apps/hobom-angel/src/entities/adoption/index.ts
@@ -1,0 +1,2 @@
+export { adoptionMutations } from "./api/adoption.mutations";
+export type { AdoptionAnswer, SubmitAdoptionRequest, SubmitAdoptionResult } from "./api/adoption.type";

--- a/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.api.ts
+++ b/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.api.ts
@@ -1,0 +1,23 @@
+import { HttpError, httpClient, parseResponse } from "@/shared/api";
+import { questionnaireSchema } from "./questionnaire.schema";
+import type { Questionnaire, QuestionnairePurpose } from "../model/questionnaire.model";
+
+const parse = parseResponse(questionnaireSchema, "GET /shelters/:id/questionnaires/:purpose");
+
+/**
+ * The shelter's survey for a purpose. A shelter that hasn't defined one yields
+ * `null` (the API 404s) — the application then needs no answers.
+ */
+export const getQuestionnaire = (
+  shelterId: string,
+  purpose: QuestionnairePurpose,
+  signal?: AbortSignal,
+): Promise<Questionnaire | null> =>
+  httpClient
+    .get(`/shelters/${shelterId}/questionnaires/${purpose}`, { signal })
+    .then(parse)
+    .catch((error: unknown) => {
+      if (error instanceof HttpError && error.status === 404) return null;
+
+      throw error;
+    });

--- a/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.queries.ts
+++ b/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.queries.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from "hobom-data";
+import { getQuestionnaire } from "./questionnaire.api";
+import type { QuestionnairePurpose } from "../model/questionnaire.model";
+
+export const questionnaireQueries = {
+  all: () => ["questionnaires"] as const,
+
+  forShelter: (shelterId: string, purpose: QuestionnairePurpose) =>
+    queryOptions({
+      queryKey: [...questionnaireQueries.all(), shelterId, purpose] as const,
+      queryFn: ({ signal }) => getQuestionnaire(shelterId, purpose, signal),
+      staleTime: 5 * 60 * 1000,
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.schema.ts
+++ b/apps/hobom-angel/src/entities/questionnaire/api/questionnaire.schema.ts
@@ -1,0 +1,20 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { Questionnaire } from "../model/questionnaire.model";
+
+/** `GET /shelters/:id/questionnaires/:purpose` schema — validates the contract. */
+export const questionnaireSchema: Schema<Questionnaire> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  shelterId: HoBomSchema.string(),
+  purpose: HoBomSchema.enum(["ADOPTION", "FOSTER"]),
+  version: HoBomSchema.number(),
+  questions: HoBomSchema.array(
+    HoBomSchema.object({
+      id: HoBomSchema.string(),
+      prompt: HoBomSchema.string(),
+      type: HoBomSchema.enum(["TEXT", "BOOLEAN", "SINGLE_CHOICE", "MULTI_CHOICE"]),
+      options: HoBomSchema.array(HoBomSchema.string()),
+      required: HoBomSchema.boolean(),
+    }),
+  ),
+});

--- a/apps/hobom-angel/src/entities/questionnaire/index.ts
+++ b/apps/hobom-angel/src/entities/questionnaire/index.ts
@@ -1,0 +1,8 @@
+export { questionnaireQueries } from "./api/questionnaire.queries";
+export type {
+  Question,
+  QuestionType,
+  Questionnaire,
+  QuestionnairePurpose,
+  Answer,
+} from "./model/questionnaire.model";

--- a/apps/hobom-angel/src/entities/questionnaire/model/questionnaire.model.ts
+++ b/apps/hobom-angel/src/entities/questionnaire/model/questionnaire.model.ts
@@ -1,0 +1,27 @@
+export type QuestionType = "TEXT" | "BOOLEAN" | "SINGLE_CHOICE" | "MULTI_CHOICE";
+export type QuestionnairePurpose = "ADOPTION" | "FOSTER";
+
+/** One survey question. Choice types carry `options`. */
+export interface Question {
+  id: string;
+  prompt: string;
+  type: QuestionType;
+  options: string[];
+  required: boolean;
+}
+
+/** A shelter's survey for a given purpose (a flat, versioned question list). */
+export interface Questionnaire {
+  id: string;
+  shelterId: string;
+  purpose: QuestionnairePurpose;
+  version: number;
+  questions: Question[];
+}
+
+/** One answer — values are always a string array (a boolean as `["true"]`,
+ *  a single choice as `["option"]`, text as `["…"]`). */
+export interface Answer {
+  questionId: string;
+  values: string[];
+}

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import type { AnimalDetail } from "@/entities/animal";
 import { ApplyCard } from "./ApplyCard";
+
+const renderCard = (detail: AnimalDetail) =>
+  render(
+    <MemoryRouter>
+      <ApplyCard animal={detail} />
+    </MemoryRouter>,
+  );
 
 const animal = (status: AnimalDetail["status"]): AnimalDetail => ({
   id: "animal-1",
@@ -28,21 +36,21 @@ const button = (name: string) => screen.getByRole("button", { name });
 
 describe("ApplyCard", () => {
   it("offers apply + foster for an available animal", () => {
-    render(<ApplyCard animal={animal("AVAILABLE")} />);
+    renderCard(animal("AVAILABLE"));
 
     expect(button("입양 신청하기").hasAttribute("disabled")).toBe(false);
     expect(screen.queryByRole("button", { name: "임시보호 신청" })).not.toBeNull();
   });
 
   it("disables the CTA and hides foster once adopted", () => {
-    render(<ApplyCard animal={animal("ADOPTED")} />);
+    renderCard(animal("ADOPTED"));
 
     expect(button("입양 완료").hasAttribute("disabled")).toBe(true);
     expect(screen.queryByRole("button", { name: "임시보호 신청" })).toBeNull();
   });
 
   it("toggles the bookmark on click", () => {
-    render(<ApplyCard animal={animal("AVAILABLE")} />);
+    renderCard(animal("AVAILABLE"));
     const bookmark = button("관심 동물");
 
     expect(bookmark.getAttribute("aria-pressed")).toBe("false");

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { Favorite, FavoriteBorder } from "hobom-design-system/icons";
 import { SEX_LABEL, SIZE_LABEL, STATUS_LABEL, formatAge } from "@/entities/animal";
+import { applyPath } from "@/shared/config";
 import { useToast } from "@/shared/model";
 import type { AnimalDetail } from "@/entities/animal";
 import { applyCta } from "../lib/apply-cta.lib";
@@ -21,6 +23,7 @@ const COMING_SOON = "곧 제공될 예정이에요.";
 /** Sticky application panel with status-branched CTAs (§02). Apply/foster and
  *  inquiry are placeholders until the funnel and inquiry threads land. */
 export const ApplyCard = ({ animal }: { animal: AnimalDetail }) => {
+  const navigate = useNavigate();
   const { openWarnToast } = useToast();
   const [bookmarked, setBookmarked] = useState(false);
 
@@ -58,7 +61,12 @@ export const ApplyCard = ({ animal }: { animal: AnimalDetail }) => {
       )}
 
       <div {...stylex.props(styles.ctas)}>
-        <Hb.Button variant="primary" fullWidth disabled={!cta.primaryEnabled} onClick={notReady}>
+        <Hb.Button
+          variant="primary"
+          fullWidth
+          disabled={!cta.primaryEnabled}
+          onClick={() => navigate(applyPath(animal.id))}
+        >
           {cta.primaryLabel}
         </Hb.Button>
         {cta.showFoster && (

--- a/apps/hobom-angel/src/features/apply-adoption/index.ts
+++ b/apps/hobom-angel/src/features/apply-adoption/index.ts
@@ -1,0 +1,1 @@
+export { ApplyAdoption } from "./ui/ApplyAdoption";

--- a/apps/hobom-angel/src/features/apply-adoption/lib/apply-steps.lib.spec.ts
+++ b/apps/hobom-angel/src/features/apply-adoption/lib/apply-steps.lib.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { Question } from "@/entities/questionnaire";
+import { isAnswered, isStepBlocked, toAnswerList } from "./apply-steps.lib";
+
+const q = (id: string, type: Question["type"], required = false): Question => ({
+  id,
+  prompt: id,
+  type,
+  options: type === "SINGLE_CHOICE" || type === "MULTI_CHOICE" ? ["a", "b"] : [],
+  required,
+});
+
+describe("isAnswered", () => {
+  it("treats whitespace-only text as unanswered", () => {
+    expect(isAnswered(q("1", "TEXT"), ["   "])).toBe(false);
+    expect(isAnswered(q("1", "TEXT"), ["집"])).toBe(true);
+  });
+
+  it("counts any selected choice as answered", () => {
+    expect(isAnswered(q("1", "SINGLE_CHOICE"), ["a"])).toBe(true);
+    expect(isAnswered(q("1", "MULTI_CHOICE"), [])).toBe(false);
+  });
+});
+
+describe("isStepBlocked", () => {
+  it("blocks only when a required question is unanswered", () => {
+    expect(isStepBlocked(q("1", "TEXT", true), {})).toBe(true);
+    expect(isStepBlocked(q("1", "TEXT", true), { "1": ["집"] })).toBe(false);
+    expect(isStepBlocked(q("1", "TEXT", false), {})).toBe(false);
+  });
+});
+
+describe("toAnswerList", () => {
+  it("keeps only answered questions and trims text", () => {
+    const questions = [q("1", "TEXT"), q("2", "MULTI_CHOICE"), q("3", "TEXT")];
+    const result = toAnswerList(questions, { "1": [" 집 "], "2": [], "3": [""] });
+
+    expect(result).toEqual([{ questionId: "1", values: ["집"] }]);
+  });
+});

--- a/apps/hobom-angel/src/features/apply-adoption/lib/apply-steps.lib.ts
+++ b/apps/hobom-angel/src/features/apply-adoption/lib/apply-steps.lib.ts
@@ -1,0 +1,25 @@
+import type { AdoptionAnswer } from "@/entities/adoption";
+import type { Question } from "@/entities/questionnaire";
+
+export type AnswerMap = Record<string, string[]>;
+
+/** A question counts as answered when it has a non-empty value (text trimmed). */
+export const isAnswered = (question: Question, values: string[] | undefined): boolean => {
+  if (!values || values.length === 0) return false;
+  if (question.type === "TEXT") return (values[0]?.trim().length ?? 0) > 0;
+
+  return true;
+};
+
+/** Whether a single question still needs an answer to advance past its step. */
+export const isStepBlocked = (question: Question, answers: AnswerMap): boolean =>
+  question.required && !isAnswered(question, answers[question.id]);
+
+/** Build the submit payload — only questions with a real answer are sent. */
+export const toAnswerList = (questions: Question[], answers: AnswerMap): AdoptionAnswer[] =>
+  questions
+    .map((question) => ({
+      questionId: question.id,
+      values: (answers[question.id] ?? []).map((value) => value.trim()).filter(Boolean),
+    }))
+    .filter((answer) => answer.values.length > 0);

--- a/apps/hobom-angel/src/features/apply-adoption/model/useApplyAdoption.ts
+++ b/apps/hobom-angel/src/features/apply-adoption/model/useApplyAdoption.ts
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useMutation, useSuspenseQuery } from "hobom-data";
+import { animalQueries } from "@/entities/animal";
+import { adoptionMutations } from "@/entities/adoption";
+import { questionnaireQueries } from "@/entities/questionnaire";
+import { animalDetailPath } from "@/shared/config";
+import { useFunnel, useToast } from "@/shared/model";
+import { isStepBlocked, toAnswerList, type AnswerMap } from "../lib/apply-steps.lib";
+
+const STEP_QUERY_KEY = "step";
+
+export const REVIEW_STEP = "review";
+
+/**
+ * Drives the adoption funnel: loads the animal and its shelter's survey, then
+ * walks one question per step (URL-synced via `useFunnel`, so back/forward and
+ * refresh keep the step), ending on a review step that submits the application.
+ */
+export const useApplyAdoption = (animalId: string) => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { openSuccessToast, openErrorToast, openWarnToast } = useToast();
+
+  const { data: animal } = useSuspenseQuery(animalQueries.detail(animalId));
+  const { data: questionnaire } = useSuspenseQuery(
+    questionnaireQueries.forShelter(animal.shelterId, "ADOPTION"),
+  );
+
+  const questions = questionnaire?.questions ?? [];
+  const stepNames: string[] = [...questions.map((question) => question.id), REVIEW_STEP];
+  const stepAt = (index: number): string => stepNames[index] ?? REVIEW_STEP;
+
+  const [Funnel, setStep] = useFunnel(stepNames as [string, ...string[]], {
+    stepQueryKey: STEP_QUERY_KEY,
+    initialStep: stepAt(0),
+  });
+
+  const [answers, setAnswers] = useState<AnswerMap>({});
+
+  const currentStep = searchParams.get(STEP_QUERY_KEY) ?? stepAt(0);
+  const currentIndex = Math.max(0, stepNames.indexOf(currentStep));
+
+  const { mutate, isPending } = useMutation({
+    ...adoptionMutations.submit(animalId),
+    onSuccess: () => {
+      openSuccessToast({ message: "신청이 접수됐어요. 승인 결과를 기다려주세요." });
+      void navigate(animalDetailPath(animalId), { replace: true });
+    },
+    onError: (error) =>
+      openErrorToast({ message: error instanceof Error ? error.message : "신청에 실패했어요." }),
+  });
+
+  const setAnswer = (questionId: string, values: string[]) =>
+    setAnswers((prev) => ({ ...prev, [questionId]: values }));
+
+  const currentQuestion = questions[currentIndex];
+  const isReview = currentIndex >= questions.length;
+
+  const submit = () => mutate({ answers: toAnswerList(questions, answers) });
+
+  const onNext = () => {
+    if (isReview) {
+      submit();
+
+      return;
+    }
+
+    if (currentQuestion && isStepBlocked(currentQuestion, answers)) {
+      openWarnToast({ message: "필수 항목이에요." });
+
+      return;
+    }
+
+    setStep(stepAt(currentIndex + 1));
+  };
+
+  const onPrev = () => setStep(stepAt(Math.max(0, currentIndex - 1)));
+
+  return {
+    animal,
+    Funnel,
+    questions,
+    answers,
+    setAnswer,
+    currentIndex,
+    totalSteps: stepNames.length,
+    isReview,
+    canPrev: currentIndex > 0,
+    onNext,
+    onPrev,
+    isSubmitting: isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/ApplyAdoption.styles.ts
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/ApplyAdoption.styles.ts
@@ -1,0 +1,147 @@
+import * as stylex from "@stylexjs/stylex";
+
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  root: {
+    minHeight: "100%",
+    maxWidth: 640,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: { default: 16, [DESKTOP]: 40 },
+    display: "flex",
+    flexDirection: "column",
+    gap: 20,
+  },
+  // Grows on mobile so the nav sits at the screen bottom; natural height on
+  // desktop so the nav sits just below the question.
+  funnelArea: {
+    flex: { default: 1, [DESKTOP]: "0 1 auto" },
+  },
+
+  // ── Header ──────────────────────────────────────────────
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+  },
+  back: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    fontSize: "1.1rem",
+    color: "var(--hb-color-text-primary)",
+    textDecoration: "none",
+  },
+  title: {
+    margin: 0,
+    fontSize: "1.25rem",
+    fontWeight: 800,
+    color: "var(--hb-color-text-primary)",
+  },
+
+  // ── Progress ────────────────────────────────────────────
+  progressRow: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+  },
+  stepLabel: {
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+  },
+  progressTrack: {
+    height: 6,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-color-canvas)",
+    overflow: "hidden",
+  },
+  progressBar: {
+    height: "100%",
+    borderRadius: 999,
+    backgroundColor: "var(--hb-color-accent)",
+    transitionProperty: "width",
+    transitionDuration: "0.25s",
+    transitionTimingFunction: "ease",
+  },
+
+  // ── Step / fields ───────────────────────────────────────
+  step: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 24,
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  prompt: {
+    fontSize: "0.9375rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+  required: {
+    color: "var(--hb-color-accent-dark)",
+  },
+  options: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  counter: {
+    alignSelf: "flex-end",
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  emptyNote: {
+    margin: 0,
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+
+  // ── Nav (bottom action bar on mobile, inline on desktop) ─
+  nav: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    paddingTop: 12,
+    borderTopWidth: { default: 1, [DESKTOP]: 0 },
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-color-border)",
+  },
+  navGrow: {
+    flex: 1,
+  },
+
+  // ── Review ──────────────────────────────────────────────
+  reviewTitle: {
+    margin: 0,
+    fontSize: "1.0625rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  reviewItem: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    paddingBlock: 12,
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+  },
+  reviewPrompt: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  reviewAnswer: {
+    fontSize: "0.9375rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+});

--- a/apps/hobom-angel/src/features/apply-adoption/ui/ApplyAdoption.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/ApplyAdoption.tsx
@@ -1,0 +1,64 @@
+import * as stylex from "@stylexjs/stylex";
+import { REVIEW_STEP, useApplyAdoption } from "../model/useApplyAdoption";
+import { ApplyHeader } from "./ApplyHeader";
+import { ApplyNav } from "./ApplyNav";
+import { QuestionField } from "./QuestionField";
+import { ReviewStep } from "./ReviewStep";
+import { styles } from "./ApplyAdoption.styles";
+
+/** §03 adoption funnel: one question per step (URL-synced) ending in a review,
+ *  with a bottom action bar on mobile / inline nav on desktop. */
+export const ApplyAdoption = ({ animalId }: { animalId: string }) => {
+  const {
+    animal,
+    Funnel,
+    questions,
+    answers,
+    setAnswer,
+    currentIndex,
+    totalSteps,
+    isReview,
+    canPrev,
+    onNext,
+    onPrev,
+    isSubmitting,
+  } = useApplyAdoption(animalId);
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <ApplyHeader
+        animalId={animalId}
+        animalName={animal.name}
+        currentIndex={currentIndex}
+        totalSteps={totalSteps}
+      />
+
+      <div {...stylex.props(styles.funnelArea)}>
+        <Funnel>
+          {[
+            ...questions.map((question) => (
+              <Funnel.Step key={question.id} name={question.id}>
+                <QuestionField
+                  question={question}
+                  values={answers[question.id] ?? []}
+                  onChange={(values) => setAnswer(question.id, values)}
+                />
+              </Funnel.Step>
+            )),
+            <Funnel.Step key={REVIEW_STEP} name={REVIEW_STEP}>
+              <ReviewStep questions={questions} answers={answers} />
+            </Funnel.Step>,
+          ]}
+        </Funnel>
+      </div>
+
+      <ApplyNav
+        canPrev={canPrev}
+        isReview={isReview}
+        isSubmitting={isSubmitting}
+        onPrev={onPrev}
+        onNext={onNext}
+      />
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/ApplyHeader.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/ApplyHeader.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { animalDetailPath } from "@/shared/config";
+import { styles } from "./ApplyAdoption.styles";
+
+interface ApplyHeaderProps {
+  animalId: string;
+  animalName: string;
+  currentIndex: number;
+  totalSteps: number;
+}
+
+/** Back link, title, and the step progress bar. */
+export const ApplyHeader = ({ animalId, animalName, currentIndex, totalSteps }: ApplyHeaderProps) => {
+  const progress = Math.round(((currentIndex + 1) / totalSteps) * 100);
+
+  return (
+    <>
+      <div {...stylex.props(styles.header)}>
+        <Link to={animalDetailPath(animalId)} {...stylex.props(styles.back)} aria-label="뒤로">
+          ←
+        </Link>
+        <h1 {...stylex.props(styles.title)}>{animalName} 입양 신청</h1>
+      </div>
+
+      <div {...stylex.props(styles.progressRow)}>
+        <span {...stylex.props(styles.stepLabel)}>
+          {currentIndex + 1} / {totalSteps} 단계
+        </span>
+        <div {...stylex.props(styles.progressTrack)}>
+          <div {...stylex.props(styles.progressBar)} style={{ width: `${progress}%` }} />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/ApplyNav.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/ApplyNav.tsx
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles } from "./ApplyAdoption.styles";
+
+interface ApplyNavProps {
+  canPrev: boolean;
+  isReview: boolean;
+  isSubmitting: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+/** Bottom action bar (mobile) / inline nav (desktop): 이전 + 다음/신청하기. */
+export const ApplyNav = ({ canPrev, isReview, isSubmitting, onPrev, onNext }: ApplyNavProps) => (
+  <div {...stylex.props(styles.nav)}>
+    {canPrev && (
+      <div {...stylex.props(styles.navGrow)}>
+        <Hb.Button variant="secondary" fullWidth onClick={onPrev}>
+          이전
+        </Hb.Button>
+      </div>
+    )}
+    <div {...stylex.props(styles.navGrow)}>
+      <Hb.Button variant="primary" fullWidth loading={isSubmitting} onClick={onNext}>
+        {isReview ? "신청하기" : "다음"}
+      </Hb.Button>
+    </div>
+  </div>
+);

--- a/apps/hobom-angel/src/features/apply-adoption/ui/QuestionField.spec.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/QuestionField.spec.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Question } from "@/entities/questionnaire";
+import { QuestionField } from "./QuestionField";
+
+const question = (type: Question["type"], options: string[] = []): Question => ({
+  id: "q1",
+  prompt: "질문",
+  type,
+  options,
+  required: false,
+});
+
+/** Controlled harness that surfaces the current answer for assertions. */
+const Harness = ({ q }: { q: Question }) => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <>
+      <QuestionField question={q} values={values} onChange={setValues} />
+      <output data-testid="values">{values.join(",")}</output>
+    </>
+  );
+};
+
+const answer = () => screen.getByTestId("values").textContent;
+
+describe("QuestionField", () => {
+  it("selects a single choice", () => {
+    render(<Harness q={question("SINGLE_CHOICE", ["아파트", "주택", "원룸"])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "주택" }));
+
+    expect(answer()).toBe("주택");
+  });
+
+  it("toggles multiple choices on and off", () => {
+    render(<Harness q={question("MULTI_CHOICE", ["자녀", "부모님"])} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "자녀" }));
+    fireEvent.click(screen.getByRole("button", { name: "부모님" }));
+
+    expect(answer()).toBe("자녀,부모님");
+
+    fireEvent.click(screen.getByRole("button", { name: "자녀" }));
+
+    expect(answer()).toBe("부모님");
+  });
+
+  it("maps a boolean answer to true/false", () => {
+    render(<Harness q={question("BOOLEAN")} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "아니오" }));
+
+    expect(answer()).toBe("false");
+  });
+
+  it("captures free text", () => {
+    render(<Harness q={question("TEXT")} />);
+
+    fireEvent.change(screen.getByPlaceholderText("자유롭게 작성해주세요"), {
+      target: { value: "함께 살고 싶어요" },
+    });
+
+    expect(answer()).toBe("함께 살고 싶어요");
+  });
+});

--- a/apps/hobom-angel/src/features/apply-adoption/ui/QuestionField.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/QuestionField.tsx
@@ -1,0 +1,42 @@
+import * as stylex from "@stylexjs/stylex";
+import type { Question } from "@/entities/questionnaire";
+import { BooleanAnswer } from "./fields/BooleanAnswer";
+import { MultiChoiceAnswer } from "./fields/MultiChoiceAnswer";
+import { SingleChoiceAnswer } from "./fields/SingleChoiceAnswer";
+import { TextAnswer } from "./fields/TextAnswer";
+import { styles } from "./ApplyAdoption.styles";
+
+interface QuestionFieldProps {
+  question: Question;
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+const renderAnswer = (question: Question, id: string, props: Omit<QuestionFieldProps, "question">) => {
+  switch (question.type) {
+    case "TEXT":
+      return <TextAnswer id={id} {...props} />;
+    case "BOOLEAN":
+      return <BooleanAnswer id={id} {...props} />;
+    case "SINGLE_CHOICE":
+      return <SingleChoiceAnswer id={id} options={question.options} {...props} />;
+    case "MULTI_CHOICE":
+      return <MultiChoiceAnswer id={id} options={question.options} {...props} />;
+  }
+};
+
+/** One survey question: the prompt plus the field for its type (§03). */
+export const QuestionField = ({ question, values, onChange }: QuestionFieldProps) => {
+  const id = `q-${question.id}`;
+
+  return (
+    <div {...stylex.props(styles.field)}>
+      <label {...stylex.props(styles.prompt)} id={id}>
+        {question.prompt}
+        {question.required && <span {...stylex.props(styles.required)}> *</span>}
+      </label>
+
+      {renderAnswer(question, id, { values, onChange })}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/ReviewStep.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/ReviewStep.tsx
@@ -1,0 +1,37 @@
+import * as stylex from "@stylexjs/stylex";
+import type { Question } from "@/entities/questionnaire";
+import { isAnswered } from "../lib/apply-steps.lib";
+import { styles } from "./ApplyAdoption.styles";
+import type { AnswerMap } from "../lib/apply-steps.lib";
+
+const BOOLEAN_LABELS: Record<string, string> = { true: "예", false: "아니오" };
+const readable = (value: string) => BOOLEAN_LABELS[value] ?? value;
+
+interface ReviewStepProps {
+  questions: Question[];
+  answers: AnswerMap;
+}
+
+/** Final funnel step — a summary of the answered questions before submitting. */
+export const ReviewStep = ({ questions, answers }: ReviewStepProps) => {
+  const reviewed = questions.filter((question) => isAnswered(question, answers[question.id]));
+
+  return (
+    <div {...stylex.props(styles.step)}>
+      <h2 {...stylex.props(styles.reviewTitle)}>입력한 내용을 확인해주세요</h2>
+
+      {reviewed.length === 0 ? (
+        <p {...stylex.props(styles.emptyNote)}>추가 질문 없이 바로 신청할 수 있어요.</p>
+      ) : (
+        reviewed.map((question) => (
+          <div key={question.id} {...stylex.props(styles.reviewItem)}>
+            <span {...stylex.props(styles.reviewPrompt)}>{question.prompt}</span>
+            <span {...stylex.props(styles.reviewAnswer)}>
+              {(answers[question.id] ?? []).map(readable).join(", ")}
+            </span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/fields/BooleanAnswer.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/fields/BooleanAnswer.tsx
@@ -1,0 +1,17 @@
+import { PillGroup } from "./PillGroup";
+
+const OPTIONS = [
+  { label: "예", value: "true" },
+  { label: "아니오", value: "false" },
+];
+
+interface BooleanAnswerProps {
+  id: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+/** Yes/no answer (stored as "true"/"false"). */
+export const BooleanAnswer = ({ id, values, onChange }: BooleanAnswerProps) => (
+  <PillGroup id={id} options={OPTIONS} values={values} multiple={false} onChange={onChange} />
+);

--- a/apps/hobom-angel/src/features/apply-adoption/ui/fields/MultiChoiceAnswer.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/fields/MultiChoiceAnswer.tsx
@@ -1,0 +1,19 @@
+import { PillGroup } from "./PillGroup";
+
+interface MultiChoiceAnswerProps {
+  id: string;
+  options: string[];
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+/** Pick any number of the shelter-defined options. */
+export const MultiChoiceAnswer = ({ id, options, values, onChange }: MultiChoiceAnswerProps) => (
+  <PillGroup
+    id={id}
+    options={options.map((option) => ({ label: option, value: option }))}
+    values={values}
+    multiple
+    onChange={onChange}
+  />
+);

--- a/apps/hobom-angel/src/features/apply-adoption/ui/fields/PillGroup.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/fields/PillGroup.tsx
@@ -1,0 +1,40 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles } from "../ApplyAdoption.styles";
+
+export interface Option {
+  label: string;
+  value: string;
+}
+
+interface PillGroupProps {
+  id: string;
+  options: Option[];
+  values: string[];
+  multiple: boolean;
+  onChange: (values: string[]) => void;
+}
+
+/** Selectable option pills, single- or multi-select. */
+export const PillGroup = ({ id, options, values, multiple, onChange }: PillGroupProps) => {
+  const select = (value: string) => {
+    if (!multiple) return onChange([value]);
+
+    return onChange(values.includes(value) ? values.filter((v) => v !== value) : [...values, value]);
+  };
+
+  return (
+    <div {...stylex.props(styles.options)} role="group" aria-labelledby={id}>
+      {options.map((option) => (
+        <Hb.ToggleButton
+          key={option.value}
+          value={option.value}
+          selected={values.includes(option.value)}
+          onChange={() => select(option.value)}
+        >
+          {option.label}
+        </Hb.ToggleButton>
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/apply-adoption/ui/fields/SingleChoiceAnswer.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/fields/SingleChoiceAnswer.tsx
@@ -1,0 +1,19 @@
+import { PillGroup } from "./PillGroup";
+
+interface SingleChoiceAnswerProps {
+  id: string;
+  options: string[];
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+/** Pick exactly one of the shelter-defined options. */
+export const SingleChoiceAnswer = ({ id, options, values, onChange }: SingleChoiceAnswerProps) => (
+  <PillGroup
+    id={id}
+    options={options.map((option) => ({ label: option, value: option }))}
+    values={values}
+    multiple={false}
+    onChange={onChange}
+  />
+);

--- a/apps/hobom-angel/src/features/apply-adoption/ui/fields/TextAnswer.tsx
+++ b/apps/hobom-angel/src/features/apply-adoption/ui/fields/TextAnswer.tsx
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { styles } from "../ApplyAdoption.styles";
+
+interface TextAnswerProps {
+  id: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+}
+
+/** Free-text answer with a character counter. */
+export const TextAnswer = ({ id, values, onChange }: TextAnswerProps) => {
+  const value = values[0] ?? "";
+
+  return (
+    <>
+      <Hb.TextField
+        fullWidth
+        multiline
+        minRows={4}
+        placeholder="자유롭게 작성해주세요"
+        aria-labelledby={id}
+        value={value}
+        onChange={(event) => onChange([event.target.value])}
+      />
+      <span {...stylex.props(styles.counter)}>{value.length}자</span>
+    </>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/adoption.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/adoption.handlers.ts
@@ -1,0 +1,15 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+/** Adoption domain mock — submitting an application opens an approval request. */
+export const adoptionHandlers = [
+  http.post(mockUrl("/animals/:animalId/adoption-applications"), () => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    return ok({ applicationId: "application-1", approvalId: "approval-1" });
+  }),
+];

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -1,6 +1,14 @@
 import { authHandlers } from "./auth.handlers";
 import { userHandlers } from "./user.handlers";
 import { animalHandlers } from "./animal.handlers";
+import { questionnaireHandlers } from "./questionnaire.handlers";
+import { adoptionHandlers } from "./adoption.handlers";
 
 /** All MSW request handlers, aggregated per domain. Add new domains here. */
-export const handlers = [...authHandlers, ...userHandlers, ...animalHandlers];
+export const handlers = [
+  ...authHandlers,
+  ...userHandlers,
+  ...animalHandlers,
+  ...questionnaireHandlers,
+  ...adoptionHandlers,
+];

--- a/apps/hobom-angel/src/mocks/handlers/questionnaire.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/questionnaire.handlers.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+const ADOPTION_QUESTIONS = [
+  { id: "q1", prompt: "주거 형태를 알려주세요.", type: "SINGLE_CHOICE", options: ["아파트", "주택", "원룸"], required: true },
+  { id: "q2", prompt: "현재 반려동물이 있나요?", type: "BOOLEAN", options: [], required: true },
+  { id: "q3", prompt: "함께 지낼 가족 구성원을 모두 선택해주세요.", type: "MULTI_CHOICE", options: ["1인", "배우자", "자녀", "부모님"], required: false },
+  { id: "q4", prompt: "입양을 결심한 이유를 자유롭게 작성해주세요.", type: "TEXT", options: [], required: true },
+  { id: "q5", prompt: "하루 중 반려동물과 함께하는 시간은 어느 정도인가요?", type: "SINGLE_CHOICE", options: ["3시간 미만", "3~6시간", "6시간 이상"], required: true },
+];
+
+/** Questionnaire domain mock — a shelter's adoption survey. */
+export const questionnaireHandlers = [
+  http.get(mockUrl("/shelters/:shelterId/questionnaires/:purpose"), ({ params }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    if (params.purpose !== "ADOPTION") {
+      return HttpResponse.json({ message: "설문을 찾을 수 없어요." }, { status: 404 });
+    }
+
+    return ok({
+      id: "questionnaire-1",
+      shelterId: String(params.shelterId),
+      purpose: "ADOPTION",
+      version: 1,
+      questions: ADOPTION_QUESTIONS,
+    });
+  }),
+];

--- a/apps/hobom-angel/src/pages/apply-adoption/index.ts
+++ b/apps/hobom-angel/src/pages/apply-adoption/index.ts
@@ -1,0 +1,1 @@
+export { ApplyAdoptionPage } from "./ui/ApplyAdoptionPage";

--- a/apps/hobom-angel/src/pages/apply-adoption/ui/ApplyAdoptionPage.tsx
+++ b/apps/hobom-angel/src/pages/apply-adoption/ui/ApplyAdoptionPage.tsx
@@ -1,0 +1,11 @@
+import { useParams } from "react-router-dom";
+import { ApplyAdoption } from "@/features/apply-adoption";
+import { NotFoundState } from "@/shared/ui";
+
+export const ApplyAdoptionPage = () => {
+  const { animalId } = useParams<{ animalId: string }>();
+
+  if (!animalId) return <NotFoundState />;
+
+  return <ApplyAdoption animalId={animalId} />;
+};

--- a/apps/hobom-angel/src/shared/config/index.ts
+++ b/apps/hobom-angel/src/shared/config/index.ts
@@ -1,3 +1,3 @@
 export { env } from "./env";
-export { ROUTES, animalDetailPath } from "./routes";
+export { ROUTES, animalDetailPath, applyPath } from "./routes";
 export { ROUTE_META, DEFAULT_META } from "./route-meta";

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   // Consumer sections (behind auth — the landing is the only public surface).
   ANIMALS: "/animals",
   ANIMAL_DETAIL: "/animals/:animalId",
+  APPLY: "/apply/:animalId",
   FOSTER: "/foster",
   VOLUNTEER: "/volunteer",
   SHELTERS: "/shelters",
@@ -20,3 +21,6 @@ export const ROUTES = {
 
 /** Build the concrete path to an animal's detail page. */
 export const animalDetailPath = (animalId: string): string => `/animals/${animalId}`;
+
+/** Build the concrete path to an animal's adoption application funnel. */
+export const applyPath = (animalId: string): string => `/apply/${animalId}`;


### PR DESCRIPTION
Adds the `/apply/:animalId` adoption application funnel — §03, opened from the detail page's apply CTA.

## What
- Loads the shelter's survey (`GET /shelters/:id/questionnaires/ADOPTION`) and walks it **one question per step**, ending on a review step that submits the application (`POST /animals/:id/adoption-applications`).
- Steps are **URL-synced** through the shared `useFunnel`, so back/forward and a refresh land on the same step — a real funnel, not a paginated form.
- Each question type is its own field component (`TextAnswer`, `BooleanAnswer`, `SingleChoiceAnswer`, `MultiChoiceAnswer`) over a shared `PillGroup`; `QuestionField` just dispatches by type. Required questions block advancing.

## UX
- The step nav is a **bottom action bar on mobile** (thumb-reachable, above the tab bar) and **inline below the question on desktop**, with equal-width 이전 / 다음.

## Notes
- Built to the actual questionnaire contract: a flat list of four question types (`TEXT`, `BOOLEAN`, `SINGLE_CHOICE`, `MULTI_CHOICE`) with a `required` flag. The design's conditional show/require, draft autosave, file uploads, and scale/date types aren't in the contract, so they're deferred.
- A shelter with no questionnaire (the API 404s) goes straight to the review/submit step.

## Testing
- `pnpm --filter hobom-angel typecheck` / `lint` / `test` (50 unit — funnel lib + `QuestionField` RTL interaction tests)
- `pnpm --filter hobom-angel exec playwright test` (17 e2e — funnel walks step by step and submits, required question blocks advancing)