### PR TITLE
Guard requestIdleCallback so Safari doesn't crash on load

### DIFF
--- a/apps/hobom-angel/e2e/landing.spec.ts
+++ b/apps/hobom-angel/e2e/landing.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("landing", () => {
+  test("renders for a guest without requestIdleCallback (Safari)", async ({ page }) => {
+    // Simulate Safari < 18.4, where a bare requestIdleCallback reference throws.
+    await page.addInitScript(() => {
+      // @ts-expect-error — remove the API to reproduce the Safari environment.
+      delete window.requestIdleCallback;
+      // @ts-expect-error — same.
+      delete window.cancelIdleCallback;
+    });
+
+    await page.goto("./");
+
+    // The public landing renders (guest) instead of the error boundary.
+    await expect(page.getByRole("button", { name: "로그인" })).toBeVisible();
+    await expect(page.getByText("일시적인 오류가 발생했어요")).toHaveCount(0);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ROUTES } from "@/shared/config";
+import { onIdle } from "@/shared/lib";
 import { useRouteMeta } from "@/shared/model";
 import { ErrorBoundary, LoadingState, NotFoundState } from "@/shared/ui";
 import { ComingSoonPage } from "@/pages/coming-soon";
@@ -47,11 +48,7 @@ const SECTION_ROUTES = [
 export const AppRouter = () => {
   useRouteMeta();
 
-  useEffect(() => {
-    const id = requestIdleCallback(prefetchRoutes);
-
-    return () => cancelIdleCallback(id);
-  }, []);
+  useEffect(() => onIdle(prefetchRoutes), []);
 
   return (
     <ErrorBoundary>

--- a/apps/hobom-angel/src/shared/lib/index.ts
+++ b/apps/hobom-angel/src/shared/lib/index.ts
@@ -4,3 +4,4 @@ export { createFunnelStateId, createFunnelStorage } from "./funnel.lib";
 export type { FunnelStorage } from "./funnel.lib";
 export { warmApiOrigin } from "./warm-api-origin";
 export { toQueryString } from "./query-string.lib";
+export { onIdle } from "./on-idle.lib";

--- a/apps/hobom-angel/src/shared/lib/on-idle.lib.spec.ts
+++ b/apps/hobom-angel/src/shared/lib/on-idle.lib.spec.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onIdle } from "./on-idle.lib";
+
+describe("onIdle", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("falls back to a timeout when requestIdleCallback is unavailable", () => {
+    vi.useFakeTimers();
+    const task = vi.fn();
+
+    onIdle(task);
+    vi.runAllTimers();
+
+    expect(task).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the pending task", () => {
+    vi.useFakeTimers();
+    const task = vi.fn();
+
+    onIdle(task)();
+    vi.runAllTimers();
+
+    expect(task).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hobom-angel/src/shared/lib/on-idle.lib.ts
+++ b/apps/hobom-angel/src/shared/lib/on-idle.lib.ts
@@ -1,0 +1,19 @@
+type IdleCancel = () => void;
+
+/**
+ * Run low-priority work when the browser is idle, falling back to a timeout on
+ * browsers without `requestIdleCallback` (e.g. Safari before 18.4). A bare
+ * `requestIdleCallback(...)` reference throws there, which would crash the app
+ * on load — so this feature-detects it off `window` first.
+ */
+export const onIdle = (task: () => void): IdleCancel => {
+  if (typeof window !== "undefined" && typeof window.requestIdleCallback === "function") {
+    const handle = window.requestIdleCallback(task);
+
+    return () => window.cancelIdleCallback(handle);
+  }
+
+  const handle = setTimeout(task, 200);
+
+  return () => clearTimeout(handle);
+};


### PR DESCRIPTION
## Problem
`AppRouter`'s idle route-prefetch called the bare global `requestIdleCallback`. That API isn't defined in Safari before 18.4 (iOS Safari and older macOS Safari), so the reference throws inside the effect → the root `ErrorBoundary` catches it → **every page, including the landing, renders the error fallback**.

## Fix
Feature-detect `requestIdleCallback` off `window` with a `setTimeout` fallback, via a small `onIdle` helper. The bare-global reference is gone, so browsers without the API just schedule the prefetch on a timeout instead of crashing.

## Tests
- Unit: `onIdle` uses the timeout fallback and cancels.
- e2e: deletes `requestIdleCallback`/`cancelIdleCallback` to reproduce the Safari environment, then loads the guest landing and asserts it renders (no error fallback). Verified this e2e **fails** against the old bare-call code and passes with the fix.

## Scope note
This addresses the crash on browsers **lacking** `requestIdleCallback` (Safari < 18.4). It is not expected to affect Chromium or Safari 18.4+, which have the API — a separately reported crash there is still being diagnosed from the actual console error.