### PR TITLE
Add design-system composition patterns and package docs

### DIFF
--- a/.claude/skills/hobom-data/SKILL.md
+++ b/.claude/skills/hobom-data/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: hobom-data
+description: Use when importing from hobom-data, reading source under packages/hobom-data, or working with useQuery/useMutation/useInfiniteQuery/queryOptions/DataLot — the in-house query cache & data-fetching hooks (a lean TanStack-Query alternative). Covers the suspense-vs-non-suspense choice, the isLoading-first-render gotcha, cache invalidation, and provider setup.
+---
+
+# hobom-data (DataLot)
+
+`hobom-data` is a small in-house data-fetching + caching library shaped like
+TanStack Query (query cache, staleness, dedup, invalidation, mutations,
+infinite/suspense variants) but with only the surface we use. The cache client
+is a **`DataLot`**. Hook and option names mirror TanStack Query, so most code
+reads identically — but a few behaviors differ (see Gotchas), and getting those
+wrong causes real bugs.
+
+```ts
+import { HoBom } from "hobom-data";
+// or flat named exports (migration-friendly):
+import { useQuery, useMutation, queryOptions, DataLot, DataLotProvider } from "hobom-data";
+```
+
+`HoBom.DataKernel.*` (hooks) and `HoBom.DataLot` (cache class, with `.Provider`
+/ `.queryOptions` / `.mutationOptions` / `.infiniteQueryOptions` statics) are the
+same functions as the flat exports.
+
+## Golden rules
+
+1. **`useQuery` never throws — branch on `status`.** `status === "pending" |
+   "success" | "error"`. The error is on `result.error`. Only the `useSuspense*`
+   hooks throw (to `<Suspense>` / `<ErrorBoundary>`).
+2. **Never gate on `isLoading` for the first render.** It is
+   `status === "pending" && fetchStatus === "fetching"` and is `false` before
+   the fetch effect runs. Auth guards / initial gates branch on
+   `status === "pending"`.
+3. **Define options with the factories, reuse them.** `queryOptions(...)` /
+   `mutationOptions(...)` / `infiniteQueryOptions(...)` return a typed object you
+   pass to the hook, `prefetchQuery`, etc. Don't inline the same key/fn twice.
+4. **One `DataLot` per app, provided via `DataLotProvider client={...}`.** Cache
+   mutations (`invalidateQueries`, `setQueryData`, …) come from `useDataLot()`.
+
+## Provider setup
+
+```tsx
+import { DataLot, DataLotProvider } from "hobom-data";
+
+const dataLot = new DataLot({
+  defaultOptions: { queries: { staleTime: 60_000, retry: 1 } },
+});
+
+<DataLotProvider client={dataLot}>
+  <App />
+</DataLotProvider>
+```
+
+Note: `new DataLot({ defaultOptions })` (not options directly), and the provider
+prop is **`client`**. `useDataLot()` throws if called outside the provider.
+
+## Hooks & options catalog
+
+### Option factories
+
+```ts
+// queryOptions<TData, TQueryKey>(opts): DefinedQueryOptions
+queryOptions({
+  queryKey: ["shelter", id] as const,
+  queryFn: async ({ signal, queryKey }) => fetchShelter(id, signal),
+  staleTime: 60_000, // optional; also gcTime, retry, retryDelay,
+  //                    refetchOnWindowFocus, refetchOnReconnect, enabled
+});
+
+// mutationOptions<TData, TError, TVariables, TContext>(opts)
+mutationOptions({
+  mutationFn: (input: AdoptInput) => postAdopt(input),
+  onMutate, onSuccess, onError, onSettled, // all optional
+});
+
+// infiniteQueryOptions<TData, TPageParam, TQueryKey>(opts)
+infiniteQueryOptions({
+  queryKey: ["animals", filter] as const,
+  queryFn: ({ pageParam, signal }) => fetchAnimals({ cursor: pageParam, signal }),
+  initialPageParam: 0,                                    // REQUIRED
+  getNextPageParam: (lastPage, allPages) => lastPage.nextCursor, // REQUIRED; undefined = no more
+});
+```
+
+### `useQuery(options): UseQueryResult`
+
+Options: `QueryOptions` + `enabled?`, `select?: (data) => data`.
+Result: `{ data, error, status, fetchStatus, isLoading, isFetching, isError,
+isSuccess, refetch }`. **Does not throw.**
+
+```tsx
+const { data, status, isError, error } = useQuery(shelterQuery(id));
+if (status === "pending") return <Spinner />;
+if (isError) return <ErrorText>{error.message}</ErrorText>;
+return <h1>{data.name}</h1>;
+```
+
+### `useSuspenseQuery(options): UseSuspenseQueryResult`
+
+Options: `QueryOptions` minus `enabled`, plus `select?`.
+Result: `{ data, error: null, status: "success", fetchStatus, isFetching,
+refetch }`. **Suspends while pending, throws the error to an `ErrorBoundary`.**
+`data` is always defined — no pending/error branch needed in the component.
+
+```tsx
+const { data } = useSuspenseQuery(shelterQuery(id)); // data: Shelter
+```
+
+### `useMutation(options): UseMutationResult`
+
+Result: `{ data, error, variables, status, isIdle, isPending, isError,
+isSuccess, mutate, mutateAsync, reset }`.
+`mutate(vars, { onSuccess, onError, onSettled })` fires and forgets;
+`mutateAsync(vars)` returns a promise. Per-call callbacks run in addition to the
+option-level ones.
+
+```tsx
+const dataLot = useDataLot();
+const { mutate, isPending } = useMutation({
+  mutationFn: (id: string) => adopt(id),
+  onSuccess: () => dataLot.invalidateQueries({ queryKey: ["animals"] }),
+});
+```
+
+### `useInfiniteQuery(options): UseInfiniteQueryResult`
+
+Options: `infiniteQueryOptions(...)`. Result includes `data:
+{ pages, pageParams } | undefined`, `hasNextPage`, `isFetchingNextPage`,
+`fetchNextPage`, plus the usual `status`/`isLoading`/etc. **Does not throw.**
+
+```tsx
+const { data, hasNextPage, fetchNextPage, isFetchingNextPage, status } =
+  useInfiniteQuery(animalsInfinite(filter));
+const rows = data?.pages.flatMap((p) => p.items) ?? [];
+```
+
+### `useSuspenseInfiniteQuery(options)`
+
+Suspense variant. `data` always defined (`{ pages, pageParams }`); suspends /
+throws like `useSuspenseQuery`.
+
+### `useQueries({ queries: [...] })` / `useSuspenseQueries({ queries: [...] })`
+
+Run an array of query options in one hook; returns a tuple of results
+(non-suspense = `UseQueryResult[]`, suspense = `UseSuspenseQueryResult[]`).
+
+### `useDataLot(): DataLot` — cache operations
+
+- `getQueryData<T>(queryKey): T | undefined`
+- `setQueryData<T>(queryKey, updater)` — value or `(old) => new`
+- `invalidateQueries(filters?)` — mark stale + refetch active observers.
+  `filters` is `{ queryKey? }`; omit to invalidate everything. (`invalidates`
+  is the underlying alias.)
+- `prefetchQuery(options)` — warm the cache (e.g. in a loader)
+- `cancelQueries(filters?)` — abort in-flight fetches
+- `clear()` — drop the whole cache
+
+## Suspense vs non-suspense — which to pick
+
+| Want | Use |
+| --- | --- |
+| Inline `if (status === "pending")` / `isError` branches in the component | `useQuery` / `useInfiniteQuery` |
+| A parent `<Suspense fallback>` + `<ErrorBoundary>`, `data` always defined | `useSuspenseQuery` / `useSuspenseInfiniteQuery` |
+| Conditional / lazy fetching (`enabled: false`) | `useQuery` only — suspense variants force `enabled: true` |
+
+## Gotchas (these have bitten us)
+
+- **`useQuery` never throws.** Read `result.error`; branch on `status` /
+  `isError`. If you expected a try/catch or an `ErrorBoundary` to catch it,
+  switch to `useSuspenseQuery`.
+- **`isLoading` is `false` on the first render.** It's `status === "pending" &&
+  fetchStatus === "fetching"`, and the fetch starts in an effect after mount. So
+  on render #1 it's pending-but-not-fetching → `isLoading === false`. **Gate on
+  `status === "pending"`**, never `isLoading`, for auth guards / initial spinners.
+- **Suspense variants force `enabled: true`** and omit `enabled` from their
+  options type. For conditional fetching use plain `useQuery` with `enabled`.
+- **`infiniteQueryOptions` requires `initialPageParam` AND `getNextPageParam`;**
+  `getNextPageParam` returning `undefined` means "no next page" (`hasNextPage`
+  becomes `false`).
+- **Provider prop is `client`; constructor takes `{ defaultOptions }`.** A bare
+  `new DataLot(defaultOptions)` or `<DataLotProvider value=...>` is wrong.
+- **`select` runs on `useQuery`/`useSuspenseQuery` only** (transform result data);
+  it is not an option on the infinite hooks.
+
+## Verify
+
+```bash
+pnpm --filter hobom-data typecheck   # tsc --noEmit
+pnpm --filter hobom-data lint         # eslint --max-warnings=0
+pnpm --filter hobom-data test         # vitest
+```

--- a/.claude/skills/hobom-ds/SKILL.md
+++ b/.claude/skills/hobom-ds/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: hobom-ds
+description: Use when building or styling any UI in this monorepo, or when adding/extending a component in the hobom-design-system package. Covers the Hb component catalog, the "compose, don't hand-roll" rule, the folder/doc/story recipe for new components, CSS tokens, and verification commands. Invoke before writing bespoke StyleX in an app or reinventing a primitive.
+---
+
+# hobom-design-system (Hb)
+
+`hobom-design-system` is a self-hosted, MUI-parity component kit built on **StyleX**.
+Everything the app renders should come from it. Before writing a `*.styles.ts` in an
+app, check the catalog — the primitive almost certainly exists.
+
+```ts
+import { Hb } from "hobom-design-system";
+import { LocationOnOutlined } from "hobom-design-system/icons";
+
+<Hb.Stack spacing={2}>
+  <Hb.Text variant="h5">보호소</Hb.Text>
+  <Hb.SectionCard title="소개">…</Hb.SectionCard>
+</Hb.Stack>
+```
+
+## Golden rules
+
+1. **Compose, don't hand-roll.** Layout, typography, and surfaces are DS primitives
+   (`Hb.Stack`, `Hb.Grid`, `Hb.Box`, `Hb.Text`, `Hb.Card`, `Hb.SectionCard`,
+   `Hb.PageHeader`, `Hb.Breadcrumb`, `Hb.DescriptionList`, `Hb.StatGroup`,
+   `Hb.Gallery`). Reach for a bespoke `stylex.create` in an app only for a
+   one-off that no primitive covers — and if it recurs, promote it to the DS.
+2. **New shared UI goes in the DS, not the app.** If a screen needs a new visual
+   pattern, add a variant/component here so every app gets it. Never reference an
+   app token (`--hb-angel-*`) from inside the DS — DS uses only its own `--hb-*`
+   tokens so it stays app-agnostic and theme-flippable.
+3. **Compound (namespace) pattern** for anything with parts:
+   `export const X = { Root, Item }` with a React context linking them
+   (see `Tabs`, `DescriptionList`, `Breadcrumb`).
+4. **Semantic colors, not hex.** Use `Hb.Text color="text.secondary"` and the
+   `--hb-color-*` vars, never raw hex — they flip in dark mode automatically.
+
+## Catalog
+
+37+ components live under `Hb.*`. For the full list with props and one-line
+usage, read **[references/component-index.md](references/component-index.md)** —
+do that instead of reading each component's source. The composition patterns you
+will reach for most when laying out a screen:
+
+| Need | Use |
+| --- | --- |
+| Page/screen title block | `Hb.PageHeader` (title, description, actions, breadcrumb) |
+| Trail above a title | `Hb.Breadcrumb.Root` / `.Item current` |
+| Titled bordered section | `Hb.SectionCard` (title, description, action, `variant`) |
+| Term/value attribute grid | `Hb.DescriptionList.Root` / `.Item term=` |
+| Stat row (240+ 입양 · 32 보호중) | `Hb.StatGroup.Root` / `.Item value= label=` |
+| Photo gallery (main + thumbs) | `Hb.Gallery images=` (composes `Hb.Image`) |
+| Tabbed content | `Hb.Tabs.Root` + `.Item` + `.Panel value=` |
+| Vertical/horizontal spacing | `Hb.Stack spacing=` (× 8px), `direction` |
+| 12-col responsive layout | `Hb.Grid container spacing size={{ xs, md }}` |
+| Empty/error placeholder | `EmptyState` (from `hobom-design-system`) |
+
+## Adding or extending a component
+
+A component is a folder under `packages/hobom-design-system/src/components/<Name>/`
+with four files. Copy `SectionCard/` as the canonical template.
+
+1. **`<Name>.tsx`** — `stylex.create` for styles; merge external `className`/`style`:
+   ```ts
+   className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+   style={{ ...sx.style, ...style }}
+   ```
+   Extend `HTMLAttributes<HTMLXElement>` and spread `...rest` onto the root.
+   **`Omit<…, "title">`** if you add a `title` prop (it clashes with the DOM one).
+   Compose `Text` for typography instead of raw font CSS.
+2. **`index.ts`** — `export * from "./<Name>";`
+3. **`<Name>.stories.tsx`** — `title: "Components/<Name>"`, `satisfies Meta<…>`.
+   If the component has a **required** prop, put it in `meta.args` or the story
+   won't typecheck. These stories are also the test suite (run in a browser with
+   an a11y axe pass).
+4. **`<Name>.doc.ts`** — `export const docs: ComponentDoc` (type in
+   `foundations/docs.ts`): name, description, features, props, examples,
+   accessibility, notes. This is the agent-facing source of truth — fill it so
+   future work reads the doc, not the source.
+
+Then register it in **`src/components/index.ts`**: add the import and the entry in
+the `Hb` object (see the "Batch 3 — composition patterns" section).
+
+### a11y note (color-contrast)
+`text.secondary` (#737373) on the canvas (#f1f1f1) at 13px is ~4.19:1 — just
+under WCAG AA 4.5:1. It's a DS-wide token tradeoff already shipped app-wide. When
+a story renders small secondary text on the canvas, disable just that rule (other
+checks still run), mirroring `Card.stories`/`SectionCard.stories`:
+```ts
+parameters: { a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } } },
+```
+
+## CSS tokens (DS-internal `--hb-*`)
+
+Colors: `--hb-color-surface` (card/white), `--hb-color-canvas` (page bg),
+`--hb-color-border`, `--hb-color-text-primary` / `-secondary` / `-disabled`,
+`--hb-color-accent` / `-accent-dark` / `-accent-contrast`, `--hb-color-danger`,
+`--hb-color-success` / `-success-subtle`, `--hb-color-warning` / `-warning-subtle`.
+Radius is literal in components (8 for controls, 12 for section surfaces).
+Spacing scale is 8px units (`Hb.Stack spacing={2}` = 16px).
+
+## Verify (always run before committing DS changes)
+
+```bash
+pnpm --filter hobom-design-system typecheck
+pnpm --filter hobom-design-system lint
+pnpm --filter hobom-design-system test -- --run
+```
+
+Lint gotchas: import order (react → external → internal relative), blank line
+before a `return`/`export` that follows a statement, `interface` over `type` for
+object shapes, no unused vars, `noUncheckedIndexedAccess` (guard `arr[0]`).

--- a/.claude/skills/hobom-ds/references/component-index.md
+++ b/.claude/skills/hobom-ds/references/component-index.md
@@ -1,0 +1,112 @@
+# hobom-design-system — component index
+
+Every export the app can use. Props listed are the notable ones; each component
+also spreads standard DOM attributes onto its root unless noted. For the full
+prop contract of a component, read its co-located `*.doc.ts`.
+
+`import { Hb } from "hobom-design-system"` — access as `Hb.<Name>`.
+Icons: `import { IconName } from "hobom-design-system/icons"` (see
+`src/icons/generated.tsx`; add new ones with `createIcon`).
+
+---
+
+## Layout & primitives
+
+- **`Hb.Box`** — polymorphic element. `component?` (default `"div"`), all HTML attrs. The escape hatch when no richer primitive fits.
+- **`Hb.Stack`** — flexbox stack. `direction?` `"row" | "column" | "row-reverse" | "column-reverse"` (default `"column"`), `spacing?` (× 8px), `alignItems?`, `justifyContent?`, `flexWrap?`, `divider?` (element interleaved between children), `component?`.
+- **`Hb.Grid`** — 12-column responsive grid. `container?`, `spacing?` (× 8px), `size?` number | `{ xs, sm, md, lg, xl }`. Parent has `container`; children carry `size`.
+- **`Hb.Paper`** — surface. `variant?` `"elevation" | "outlined"`.
+- **`Hb.Divider`** — hairline rule. `orientation?`, standard attrs.
+- **`Hb.Text`** — typography. `variant?` `h1–h6 | subtitle1/2 | body1/2 | caption | overline | button | inherit` (default `body1`), `color?` (semantic role `"text.secondary" | "primary" | "error" | …` or any CSS color), `align?`, `noWrap?`, `gutterBottom?`, `fontWeight?`, `component?` (override the tag).
+
+## Surfaces & containers
+
+- **`Hb.Card`** = `{ Root, Content, Actions, Clickable }`. `Root.variant?` `"outlined" | "elevation"`. `Clickable` makes the whole surface a button (`onClick`).
+- **`Hb.SectionCard`** — titled content block. `title?`, `description?`, `action?` (right-aligned header slot), `variant?` `"outlined" | "plain"` (default `outlined`). Renders `<section>`; header collapses when empty.
+- **`Hb.Accordion`** = `{ Root, Summary, Details }`. `Root.variant?` `"outlined" | "elevation"`, controlled via `expanded`/`onChange`.
+- **`Hb.Collapse`** — animated open/close container. `in?` (open), standard attrs.
+
+## Composition patterns
+
+- **`Hb.PageHeader`** — screen title block. `title` (required), `description?`, `actions?` (right slot), `breadcrumb?` (above title), `children?` (below, e.g. tabs/filters). Renders `<header>`.
+- **`Hb.Breadcrumb`** = `{ Root, Item }`. `Root.separator?` (default `"/"`), `aria-label` default `"위치"`. `Item.current?` → `aria-current="page"` + primary weight. Put a router `<Link>` or `<a>` inside an `Item`.
+- **`Hb.DescriptionList`** = `{ Root, Item }`. `Root.layout?` `"grid" | "stacked"` (default `grid`). `Item.term` (ReactNode) + children (the value). Term = secondary caption, value = primary body. Semantic `<dl>/<dt>/<dd>`.
+- **`Hb.StatGroup`** = `{ Root, Item }`. `Root.columns?` number (grid of N; else flex-wrap). `Item.value` + `Item.label` — big value over small secondary label. Semantic `<dl>`.
+- **`Hb.Gallery`** — photo gallery. `images: { src, alt? }[]` (required), `alt?` (base label fallback), `ratio?` (default `"4 / 3"`). Main image + thumbnail strip (thumbnails only when >1). Composes `Hb.Image`.
+
+## Navigation
+
+- **`Hb.Tabs`** = `{ Root, Item, Panel }`. `Root.value` + `onChange` (controlled). `Item.value?` (falls back to index), `label`, `icon?`, `iconPosition?`, `disabled?`. `Panel.value` (shown when active), `keepMounted?`. role=tablist/tab/tabpanel.
+- **`Hb.Menu`** = `{ Root, Item }`. `Root` controlled list (`Omit onChange`), `Item.onClick` via context. Popover-style menu.
+- **`Hb.List`** = `{ Root, Item, ItemText, ItemIcon, ItemButton, ItemAvatar, Subheader }`. Semantic `<ul>` list with rich rows.
+- **`Hb.Table`** = `{ Container, Root, Head, Body, Row, Cell }`. `Root.size?` `"small" | "medium"`, `Container.variant?`, `Cell.align?`. Semantic `<table>` scaffolding.
+- **`Hb.Pagination`** — page controls. `count`, `page`, `onChange`, `size?` `"small" | "medium"`.
+- **`Hb.Link`** — styled `<a>`. `color?`, `underline?`, standard anchor attrs. (For SPA routing wrap a router `<Link>` or use `component`.)
+
+## Inputs & forms
+
+- **`Hb.Button`** — `variant?` `"primary" | "secondary" | "danger" | "ghost"`, `size?`, `fullWidth?`, `loading?`, `disabled?`, `startIcon?`/`endIcon?`. **`Hb.Button.Icon`** — icon-only, `variant?` `"default" | "danger"`, `size?`.
+- **`Hb.ButtonBase`** — unstyled button primitive (ripple/focus handling) to build on.
+- **`Hb.TextField`** — `size?` `"small" | "medium"`, `multiline?`, `error?`, `startAdornment?`/`endAdornment?`, label/helper via `Hb.Form`. Standard input attrs (`Omit size/ref`).
+- **`Hb.InputBase`** — bare input (no chrome) for custom fields.
+- **`Hb.Checkbox`** — `size?`, standard input attrs (`Omit size/type`).
+- **`Hb.Radio`** = `{ Root, Group }`. `Group` controlled via `value`/`onChange`; `Root.size?`.
+- **`Hb.ToggleButton`** + **`Hb.ToggleButtonGroup`** — `ToggleButton.variant?` `"outlined" | "segmented"`, `size?`, `selected`/`value`. Group manages exclusive/multi selection (segmented = the pill switch).
+- **`Hb.Autocomplete`** — generic combobox `Autocomplete<T>`. `options`, `value`, `onChange`, `getOptionLabel`, `renderOption?`, `size?`.
+- **`Hb.Form`** = `{ Control, Label, Helper, Select, Option, ControlLabel }`. Field scaffolding + a styled native-ish `Select`/`Option`. `Control.size?`, `Select` controlled.
+
+## Feedback & status
+
+- **`Hb.Alert`** — `variant?` `"standard" | "outlined"`, `severity` (info/success/warning/error), standard attrs.
+- **`Hb.Badge`** — count/dot overlay. `badgeContent`, `color?` `"primary" | "error"`, `max?`.
+- **`Hb.Chip`** — tag/pill. `label`, `variant?` `"filled" | "outlined" | "soft"`, `color?`, `size?`, `onDelete?`, `color` accepts any CSS color for a tonal tint.
+- **`Hb.Progress`** = `{ Circular, Linear }`. `Circular.size?` number|string. `Linear.variant?` `"indeterminate" | "determinate"`, `value?`, `color?`.
+- **`Hb.Skeleton`** — `variant?` `"text" | "circular" | "rectangular"`, `width`/`height`. (Also `HoBomSkeleton.Card` / `.List` pattern presets.)
+- **`Hb.Tooltip`** — `title`, `placement?`, wraps a child trigger.
+
+## Media
+
+- **`Hb.Image`** — responsive image with reserved aspect frame, shimmer→fade, lazy/priority, fallback. `src?`, `alt` (required), `ratio?` (default `"1 / 1"`), `priority?`, `objectFit?` `"cover" | "contain"`, `fallback?`.
+- **`Hb.Avatar`** — `variant?` `"circular" | "rounded" | "square"`, `src?`, `alt?`, children (initials).
+
+## Overlays
+
+- **`Hb.Dialog`** = `{ Root, Title, Content, Actions, ContentText }`. `Root.open`, `onClose`, `size?` `"xs" | "sm" | "md" | "lg"` (maps to max-width).
+- **`Hb.Drawer`** — side sheet. `open`, `onClose`, `anchor?`.
+- **`Hb.Popover`** — anchored floating surface. `open`, `anchorEl`, `onClose`, placement.
+
+## Infra (providers / global)
+
+- **`Hb.CssBaseline`** — global reset.
+- **`Hb.GlobalStyles`** — inject global CSS.
+- **`Hb.ColorSchemeProvider`** — light/dark scheme context. Also exported from root:
+  `ColorSchemeVars`, `useColorScheme`, `useColorSchemeStyles`, `ColorSchemeProvider`.
+
+---
+
+## Package-root patterns (NOT under `Hb.*`)
+
+Imported directly: `import { AppShell, EmptyState } from "hobom-design-system"`.
+
+- **`AppShell`** — desktop app shell (app bar + drawer + content). Props include `navItems: AppShellNavItem[]`, sections. Types: `AppShellNavItem`, `AppShellNavSection`, `NavEntry`. Layout consts: `DRAWER_WIDTH`, `DRAWER_WIDTH_COLLAPSED`, `APPBAR_HEIGHT`.
+- **`EmptyState`** — centered empty placeholder. `icon?`, `message`.
+- **`ErrorBoundary`** — React error boundary with fallback.
+- **`SuspenseLoader`** — Suspense wrapper with a centered spinner.
+- **`Funnel`, `Step`** — multi-step funnel primitives (types `FunnelProps`, `StepProps`).
+- **`OverlayProvider`, `OverlayContext`** — imperative overlay/modal mounting.
+- **`BottomSheetCTA`** — bottom-sheet call-to-action pattern.
+- **`ConfirmDialog`** — promise-based confirm dialog.
+- **`Sortable`** (+ `arrayMove`, `useDroppable`, drag event types) — drag-and-drop list.
+- **`HoBomSkeleton`** = `{ Card, List }` — skeleton presets.
+
+## Charts
+
+`import { createChart } from "hobom-design-system/charts"` (or the charts entry) —
+d3-based chart factory with line/area/bar/donut/radar renderers, axes, legend,
+hover overlay/tooltip. See `src/charts/`.
+
+---
+
+_Count check: Batch 1 (11) + Batch 2 passthrough (17, incl. ToggleButtonGroup) +
+Batch 2 compound (9) + Batch 3 patterns (6) + Infra (3) = the full `Hb` object in
+`src/components/index.ts`, plus the package-root patterns and charts above._

--- a/.claude/skills/hobom-schema/SKILL.md
+++ b/.claude/skills/hobom-schema/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: hobom-schema
+description: Use when importing from hobom-schema, reading source under packages/hobom-schema, or defining/validating runtime schemas with HoBomSchema.object/string/enum/array or parse/safeParse/Infer — the Zod-like validation kit used for API-boundary parsing.
+---
+
+# hobom-schema
+
+`hobom-schema` is a tiny, dependency-free runtime validation kit — a Zod-like
+API for describing the shape of untrusted data and turning it into typed,
+validated values. It ships only the primitives it needs: schema builders,
+`parse` / `safeParse`, and the `Infer` type helper. Import everything from the
+package root; never reach into internal paths.
+
+```ts
+import { HoBomSchema, type Infer } from "hobom-schema";
+import type { Schema, SafeParseResult, ValidationIssue } from "hobom-schema";
+import { SchemaError } from "hobom-schema";
+
+const animalSchema = HoBomSchema.object({
+  id: HoBomSchema.number(),
+  name: HoBomSchema.string().min(1),
+  status: HoBomSchema.enum(["protecting", "adopted"] as const),
+});
+
+type Animal = Infer<typeof animalSchema>;
+```
+
+## Golden rules
+
+1. **Validate at the boundary.** Untrusted data (API responses, form input,
+   `localStorage`) gets a schema at the edge, then flows inward as a typed
+   value. Don't sprinkle `as` casts or ad-hoc `typeof` checks downstream.
+2. **Derive types with `Infer`, never hand-write them.** `type T = Infer<typeof
+   schema>` keeps the runtime schema and the static type in lockstep — one
+   source of truth. Writing a matching `interface` by hand invites drift.
+3. **Prefer `safeParse` for advisory boundaries, `parse` for strict ones.** At
+   an API edge where backend drift shouldn't crash the screen, branch on
+   `safeParse`'s result (or use the app's `parseResponse`). Use `parse` when a
+   mismatch is a genuine programmer error you want to throw on.
+4. **Compose, don't extend the kit.** The validator set is intentionally small
+   (`.min` / `.max` / `.regex` / `.positive`). For anything more specific, reach
+   for `.regex(...)` — don't add `.email()`/`.url()` to the package.
+5. **Chain returns a new schema.** Validators are immutable; `.min(1)` yields a
+   fresh schema. Assign the chained result — never assume the base is mutated.
+
+## API catalog
+
+### Builders — `HoBomSchema.*`
+
+| Builder | Accepts | `Infer` type |
+| --- | --- | --- |
+| `.string()` | a `string` | `string` |
+| `.number()` | a finite `number` (rejects `NaN` / `Infinity`) | `number` |
+| `.boolean()` | a `boolean` | `boolean` |
+| `.date()` | a `Date.parse`-able **string**, kept as a string | `string` |
+| `.enum(values)` | a `string` in `values` (pass `as const`) | union of `values` |
+| `.object(shape)` | a non-null, non-array object | `{ [K]: Infer<shape[K]> }` |
+| `.array(element)` | an array of `element` | `Infer<element>[]` |
+
+### Validators (chainable; each takes an optional `message`)
+
+| Schema | Validators |
+| --- | --- |
+| `string()` | `.min(n)`, `.max(n)`, `.regex(pattern)` |
+| `number()` | `.min(n)`, `.max(n)`, `.positive()` |
+| others | none |
+
+`enum()` also exposes a read-only `.options` getter (the allowed values).
+
+### Base methods (on every schema)
+
+| Method | Behavior |
+| --- | --- |
+| `.parse(input)` | Returns the typed value, or **throws** `SchemaError`. |
+| `.safeParse(input)` | Returns `SafeParseResult<T>` — never throws. |
+| `.optional()` | Passes `undefined` through → `T \| undefined`. |
+| `.nullable()` | Passes `null` through → `T \| null`. |
+
+`.optional()` = `undefined` only; `.nullable()` = `null` only. Distinct — chain
+both if a field can be either.
+
+### Result and error shapes
+
+```ts
+type SafeParseResult<T> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly error: { readonly issues: readonly ValidationIssue[] } };
+
+interface ValidationIssue {
+  readonly message: string;
+}
+```
+
+`SchemaError extends Error` carries the same `.issues`; its message is every
+issue joined by `, `. Issue messages are path-prefixed as they bubble up —
+object fields with `"<key>: "`, array items with `"[<index>]: "`.
+
+### Example — parse vs safeParse
+
+```ts
+// strict: throws SchemaError on mismatch
+const animal = animalSchema.parse(payload);
+
+// advisory: branch on the result
+const result = animalSchema.safeParse(payload);
+if (result.success) {
+  use(result.data); // Animal
+} else {
+  const detail = result.error.issues.map((i) => i.message).join("; ");
+}
+```
+
+## `object()` strips unknown keys
+
+`object()` reads only the keys in its `shape`; extra input keys are **dropped**
+(output is built on a fresh `Object.create(null)`). There is no
+strict/passthrough mode. A missing key is validated as `undefined`, so mark
+possibly-absent fields `.optional()`.
+
+## The `parseResponse` boundary (app-owned, not in this package)
+
+This package does **not** export `parseResponse`. The Angel app wraps these
+primitives at its API edge in
+`apps/hobom-angel/src/shared/api/parse-response.api.ts`:
+`parseResponse(schema, context)` runs `safeParse`, and on a mismatch reports the
+contract violation and passes the raw payload through instead of throwing
+(advisory validation — backend drift is logged, not fatal). Use `parseResponse`
+in the app's API layer; use `parse` / `safeParse` directly for strict
+validation anywhere.
+
+## Verify
+
+```bash
+pnpm --filter hobom-schema typecheck
+pnpm --filter hobom-schema lint
+pnpm --filter hobom-schema test
+pnpm --filter hobom-schema test:coverage
+```

--- a/.claude/skills/hobom-utils/SKILL.md
+++ b/.claude/skills/hobom-utils/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: hobom-utils
+description: Use when importing from hobom-utils, reading source under packages/hobom-utils, or reaching for functional array/object/guard helpers (pipe, filter, map, groupBy, pick, isDefined, maskEmail…) — the data-last, tree-shakeable utility kit. Prefer these over hand-rolled loops or adding lodash.
+---
+
+# hobom-utils (Bom)
+
+`hobom-utils` is HoBom's in-house, Remeda-style functional utility library:
+data-last, tree-shakeable, fully typed, with **zero third-party runtime
+dependency**. 52 helpers spanning arrays, objects, guards, math, flow control,
+and PII masking. Before you write a `for` loop, a `.reduce`, or `import _ from
+"lodash"`, check the catalog — the helper almost certainly exists.
+
+```ts
+import { pipe, filter, map, groupBy, isDefined } from "hobom-utils";
+
+const names = pipe(
+  users,
+  filter((u) => u.active),
+  map((u) => u.name),
+);
+```
+
+## Golden rules
+
+1. **Prefer these over hand-rolled loops or lodash.** Do not add lodash/ramda,
+   and do not reinvent `groupBy`/`uniqBy`/`partition`/mask helpers inline. If a
+   utility is genuinely missing, add it to the package (one folder per function
+   under `src/packages/<name>/`, co-located `*.spec.ts`) rather than to an app.
+2. **Data-last + `pipe` for chains.** Compose with `pipe(value, op1, op2, …)`
+   using the data-last form of each op — no intermediate variables, no nested
+   calls. Reach for the data-first form only for a genuine one-off.
+3. **Import individually for tree-shaking.** `import { pipe, filter } from
+   "hobom-utils"` (or the `Bom` namespace). `"sideEffects": false` + per-function
+   modules mean only what you import ships.
+4. **Let guards narrow.** `isDefined`, `isString`, `isNumber`, `isNotNull`,
+   `isNullish`, `isTruthy` are type predicates — use them in `filter`/`when` so
+   the result type narrows automatically instead of casting.
+
+## Calling convention — data-first vs data-last
+
+Most helpers are **dual**: the same name accepts either shape, resolved at
+runtime by whether the first argument looks like data.
+
+```ts
+// data-first: pass the data as arg 1, get the result.
+filter(users, (u) => u.active); // → User[]
+
+// data-last: omit the data, get an operation (data) => result. For pipe.
+const onlyActive = filter((u) => u.active); // → (users) => User[]
+pipe(users, filter((u) => u.active));
+```
+
+Not everything is dual — three shapes exist:
+
+- **Dual (data-first + data-last):** `map` `filter` `flatMap` `forEach` `reduce`
+  `sortBy` `find` `findIndex` `take` `drop` `every` `some` `countBy` `groupBy`
+  `partition` `uniqBy` `sum` `pick` `omit` `mapValues` `prop` `values` `add`
+  `subtract` `clamp` `tap` `clone`.
+- **`pipe`-oriented (returns an op, or takes data first):** `when` `conditional`
+  — call `when(predicate, onTrue)` to get a `(data) => …` op, or
+  `when(data, predicate, onTrue)` eagerly.
+- **Unary / factory (no data-last form):** `uniq` `first` `last` `keys`
+  `entries` `identity` `not` `constant` all the `isX` guards, and
+  `maskEmail`/`maskName`/`maskPhone` take their argument directly.
+
+`map`/`filter`/`forEach`/`tap` are additionally **lazy** inside `pipe` — a
+single pass over the data instead of one array allocation per step.
+
+## Most reached-for
+
+| Need | Use |
+| --- | --- |
+| Transform each element | `map(fn)` |
+| Keep matching (narrows) | `filter(pred)` |
+| First match / its index | `find(pred)` · `findIndex(pred)` |
+| Group into buckets | `groupBy(fn)` → `Record<string, T[]>` |
+| Split by predicate | `partition(pred)` → `[pass, fail]` |
+| Dedupe | `uniq(arr)` · `uniqBy(fn)` |
+| Sort (immutable) | `sortBy(fn)` |
+| Compose a chain | `pipe(value, op1, op2, …)` |
+| Pluck a field | `prop("name")` / `map(prop("name"))` |
+| Pick/drop object keys | `pick(keys)` · `omit(keys)` |
+| Drop nullish (narrows) | `filter(isDefined)` |
+| Conditional transform | `when(pred, onTrue)` |
+| Clamp a number | `clamp({ min, max })` |
+| Mask PII for logs/UI | `maskEmail` · `maskName` · `maskPhone` |
+
+## Full catalog
+
+All 52 functions grouped by category, each with its data-first and data-last
+signatures and a terse example, live in
+**[references/functions.md](references/functions.md)** — read that instead of
+opening each `src/packages/<name>/<name>.ts`.
+
+## Verify
+
+```bash
+pnpm --filter hobom-utils typecheck
+pnpm --filter hobom-utils lint
+pnpm --filter hobom-utils test
+pnpm --filter hobom-utils test:coverage
+```

--- a/.claude/skills/hobom-utils/references/functions.md
+++ b/.claude/skills/hobom-utils/references/functions.md
@@ -1,0 +1,566 @@
+# hobom-utils — function catalog
+
+All 52 exported functions, grouped by category. Each entry lists its signatures
+(data-first and, where supported, data-last) and one terse example. Signatures
+are simplified for readability — the source carries the full generic overloads.
+
+**Convention key**
+
+- **Dual** — accepts data-first `fn(data, …)` or data-last `fn(…) → (data) => …`.
+  The data-last form is what you pass to `pipe`.
+- **Unary / factory** — takes its argument directly; no separate data-last form.
+- **Lazy** — fuses into a single pass when used inside `pipe` (`map`, `filter`,
+  `forEach`, `tap`).
+
+```ts
+import { pipe, filter, map /* … */ } from "hobom-utils";
+// or: import { Bom } from "hobom-utils"; Bom.filter(...)
+```
+
+---
+
+## Collections (arrays / iterables)
+
+### `map` — dual, lazy
+Transform each element. Equivalent to `Array.prototype.map`.
+```ts
+map<T, U>(data: T[], cb: (item: T, i: number, arr: T[]) => U): U[];
+map<T, U>(cb: (item: T, i: number, arr: T[]) => U): (data: T[]) => U[];
+```
+```ts
+map([1, 2, 3], (n) => n * 2); // [2, 4, 6]
+```
+
+### `filter` — dual, lazy
+Keep matching elements; narrows when given a type predicate.
+```ts
+filter<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): T[];
+filter<T, S extends T>(pred: (v: T) => v is S): (data: T[]) => S[];
+```
+```ts
+pipe(users, filter((u) => u.active));
+values.filter(isDefined); // T[] with undefined removed
+```
+
+### `find` — dual
+First element matching the predicate, else `undefined`. Narrows with a guard.
+```ts
+find<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): T | undefined;
+find<T>(pred: (v: T) => boolean): (data: T[]) => T | undefined;
+```
+```ts
+find(users, (u) => u.id === 7);
+```
+
+### `findIndex` — dual
+Index of the first match, or `-1`.
+```ts
+findIndex<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): number;
+findIndex<T>(pred: (v: T) => boolean): (data: T[]) => number;
+```
+```ts
+findIndex([4, 8, 15], (n) => n > 10); // 2
+```
+
+### `reduce` — dual
+Fold to a single value. Initial value is passed via the data-first `reduceImpl`
+seed / the accumulator callback.
+```ts
+reduce<T, U>(data: T[], cb: (acc: U, cur: T, i: number, arr: T[]) => U): U;
+reduce<T, U>(cb: (acc: U, cur: T, i: number, arr: T[]) => U): (data: T[]) => U;
+```
+```ts
+reduce([1, 2, 3], (acc, n) => acc + n); // 6
+```
+
+### `forEach` — dual, lazy
+Run a side effect per element; returns the (writable) data unchanged.
+```ts
+forEach<T>(data: T[], cb: (v: T, i: number, arr: T[]) => void): T[];
+forEach<T>(cb: (v: T, i: number, arr: T[]) => void): (data: T[]) => T[];
+```
+```ts
+pipe(rows, forEach((r) => log(r)));
+```
+
+### `every` — dual
+True if all elements pass; narrows the array type with a guard.
+```ts
+every<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): boolean;
+every<T, S extends T>(pred: (v: T) => v is S): (data: T[]) => data is S[];
+```
+```ts
+every([2, 4, 6], (n) => n % 2 === 0); // true
+```
+
+### `some` — dual
+True if any element passes.
+```ts
+some<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): boolean;
+some<T>(pred: (v: T) => boolean): (data: T[]) => boolean;
+```
+```ts
+some(users, (u) => u.isAdmin);
+```
+
+### `flatMap` — dual
+Map then flatten one level.
+```ts
+flatMap<T, U>(data: T[], cb: (item: T, i: number, arr: T[]) => U[]): U[];
+flatMap<T, U>(cb: (item: T, i: number, arr: T[]) => U[]): (data: T[]) => U[];
+```
+```ts
+flatMap([1, 2], (n) => [n, n * 10]); // [1, 10, 2, 20]
+```
+
+### `partition` — dual
+Split into `[pass, fail]`. Narrows the passing side with a guard.
+```ts
+partition<T>(data: T[], pred: (v: T, i: number, arr: T[]) => boolean): [T[], T[]];
+partition<T, S extends T>(pred: (v: T) => v is S): (data: T[]) => [S[], Exclude<T, S>[]];
+```
+```ts
+partition([1, 2, 3, 4], (n) => n % 2 === 0); // [[2, 4], [1, 3]]
+```
+
+### `countBy` — dual
+Count elements by the key each returns (skips `undefined` keys).
+```ts
+countBy<T, K extends PropertyKey>(data: T[], fn: (v: T, i: number, arr: T[]) => K | undefined): Record<K, number>;
+countBy<T, K extends PropertyKey>(fn: (v: T) => K | undefined): (data: T[]) => Record<K, number>;
+```
+```ts
+countBy(words, (w) => w[0]); // { a: 3, b: 1, … }
+```
+
+### `groupBy` — dual
+Group into `Record<string, T[]>` by the returned key.
+```ts
+groupBy<T>(data: T[], fn: (item: T, i: number, arr: T[]) => string): Record<string, T[]>;
+groupBy<T>(fn: (item: T) => string): (data: T[]) => Record<string, T[]>;
+```
+```ts
+groupBy(users, (u) => u.team); // { alpha: [...], beta: [...] }
+```
+
+### `sortBy` — dual
+Immutable sort by the returned `number | string` key (original not mutated).
+```ts
+sortBy<T>(data: T[], fn: (item: T) => number | string): T[];
+sortBy<T>(fn: (item: T) => number | string): (data: T[]) => T[];
+```
+```ts
+sortBy(users, (u) => u.age);
+```
+
+### `uniq` — unary
+Dedupe by `===`, keeping first occurrence.
+```ts
+uniq<T>(data: T[]): T[];
+```
+```ts
+uniq([1, 1, 2, 3, 3]); // [1, 2, 3]
+```
+
+### `uniqBy` — dual
+Dedupe by a derived key, keeping first occurrence.
+```ts
+uniqBy<T, K>(data: T[], fn: (item: T) => K): T[];
+uniqBy<T, K>(fn: (item: T) => K): (data: T[]) => T[];
+```
+```ts
+uniqBy(users, (u) => u.id);
+```
+
+### `take` — dual
+First `count` elements.
+```ts
+take<T>(data: T[], count: number): T[];
+take<T>(count: number): (data: T[]) => T[];
+```
+```ts
+take([1, 2, 3, 4], 2); // [1, 2]
+```
+
+### `drop` — dual
+All but the first `count` elements.
+```ts
+drop<T>(data: T[], count: number): T[];
+drop<T>(count: number): (data: T[]) => T[];
+```
+```ts
+drop([1, 2, 3, 4], 2); // [3, 4]
+```
+
+### `first` — unary
+First element (typed as the element type for non-empty tuples, else `T | undefined`).
+```ts
+first<T>(data: T[]): T | undefined;
+```
+```ts
+first([10, 20]); // 10
+```
+
+### `last` — unary
+Last element.
+```ts
+last<T>(data: T[]): T | undefined;
+```
+```ts
+last([10, 20]); // 20
+```
+
+---
+
+## Objects
+
+### `pick` — dual
+New object with only the given keys.
+```ts
+pick<T, K extends keyof T>(data: T, keys: readonly K[]): Pick<T, K>;
+pick<T, K extends keyof T>(keys: readonly K[]): (data: T) => Pick<T, K>;
+```
+```ts
+pick(user, ["id", "name"]);
+```
+
+### `omit` — dual
+New object without the given keys.
+```ts
+omit<T, K extends keyof T>(data: T, keys: readonly K[]): Omit<T, K>;
+omit<T, K extends keyof T>(keys: readonly K[]): (data: T) => Omit<T, K>;
+```
+```ts
+omit(user, ["password"]);
+```
+
+### `keys` — unary
+Own string keys (typed `(keyof T & string)[]`).
+```ts
+keys<T extends object>(data: T): (keyof T & string)[];
+```
+```ts
+keys({ a: 1, b: 2 }); // ["a", "b"]
+```
+
+### `values` — dual
+Own values.
+```ts
+values<T extends object>(v: T): Values<T>;
+values(): <T extends object>(v: T) => Values<T>;
+```
+```ts
+values({ a: 1, b: 2 }); // [1, 2]
+```
+
+### `entries` — unary
+`[key, value]` pairs.
+```ts
+entries<T extends object>(data: T): [keyof T & string, T[keyof T]][];
+```
+```ts
+entries({ a: 1 }); // [["a", 1]]
+```
+
+### `mapValues` — dual
+Transform each value, keeping keys.
+```ts
+mapValues<T, U>(data: T, fn: (v: T[keyof T], key: keyof T & string, data: T) => U): Record<keyof T & string, U>;
+mapValues<T, U>(fn: (v: T[keyof T], key: keyof T & string, data: T) => U): (data: T) => Record<keyof T & string, U>;
+```
+```ts
+mapValues({ a: 1, b: 2 }, (n) => n * 10); // { a: 10, b: 20 }
+```
+
+### `prop` — dual
+Read a property by key. Handy as `map(prop("name"))`.
+```ts
+prop<T, K extends keyof T>(data: T, key: K): T[K];
+prop<T, K extends keyof T>(key: K): (data: T) => T[K];
+```
+```ts
+map(users, prop("name")); // string[]
+```
+
+---
+
+## Guards (type predicates — unary)
+
+Each narrows its argument's type. Ideal inside `filter`/`when`.
+
+### `isArray`
+```ts
+isArray<T>(value: T | readonly unknown[]): value is readonly unknown[];
+```
+```ts
+isArray(x) ? x.length : 0;
+```
+
+### `isDate`
+```ts
+isDate(v: unknown): v is Date;
+```
+```ts
+isDate(v) && v.getTime();
+```
+
+### `isDefined`
+Not `undefined` (keeps `null`).
+```ts
+isDefined<T>(value: T): value is Exclude<T, undefined>;
+```
+```ts
+list.filter(isDefined);
+```
+
+### `isEmpty`
+`""`, `[]`, empty `Map`/`Set`/object.
+```ts
+isEmpty(value: string): value is "";
+isEmpty<T>(value: readonly T[]): value is [];
+isEmpty(value: Map | Set | Record<string, unknown>): boolean;
+```
+```ts
+isEmpty([]); // true
+```
+
+### `isFunction`
+```ts
+isFunction<T>(v: Function | T): v is ExactlyFunction<T>;
+```
+```ts
+isFunction(x) && x();
+```
+
+### `isNotNull`
+Not `null` (keeps `undefined`).
+```ts
+isNotNull<T>(value: T | null): value is T;
+```
+```ts
+list.filter(isNotNull);
+```
+
+### `isNullish`
+`null` or `undefined`.
+```ts
+isNullish<T>(v: T | null | undefined): v is null | undefined;
+```
+```ts
+when(x, isNullish, constant(fallback));
+```
+
+### `isNumber`
+```ts
+isNumber<T>(v: T | number): v is number;
+```
+```ts
+isNumber(x) && x.toFixed(2);
+```
+
+### `isString`
+```ts
+isString<T>(v: T | string): v is string;
+```
+```ts
+isString(x) && x.trim();
+```
+
+### `isTruthy`
+Excludes `0 | null | undefined | false | ""`.
+```ts
+isTruthy<T>(v: T): boolean; // narrows out falsy members
+```
+```ts
+list.filter(isTruthy);
+```
+
+---
+
+## Function / flow
+
+### `pipe` — value-first composition
+Threads a value through a chain of data-last operations, left to right. Fuses
+adjacent lazy ops (`map`/`filter`/`forEach`/`tap`) into a single pass.
+```ts
+pipe<A, B>(value: A, op1: (input: A) => B): B;
+pipe<A, B, C>(value: A, op1: (input: A) => B, op2: (input: B) => C): C;
+// … up to 15 operations
+```
+```ts
+pipe(
+  users,
+  filter((u) => u.active),
+  sortBy((u) => u.age),
+  map(prop("name")),
+);
+```
+
+### `curry` — internal helper
+Wraps an impl so it accepts both data-first and data-last calls (and optional
+lazy evaluator). Used to build the dual helpers above; rarely called directly.
+```ts
+curry(impl, args, lazy?): unknown;
+```
+
+### `identity` — unary
+Returns its input.
+```ts
+identity<T>(value: T): T;
+```
+```ts
+map(xs, identity); // shallow copy passthrough
+```
+
+### `constant` — factory
+Returns a function that always yields `v`.
+```ts
+constant<T>(v: T): (...args: unknown[]) => T;
+```
+```ts
+when(x, isNullish, constant(0));
+```
+
+### `conditional` — data-first, returns an op
+Runs the first matching `[when, then]` case. `conditional.defaultCase(fn?)`
+provides a catch-all. Throws if nothing matches and no default is given.
+```ts
+conditional(data, case0, …case9): Return;
+conditional(case0, …case9): (data) => Return; // for pipe
+conditional.defaultCase(then?): Case;
+```
+```ts
+conditional(
+  n,
+  [(x) => x < 0, () => "neg"],
+  [(x) => x === 0, () => "zero"],
+  conditional.defaultCase(() => "pos"),
+);
+```
+
+### `when` — predicate-first
+If `predicate(data)` holds, run `onTrue`; else return data unchanged (or run
+`onFalse`). Two-arg form returns a `(data) => …` op for `pipe`.
+```ts
+when<T>(predicate, onTrue): (data: T) => …;
+when<T>(predicate, { onTrue, onFalse }): (data: T) => …;
+when<T>(data, predicate, onTrue, ...extraArgs): …;   // eager
+```
+```ts
+pipe(input, when(isNullish, constant(42)));
+when(x, (n) => n > 3, { onTrue: add(1), onFalse: (n) => n * 2 });
+```
+
+### `tap` — dual, lazy
+Run a side effect on the value, return it unchanged. For debugging pipes.
+```ts
+tap<T>(data: T, fn: (item: T) => void): T;
+tap<T>(fn: (item: T) => void): (data: T) => T;
+```
+```ts
+pipe(result, tap(console.log));
+```
+
+### `not` — factory
+Negates a predicate.
+```ts
+not<T>(predicate: (value: T) => boolean): (value: T) => boolean;
+```
+```ts
+filter(users, not((u) => u.active)); // inactive users
+```
+
+---
+
+## Math
+
+### `add` — dual
+Adds two numbers (or two bigints).
+```ts
+add(target: number, added: number): number;
+add(target: number): (added: number) => number;
+```
+```ts
+add(2, 3); // 5
+map([1, 2, 3], add(10)); // [11, 12, 13]
+```
+
+### `subtract` — dual
+Subtracts. Data-last form is `subtract(subtrahend) => (value) => …`.
+```ts
+subtract(value: number, subtrahend: number): number;
+subtract(subtrahend: number): (value: number) => number;
+```
+```ts
+subtract(10, 3); // 7
+map([10, 20], subtract(5)); // [5, 15]
+```
+
+### `sum` — dual
+Sum of a number/bigint iterable.
+```ts
+sum<T extends Iterable<number>>(data: T): number;
+sum(): <T extends Iterable<number>>(data: T) => number;
+```
+```ts
+sum([1, 2, 3]); // 6
+pipe(nums, sum());
+```
+
+### `clamp` — dual
+Clamp within inclusive `{ min?, max? }` bounds.
+```ts
+clamp(v: number, params: { min?: number; max?: number }): number;
+clamp(params: { min?: number; max?: number }): (v: number) => number;
+```
+```ts
+clamp(120, { min: 0, max: 100 }); // 100
+map(scores, clamp({ min: 0, max: 100 }));
+```
+
+---
+
+## PII masking (unary)
+
+### `maskEmail`
+Keeps the first local-part char and the full domain; single-char local → `*`;
+no usable local part → fully masked.
+```ts
+maskEmail(email: string): string;
+```
+```ts
+maskEmail("foxmon1524@gmail.com"); // "f*********@gmail.com"
+```
+
+### `maskName`
+Reveals only first and last characters (counts by code point).
+```ts
+maskName(name: string): string;
+```
+```ts
+maskName("홍길동"); // "홍*동"   maskName("남궁민수"); // "남**수"
+```
+
+### `maskPhone`
+Strips non-digits, keeps leading prefix and last four digits; `<7` digits →
+fully masked.
+```ts
+maskPhone(phone: string): string;
+```
+```ts
+maskPhone("010-1234-1234"); // "010-****-1234"
+```
+
+---
+
+## Misc
+
+### `clone` — dual
+Deep clone of the input.
+```ts
+clone<T>(data: T): T;
+clone(): <T>(data: T) => T;
+```
+```ts
+const copy = clone(state);
+```

--- a/apps/hobom-angel/README.md
+++ b/apps/hobom-angel/README.md
@@ -1,0 +1,76 @@
+# hobom-angel
+
+The consumer-facing web app for animal fostering and adoption. Visitors browse
+animals looking for a home, read a full profile, and submit an adoption or foster
+application; shelters get a public microsite. Desktop-first, built on the shared
+HoBom stack.
+
+## Stack
+
+- **React 19** + **TypeScript** (strict) + **Vite**
+- **StyleX** for styling — no bespoke CSS files; compose the design system
+- **hobom-design-system** (`Hb.*`) for all UI, **hobom-data** for fetching/caching,
+  **hobom-schema** for API-boundary validation, **hobom-utils** for helpers
+- **MSW** for mocked API scenarios, **Playwright** for e2e
+- **Feature-Sliced Design** with custom import-boundary lint rules
+
+## Getting started
+
+```bash
+pnpm install                     # from the monorepo root
+pnpm --filter hobom-angel dev    # Vite dev server
+```
+
+To run against mocked APIs (the MSW handlers under `src/mocks`):
+
+```bash
+VITE_ENABLE_MSW=true pnpm --filter hobom-angel dev
+```
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `dev` | Vite dev server |
+| `build` | Production build |
+| `typecheck` | `tsc -b` |
+| `lint` | ESLint (`--max-warnings=0`, incl. FSD boundaries) |
+| `test` | Vitest unit/component tests |
+| `test:coverage` | Vitest with coverage |
+| `test:e2e` | Playwright end-to-end tests |
+| `preview` | Serve the production build |
+
+```bash
+pnpm --filter hobom-angel typecheck
+pnpm --filter hobom-angel lint
+pnpm --filter hobom-angel test -- --run
+```
+
+E2e runs against a built preview with mocks enabled:
+
+```bash
+VITE_ENABLE_MSW=true pnpm --filter hobom-angel build
+pnpm --filter hobom-angel preview --port 4173
+pnpm --filter hobom-angel exec playwright test
+```
+
+## Architecture (FSD)
+
+Layers, from top to bottom — a layer may only import from the ones below it, and
+cross-slice imports within a layer are forbidden (enforced by
+`eslint-rules/fsd-boundaries.js`):
+
+| Layer | Contents here |
+| --- | --- |
+| `apps` | Router, providers, shell layout (`apps/ui`) |
+| `pages` | Route screens: `landing`, `animals`, `animal-detail`, `apply-adoption`, `login`, `signup` |
+| `widgets` | Composite blocks: `global-nav` |
+| `features` | User actions: `browse-animals`, `animal-detail`, `apply-adoption`, `login`, `signup`, `session` |
+| `entities` | Domain models + API + anti-corruption libs: `animal`, `adoption`, `questionnaire`, `user`, `auth` |
+| `shared` | Cross-cutting `api` / `config` / `lib` / `model` / `ui` segments (no slices) |
+
+Conventions: business logic lives in custom hooks (`model/`), pure functions in
+`lib/` with co-located `*.spec.ts`, and UI components render only. New shared UI
+is added to the design system, not hand-rolled here. See the `hobom-ds`,
+`hobom-data`, `hobom-schema`, and `hobom-utils` skills under `.claude/skills/`
+for the package APIs.

--- a/apps/hobom-system/README.md
+++ b/apps/hobom-system/README.md
@@ -1,0 +1,69 @@
+# hobom-system
+
+The internal operations platform — a single desktop app that hosts the tooling
+the team runs on. It bundles several domains behind one shell:
+
+- **Projects** — backlog, board, kanban, issues, sprints, project dashboards and settings
+- **Wiki** — spaces and pages with an editor, version history, comments, labels, trash, and search
+- **Studio** — a design-to-code canvas with layers, an inspector, an insert palette, and a code panel
+- **Privacy-law knowledge base** — study, exams, version diffs, a document viewer, and a Q&A chat
+- **Operations dashboards** — system health, logs, error monitoring, DLQ management, daily todos, notifications, and messaging
+- **Admin & misc** — pending-user approvals, menu recommendation/pick, scheduled ("future") messages, and notes
+
+Built on the shared HoBom stack, desktop-first.
+
+## Stack
+
+- **React 19** + **TypeScript** (strict) + **Vite**
+- **StyleX** for styling — compose the design system, no bespoke CSS
+- **hobom-design-system** (`Hb.*`), **hobom-data** (fetching/caching),
+  **hobom-schema** (validation), **hobom-utils** (helpers)
+- **MSW** for mocked API scenarios, **knip** for dead-code detection
+- **Feature-Sliced Design** with custom import-boundary lint rules
+
+## Getting started
+
+```bash
+pnpm install                      # from the monorepo root
+pnpm --filter hobom-system dev    # Vite dev server
+```
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `dev` | Vite dev server |
+| `build` | Production build |
+| `typecheck` | `tsc -b` |
+| `lint` | ESLint (`--max-warnings=0`, incl. FSD boundaries) |
+| `test` | Vitest unit/component tests |
+| `test:coverage` | Vitest with coverage |
+| `knip` | Report unused files/exports/dependencies |
+| `preview` | Serve the production build |
+
+```bash
+pnpm --filter hobom-system typecheck
+pnpm --filter hobom-system lint
+pnpm --filter hobom-system test -- --run
+```
+
+## Architecture (FSD)
+
+Layers, from top to bottom — a layer may only import from the ones below it, and
+cross-slice imports within a layer are forbidden (enforced by
+`eslint-rules/fsd-boundaries.js`):
+
+| Layer | Contents |
+| --- | --- |
+| `apps` | Router, providers, shell layout (`apps/ui`) |
+| `pages` | Route screens per domain (`project-*`, `wiki-*`, `studio-*`, `privacy-law-*`, `dashboard-*`, `admin-users`, `message*`, `note`, …) |
+| `widgets` | Composite blocks: per-domain workspaces (`kanban-board-workspace`, `wiki-page-view-workspace`, `canvas`, `inspector`, `notification-center`, …) |
+| `features` | User actions (`create-issue`, `kanban-board`, `wiki-page-editor`, `privacy-law-*`, `send-future-message`, `manage-pending-users`, …) |
+| `entities` | Domain models + API + anti-corruption libs (`project`, `issue`, `sprint`, `wiki-page`, `wiki-space`, `document`, `privacy-law`, `notification`, `user`, `dlq`, `log`, …) |
+| `shared` | Cross-cutting `api` / `config` / `lib` / `model` / `ui` segments (no slices) |
+
+Conventions: business logic lives in custom hooks (`model/`), pure functions in
+`lib/` with co-located `*.spec.ts`, and UI renders only. New shared UI is added
+to the design system, not hand-rolled here. See the `hobom-ds`, `hobom-data`,
+`hobom-schema`, and `hobom-utils` skills under `.claude/skills/` for the package
+APIs, and `hobom-fsd` for the boundary rules.

--- a/packages/hobom-data/README.md
+++ b/packages/hobom-data/README.md
@@ -1,0 +1,149 @@
+# hobom-data
+
+A lean, in-house data-fetching and caching library for HoBom — a small
+TanStack-Query-shaped alternative.
+
+## Why
+
+We depend on very little of TanStack Query's surface, but pull in its full
+runtime. `hobom-data` reimplements the parts we actually use — query cache,
+staleness, dedup, invalidation, mutations, infinite/suspense variants — behind a
+familiar API. That keeps the bundle small, the behavior ours to change, and the
+migration cost near zero: the hook and option names mirror the ones the team
+already knows.
+
+The public surface is the `HoBom` namespace plus flat named exports (imported
+directly to make migration mechanical). MUI-style, the cache client is called a
+**DataLot**.
+
+## Installation
+
+Part of the pnpm workspace, consumed via the workspace protocol:
+
+```jsonc
+// consumer package.json
+"dependencies": {
+  "hobom-data": "workspace:*"
+}
+```
+
+## Import
+
+```ts
+import { HoBom } from "hobom-data";
+// or flat named exports (migration-friendly):
+import { useQuery, useMutation, queryOptions, DataLot, DataLotProvider } from "hobom-data";
+```
+
+`HoBom.DataKernel.useQuery` and the flat `useQuery` are the same function.
+`HoBom.DataLot` is the cache class with `.Provider`, `.queryOptions`,
+`.mutationOptions`, and `.infiniteQueryOptions` attached as statics.
+
+## Quick start
+
+### 1. Wrap the tree in a provider
+
+One `DataLot` instance per app. Pass it to the provider as `client`.
+
+```tsx
+import { DataLot, DataLotProvider } from "hobom-data";
+
+const dataLot = new DataLot({
+  defaultOptions: { queries: { staleTime: 60_000, retry: 1 } },
+});
+
+function Root() {
+  return (
+    <DataLotProvider client={dataLot}>
+      <App />
+    </DataLotProvider>
+  );
+}
+```
+
+### 2. Read data with `useQuery`
+
+```tsx
+import { useQuery, queryOptions } from "hobom-data";
+
+const shelterQuery = (id: string) =>
+  queryOptions({
+    queryKey: ["shelter", id],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(`/api/shelters/${id}`, { signal });
+      return res.json() as Promise<Shelter>;
+    },
+  });
+
+function ShelterName({ id }: { id: string }) {
+  const { data, status, isError, error } = useQuery(shelterQuery(id));
+
+  if (status === "pending") return <Spinner />;
+  if (isError) return <ErrorText>{error.message}</ErrorText>;
+  return <h1>{data.name}</h1>;
+}
+```
+
+`useQuery` **does not throw** — you branch on `status` / `isError`. See gotchas.
+
+### 3. Write data with `useMutation`
+
+```tsx
+import { useMutation, useDataLot } from "hobom-data";
+
+function AdoptButton({ animalId }: { animalId: string }) {
+  const dataLot = useDataLot();
+  const { mutate, isPending } = useMutation({
+    mutationFn: (id: string) => fetch(`/api/animals/${id}/adopt`, { method: "POST" }),
+    onSuccess: () => dataLot.invalidateQueries({ queryKey: ["animals"] }),
+  });
+
+  return (
+    <button disabled={isPending} onClick={() => mutate(animalId)}>
+      Adopt
+    </button>
+  );
+}
+```
+
+## API overview
+
+| Export | Kind | Purpose |
+| --- | --- | --- |
+| `DataLot` | class | The cache client. `new DataLot({ defaultOptions })`. |
+| `DataLotProvider` | component | Provides a `DataLot` via context. Prop: `client`. |
+| `useDataLot()` | hook | Reads the `DataLot` from context (throws if unprovided). |
+| `useQuery` | hook | Read a query. Returns state; **never throws**. |
+| `useSuspenseQuery` | hook | Same, but suspends / throws to an `ErrorBoundary`. |
+| `useQueries` / `useSuspenseQueries` | hook | Array of queries in one call. |
+| `useInfiniteQuery` | hook | Paginated query with `pages` / `fetchNextPage`. |
+| `useSuspenseInfiniteQuery` | hook | Suspense variant of the above. |
+| `useMutation` | hook | Write. Returns `mutate` / `mutateAsync` + status. |
+| `queryOptions` | fn | Typed, reusable query-options factory. |
+| `mutationOptions` | fn | Typed, reusable mutation-options factory. |
+| `infiniteQueryOptions` | fn | Typed infinite-query factory (`getNextPageParam` + `initialPageParam`). |
+
+**`DataLot` cache operations** (via `useDataLot()`): `getQueryData`,
+`setQueryData`, `invalidateQueries`, `prefetchQuery`, `cancelQueries`, `clear`.
+
+## Gotchas
+
+- **`useQuery` never throws.** Branch on `status === "pending" | "success" |
+  "error"` (or `isError`) — the error is on `result.error`, not thrown. Use
+  `useSuspenseQuery` if you want it thrown to a `<Suspense>` / `<ErrorBoundary>`.
+- **`isLoading` is `false` on the very first render.** It is
+  `status === "pending" && fetchStatus === "fetching"`, and the fetch only
+  starts in an effect (after mount). For initial gating / auth guards, branch on
+  **`status === "pending"`**, not `isLoading`.
+- **Provider prop is `client`**, and `new DataLot(...)` takes
+  `{ defaultOptions }`, not options directly.
+- **`infiniteQueryOptions` requires `initialPageParam` and `getNextPageParam`.**
+
+## Scripts
+
+```bash
+pnpm --filter hobom-data typecheck
+pnpm --filter hobom-data lint
+pnpm --filter hobom-data test
+pnpm --filter hobom-data test:coverage
+```

--- a/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.doc.ts
+++ b/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.doc.ts
@@ -1,0 +1,72 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "Breadcrumb",
+  description:
+    "A navigation trail of the current location within a hierarchy. Renders a semantic <nav><ol> and interleaves a separator between items; the consumer supplies the links.",
+  features: [
+    "Renders <nav aria-label> wrapping an <ol> — accessible landmark and list semantics for free",
+    "Inserts the separator between items only (never trailing), each in an aria-hidden <li>",
+    "Custom `separator` node (string, glyph, or icon); defaults to \"/\"",
+    "`current` item gets aria-current=\"page\" and primary weight-600 styling; others stay secondary",
+    "Item children color: inherit — pass a <Link>/<a> or plain text and it picks up the trail color",
+  ],
+  props: [
+    {
+      name: "Root.separator",
+      type: "ReactNode",
+      description: "Node rendered between items.",
+      default: '"/"',
+    },
+    {
+      name: "Root.aria-label",
+      type: "string",
+      description: "Landmark label for the <nav>.",
+      default: '"위치"',
+    },
+    { name: "Root.children", type: "ReactNode", description: "Breadcrumb.Item elements." },
+    {
+      name: "Item.current",
+      type: "boolean",
+      description: "Marks the current location — sets aria-current=\"page\" and primary styling.",
+      default: "false",
+    },
+    {
+      name: "Item.children",
+      type: "ReactNode",
+      description: "A link or plain text for this crumb.",
+    },
+  ],
+  examples: [
+    {
+      label: "Basic trail with router links",
+      code: `<Hb.Breadcrumb.Root>
+  <Hb.Breadcrumb.Item>
+    <Link to="/">홈</Link>
+  </Hb.Breadcrumb.Item>
+  <Hb.Breadcrumb.Item>
+    <Link to="/shelter">보호소</Link>
+  </Hb.Breadcrumb.Item>
+  <Hb.Breadcrumb.Item current>우리 아이들</Hb.Breadcrumb.Item>
+</Hb.Breadcrumb.Root>`,
+    },
+    {
+      label: "Custom separator",
+      code: `<Hb.Breadcrumb.Root separator="›">
+  <Hb.Breadcrumb.Item>
+    <Link to="/adopt">입양</Link>
+  </Hb.Breadcrumb.Item>
+  <Hb.Breadcrumb.Item current>신청 내역</Hb.Breadcrumb.Item>
+</Hb.Breadcrumb.Root>`,
+    },
+  ],
+  accessibility: [
+    "Root renders <nav aria-label=\"위치\"> — a labelled navigation landmark; override aria-label per app locale/context.",
+    "The trail is an <ol> of <li>; separators are aria-hidden so screen readers skip them.",
+    "The `current` item carries aria-current=\"page\" and is non-interactive (render it as plain text, not a link).",
+  ],
+  notes: [
+    "Breadcrumb.Item only wraps and styles — put a react-router <Link> or an <a> inside for navigation.",
+    "Item children use color: inherit; a link renders in the trail color unless the consumer overrides it.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,39 @@
+import { Breadcrumb } from "./Breadcrumb";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Breadcrumb",
+  component: Breadcrumb.Root,
+} satisfies Meta<typeof Breadcrumb.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <Breadcrumb.Root>
+      <Breadcrumb.Item>
+        <a href="#">홈</a>
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>
+        <a href="#">보호소</a>
+      </Breadcrumb.Item>
+      <Breadcrumb.Item current>우리 아이들</Breadcrumb.Item>
+    </Breadcrumb.Root>
+  ),
+};
+
+export const CustomSeparator: Story = {
+  render: () => (
+    <Breadcrumb.Root separator="›">
+      <Breadcrumb.Item>
+        <a href="#">홈</a>
+      </Breadcrumb.Item>
+      <Breadcrumb.Item>
+        <a href="#">입양</a>
+      </Breadcrumb.Item>
+      <Breadcrumb.Item current>신청 내역</Breadcrumb.Item>
+    </Breadcrumb.Root>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/hobom-design-system/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,101 @@
+import {
+  Children,
+  type HTMLAttributes,
+  type LiHTMLAttributes,
+  type ReactNode,
+} from "react";
+import * as stylex from "@stylexjs/stylex";
+
+const styles = stylex.create({
+  root: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  list: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  item: {
+    display: "inline-flex",
+    alignItems: "center",
+    color: "var(--hb-color-text-secondary)",
+  },
+  current: {
+    color: "var(--hb-color-text-primary)",
+    fontWeight: 600,
+  },
+  separator: {
+    display: "inline-flex",
+    alignItems: "center",
+    color: "var(--hb-color-text-disabled)",
+    userSelect: "none",
+  },
+});
+
+interface RootProps extends HTMLAttributes<HTMLElement> {
+  /** Node rendered between items. Defaults to `"/"`. */
+  separator?: ReactNode;
+  children?: ReactNode;
+}
+
+const Root = ({
+  separator = "/",
+  "aria-label": ariaLabel = "위치",
+  className,
+  style,
+  children,
+  ...rest
+}: RootProps) => {
+  const sx = stylex.props(styles.root);
+  const sepSx = stylex.props(styles.separator);
+
+  const items = Children.toArray(children).flatMap((child, index) =>
+    index === 0
+      ? [child]
+      : [
+          <li key={`separator-${index}`} aria-hidden="true" {...sepSx}>
+            {separator}
+          </li>,
+          child,
+        ],
+  );
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      <ol {...stylex.props(styles.list)}>{items}</ol>
+    </nav>
+  );
+};
+
+interface ItemProps extends LiHTMLAttributes<HTMLLIElement> {
+  /** Marks the current location — sets `aria-current="page"` and primary styling. */
+  current?: boolean;
+  children?: ReactNode;
+}
+
+const Item = ({ current = false, className, style, children, ...rest }: ItemProps) => {
+  const sx = stylex.props(styles.item, current && styles.current);
+
+  return (
+    <li
+      aria-current={current ? "page" : undefined}
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {children}
+    </li>
+  );
+};
+
+export const Breadcrumb = { Root, Item };

--- a/packages/hobom-design-system/src/components/Breadcrumb/index.ts
+++ b/packages/hobom-design-system/src/components/Breadcrumb/index.ts
@@ -1,0 +1,1 @@
+export * from "./Breadcrumb";

--- a/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.doc.ts
+++ b/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.doc.ts
@@ -1,0 +1,46 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "DescriptionList",
+  description:
+    "A term/description attribute grid: the aligned label-and-value list that detail screens hand-roll (an animal's traits, a shelter's facts). Renders a semantic <dl> with <dt>/<dd> pairs.",
+  features: [
+    "`grid` layout aligns terms and descriptions into two columns; `stacked` stacks each pair vertically",
+    "Terms are Text body2 / secondary, descriptions Text body1 / primary — no hand-written typography",
+    "Renders semantic <dl><dt><dd>; Root spreads the rest of the dl props",
+    "Descriptions wrap and shrink safely (min-width: 0)",
+  ],
+  props: [
+    {
+      name: "layout",
+      type: '"grid" | "stacked"',
+      description: "Two aligned columns, or each term/description pair stacked vertically.",
+      default: '"grid"',
+    },
+    { name: "children", type: "ReactNode", description: "DescriptionList.Item rows." },
+  ],
+  examples: [
+    {
+      label: "Grid of attributes",
+      code: `<Hb.DescriptionList.Root>
+  <Hb.DescriptionList.Item term="성별">수컷</Hb.DescriptionList.Item>
+  <Hb.DescriptionList.Item term="나이">3살 추정</Hb.DescriptionList.Item>
+  <Hb.DescriptionList.Item term="중성화">완료</Hb.DescriptionList.Item>
+</Hb.DescriptionList.Root>`,
+    },
+    {
+      label: "Stacked (long descriptions)",
+      code: `<Hb.DescriptionList.Root layout="stacked">
+  <Hb.DescriptionList.Item term="성격">사람을 잘 따르는 온순한 성격입니다.</Hb.DescriptionList.Item>
+</Hb.DescriptionList.Root>`,
+    },
+  ],
+  accessibility: [
+    "Renders a semantic <dl> with <dt>/<dd> pairs — screen readers announce the term/description relationship.",
+    "In grid layout each Item emits a <dt> and <dd> as direct grid cells; keep one description per term.",
+  ],
+  notes: [
+    "Compose inside Hb.SectionCard for a titled attribute block.",
+    "Prefer `stacked` when descriptions are long paragraphs rather than short values.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,0 +1,41 @@
+import { DescriptionList } from "./DescriptionList";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/DescriptionList",
+  component: DescriptionList.Root,
+  parameters: {
+    // The term (dt) uses text.secondary (#737373); on the canvas at 13px it
+    // sits at ~4.19:1 — the DS-wide small-secondary-text tradeoff. Other a11y
+    // checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof DescriptionList.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Grid: Story = {
+  render: () => (
+    <DescriptionList.Root style={{ maxWidth: 420 }}>
+      <DescriptionList.Item term="성별">수컷</DescriptionList.Item>
+      <DescriptionList.Item term="나이">3살 추정</DescriptionList.Item>
+      <DescriptionList.Item term="체중">8.4kg</DescriptionList.Item>
+      <DescriptionList.Item term="중성화">완료</DescriptionList.Item>
+    </DescriptionList.Root>
+  ),
+};
+
+export const Stacked: Story = {
+  render: () => (
+    <DescriptionList.Root layout="stacked" style={{ maxWidth: 420 }}>
+      <DescriptionList.Item term="성격">
+        사람을 잘 따르고 산책을 좋아하는 온순한 성격입니다.
+      </DescriptionList.Item>
+      <DescriptionList.Item term="건강 상태">
+        기저 질환 없이 건강하며 예방접종을 모두 마쳤습니다.
+      </DescriptionList.Item>
+    </DescriptionList.Root>
+  ),
+};

--- a/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/hobom-design-system/src/components/DescriptionList/DescriptionList.tsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, type HTMLAttributes, type ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Text } from "../Text/Text";
+
+type DescriptionListLayout = "grid" | "stacked";
+
+const DescriptionListContext = createContext<DescriptionListLayout>("grid");
+
+const styles = stylex.create({
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "minmax(96px, max-content) 1fr",
+    columnGap: 20,
+    rowGap: 12,
+    alignItems: "baseline",
+  },
+  stacked: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  stackedItem: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+  },
+  dd: {
+    minWidth: 0,
+    overflowWrap: "break-word",
+  },
+});
+
+interface RootProps extends HTMLAttributes<HTMLDListElement> {
+  /** `"grid"` (aligned term/description columns) or `"stacked"` (each pair
+   *  stacked vertically). Defaults to `"grid"`. */
+  layout?: DescriptionListLayout;
+  children?: ReactNode;
+}
+
+const Root = ({ layout = "grid", className, style, children, ...rest }: RootProps) => {
+  const sx = stylex.props(layout === "grid" ? styles.grid : styles.stacked);
+
+  return (
+    <DescriptionListContext.Provider value={layout}>
+      <dl
+        {...rest}
+        className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+        style={{ ...sx.style, ...style }}
+      >
+        {children}
+      </dl>
+    </DescriptionListContext.Provider>
+  );
+};
+
+interface ItemProps {
+  /** The term (label) — rendered as the `<dt>`. */
+  term: ReactNode;
+  /** The description — rendered as the `<dd>`. */
+  children?: ReactNode;
+}
+
+const Item = ({ term, children }: ItemProps) => {
+  const layout = useContext(DescriptionListContext);
+  const dt = (
+    <Text variant="body2" color="text.secondary" component="dt">
+      {term}
+    </Text>
+  );
+  const dd = (
+    <Text variant="body1" component="dd" {...stylex.props(styles.dd)}>
+      {children}
+    </Text>
+  );
+
+  if (layout === "stacked") {
+    return (
+      <div {...stylex.props(styles.stackedItem)}>
+        {dt}
+        {dd}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {dt}
+      {dd}
+    </>
+  );
+};
+
+export const DescriptionList = { Root, Item };

--- a/packages/hobom-design-system/src/components/DescriptionList/index.ts
+++ b/packages/hobom-design-system/src/components/DescriptionList/index.ts
@@ -1,0 +1,1 @@
+export * from "./DescriptionList";

--- a/packages/hobom-design-system/src/components/Gallery/Gallery.doc.ts
+++ b/packages/hobom-design-system/src/components/Gallery/Gallery.doc.ts
@@ -1,0 +1,58 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "Gallery",
+  description:
+    "A photo gallery: one large main image plus a thumbnail strip to switch it. Generalizes the animal-detail gallery so screens (animal detail, shelter facility photos) share the same behavior.",
+  features: [
+    "Stateful — tracks the selected image internally; click a thumbnail to swap the main image",
+    "Resets to the first image when the `images` list changes; clamps the index if it falls out of range",
+    "Thumbnail strip only renders when there is more than one image",
+    "Composes Hb.Image, inheriting its aspect-ratio frame, shimmer placeholder, and fallback",
+  ],
+  props: [
+    {
+      name: "images",
+      type: "{ src: string; alt?: string }[]",
+      description: "Images to show. The first is selected initially.",
+      required: true,
+    },
+    {
+      name: "alt",
+      type: "string",
+      description: 'Base label used when an image has no `alt` (e.g. "콩이 사진 2").',
+    },
+    {
+      name: "ratio",
+      type: "string",
+      description: "CSS aspect-ratio for the main image frame.",
+      default: '"4 / 3"',
+    },
+  ],
+  examples: [
+    {
+      label: "Multi-image gallery with thumbnails",
+      code: `<Hb.Gallery
+  images={[
+    { src: kong1, alt: "콩이 정면" },
+    { src: kong2 },
+    { src: kong3 },
+  ]}
+  alt="콩이"
+  ratio="4 / 3"
+/>`,
+    },
+    {
+      label: "Single image (no thumbnail strip)",
+      code: `<Hb.Gallery images={[{ src: facility }]} alt="보호소" ratio="4 / 3" />`,
+    },
+  ],
+  accessibility: [
+    "Each thumbnail is a <button> with an aria-label like `2번째 사진 보기` and aria-current on the selected one.",
+    "Provide `alt` (or per-image `alt`) so the main and thumbnail images have meaningful labels.",
+  ],
+  notes: [
+    "Composes Hb.Image — no lightbox, zoom, or autoplay; keep it a focused switcher.",
+    "State is internal; the selected image resets whenever a new `images` array is passed.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/Gallery/Gallery.stories.tsx
+++ b/packages/hobom-design-system/src/components/Gallery/Gallery.stories.tsx
@@ -1,0 +1,27 @@
+import { Gallery } from "./Gallery";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const images = [
+  { src: "https://picsum.photos/seed/hobom1/600/450", alt: "콩이 사진 1" },
+  { src: "https://picsum.photos/seed/hobom2/600/450", alt: "콩이 사진 2" },
+  { src: "https://picsum.photos/seed/hobom3/600/450", alt: "콩이 사진 3" },
+  { src: "https://picsum.photos/seed/hobom4/600/450", alt: "콩이 사진 4" },
+];
+
+const meta = {
+  title: "Components/Gallery",
+  component: Gallery,
+  args: { images },
+} satisfies Meta<typeof Gallery>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => <Gallery images={images} alt="콩이" style={{ maxWidth: 420 }} />,
+};
+
+export const SingleImage: Story = {
+  render: () => <Gallery images={images.slice(0, 1)} alt="콩이" style={{ maxWidth: 420 }} />,
+};

--- a/packages/hobom-design-system/src/components/Gallery/Gallery.tsx
+++ b/packages/hobom-design-system/src/components/Gallery/Gallery.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import type { HTMLAttributes } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Image } from "../Image/Image";
+
+interface GalleryImage {
+  src: string;
+  alt?: string;
+}
+
+interface GalleryProps extends HTMLAttributes<HTMLDivElement> {
+  /** Images to show. The first is selected initially. */
+  images: GalleryImage[];
+  /** Base label used when an image has no `alt` (e.g. `"콩이 사진 2"`). */
+  alt?: string;
+  /** CSS aspect-ratio for the main image frame. Defaults to `"4 / 3"`. */
+  ratio?: string;
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  strip: {
+    display: "flex",
+    gap: 8,
+    overflowX: "auto",
+  },
+  thumb: {
+    flexShrink: 0,
+    width: 72,
+    padding: 0,
+    // Longhand so StyleX reliably strips the browser's default <button> border.
+    borderWidth: 2,
+    borderStyle: "solid",
+    borderRadius: 8,
+    backgroundColor: "transparent",
+    cursor: "pointer",
+    appearance: "none",
+  },
+  selected: { borderColor: "var(--hb-color-accent)" },
+  unselected: { borderColor: "transparent" },
+});
+
+/**
+ * A photo gallery: one large main image plus a thumbnail strip to switch it.
+ * Generalizes the animal-detail gallery so screens (animal detail, shelter
+ * facility photos) reuse the same behavior. Composes {@link Image}.
+ */
+export const Gallery = ({ images, alt, ratio = "4 / 3", className, style, ...rest }: GalleryProps) => {
+  const [index, setIndex] = useState(0);
+
+  // Reset to the first image when the list changes (adjust-state-during-render).
+  const [prevImages, setPrevImages] = useState(images);
+
+  if (images !== prevImages) {
+    setPrevImages(images);
+    setIndex(0);
+  }
+
+  const sx = stylex.props(styles.root);
+  const clamped = Math.min(index, Math.max(images.length - 1, 0));
+  const current = images[clamped];
+
+  return (
+    <div
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      <Image
+        src={current?.src}
+        alt={current?.alt ?? `${alt ?? "사진"} ${clamped + 1}`}
+        ratio={ratio}
+        priority
+        style={{ borderRadius: 12 }}
+      />
+      {images.length > 1 && (
+        <div {...stylex.props(styles.strip)}>
+          {images.map((image, i) => (
+            <button
+              key={i}
+              type="button"
+              aria-label={`${i + 1}번째 사진 보기`}
+              aria-current={i === clamped}
+              onClick={() => setIndex(i)}
+              {...stylex.props(styles.thumb, i === clamped ? styles.selected : styles.unselected)}
+            >
+              <Image
+                src={image.src}
+                alt={image.alt ?? `${alt ?? "사진"} ${i + 1}`}
+                ratio="1 / 1"
+                style={{ borderRadius: 8 }}
+              />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/hobom-design-system/src/components/Gallery/index.ts
+++ b/packages/hobom-design-system/src/components/Gallery/index.ts
@@ -1,0 +1,1 @@
+export * from "./Gallery";

--- a/packages/hobom-design-system/src/components/PageHeader/PageHeader.doc.ts
+++ b/packages/hobom-design-system/src/components/PageHeader/PageHeader.doc.ts
@@ -1,0 +1,58 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "PageHeader",
+  description:
+    "The standard page/screen title block: an optional breadcrumb on top, then a row with the title and supporting description on the left and actions on the right, with room for extra content (filter chips, tabs) below.",
+  features: [
+    "Owns the breadcrumb slot, title row, and 12px vertical rhythm so screens stop hand-rolling header CSS",
+    "Title (h5) and description (body2, secondary) compose Text — no hand-written font CSS",
+    "Right-aligned actions slot collapses when no actions are passed",
+    "Renders a semantic <header>; spreads the rest of the div props",
+  ],
+  props: [
+    { name: "title", type: "ReactNode", description: "Page/screen title.", required: true },
+    {
+      name: "description",
+      type: "ReactNode",
+      description: "Supporting line under the title.",
+    },
+    {
+      name: "actions",
+      type: "ReactNode",
+      description: "Right-aligned slot in the title row, e.g. buttons.",
+    },
+    {
+      name: "breadcrumb",
+      type: "ReactNode",
+      description: "Rendered above the title row, e.g. an Hb.Breadcrumb.",
+    },
+    {
+      name: "children",
+      type: "ReactNode",
+      description: "Extra content below the title row, e.g. filter chips or tabs.",
+    },
+  ],
+  examples: [
+    {
+      label: "Title with a description and actions",
+      code: `<Hb.PageHeader title="입양 관리" description="입양을 기다리는 32마리의 아이들" actions={<Hb.Button size="small" variant="primary">새 공고 등록</Hb.Button>} />`,
+    },
+    {
+      label: "With a breadcrumb slot",
+      code: `<Hb.PageHeader
+  breadcrumb={<Hb.Breadcrumb.Root><Hb.Breadcrumb.Item href="/">홈</Hb.Breadcrumb.Item><Hb.Breadcrumb.Item>입양</Hb.Breadcrumb.Item></Hb.Breadcrumb.Root>}
+  title="입양 관리"
+  description="입양을 기다리는 32마리의 아이들"
+/>`,
+    },
+  ],
+  accessibility: [
+    "Renders a <header>; the title is an <h5> (Text variant), so keep the surrounding heading order sensible.",
+    "When passing a breadcrumb, use a <nav aria-label> around the trail (Hb.Breadcrumb handles this).",
+  ],
+  notes: [
+    "Compose filter chips, tabs, or a StatGroup via children — PageHeader only owns the header block.",
+    "For an in-card section heading use Hb.SectionCard instead.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/PageHeader/PageHeader.stories.tsx
+++ b/packages/hobom-design-system/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,53 @@
+import { PageHeader } from "./PageHeader";
+import { Button } from "../Button/Button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/PageHeader",
+  component: PageHeader,
+  args: { title: "입양 관리" },
+  parameters: {
+    // The description uses text.secondary (#737373); on the canvas at 13px it
+    // sits at ~4.19:1 — the DS-wide small-secondary-text tradeoff. Other a11y
+    // checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => <PageHeader title="입양 관리" style={{ maxWidth: 720 }} />,
+};
+
+export const WithDescriptionAndActions: Story = {
+  render: () => (
+    <PageHeader
+      title="입양 관리"
+      description="입양을 기다리는 32마리의 아이들"
+      actions={
+        <Button size="small" variant="primary">
+          새 공고 등록
+        </Button>
+      }
+      style={{ maxWidth: 720 }}
+    />
+  ),
+};
+
+export const WithBreadcrumb: Story = {
+  render: () => (
+    <PageHeader
+      breadcrumb={
+        <nav aria-label="breadcrumb">
+          <a href="#">홈</a> / <a href="#">입양</a>
+        </nav>
+      }
+      title="입양 관리"
+      description="입양을 기다리는 32마리의 아이들"
+      style={{ maxWidth: 720 }}
+    />
+  ),
+};

--- a/packages/hobom-design-system/src/components/PageHeader/PageHeader.tsx
+++ b/packages/hobom-design-system/src/components/PageHeader/PageHeader.tsx
@@ -1,0 +1,72 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Text } from "../Text/Text";
+
+interface PageHeaderProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  /** Page/screen title. */
+  title: ReactNode;
+  /** Supporting line under the title. */
+  description?: ReactNode;
+  /** Right-aligned slot in the title row (e.g. buttons). */
+  actions?: ReactNode;
+  /** Rendered above the title row (e.g. an Hb.Breadcrumb). */
+  breadcrumb?: ReactNode;
+  /** Extra content below the title row (e.g. filter chips or tabs). */
+  children?: ReactNode;
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  row: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 16,
+  },
+  heading: { display: "flex", flexDirection: "column", gap: 4, minWidth: 0 },
+  actions: { flexShrink: 0 },
+});
+
+/**
+ * The standard page/screen title block — an optional breadcrumb on top, then a
+ * row with the title and supporting description on the left and actions on the
+ * right. Extra content (filter chips, tabs) can be composed below.
+ */
+export const PageHeader = ({
+  title,
+  description,
+  actions,
+  breadcrumb,
+  className,
+  style,
+  children,
+  ...rest
+}: PageHeaderProps) => {
+  const sx = stylex.props(styles.root);
+
+  return (
+    <header
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {breadcrumb}
+      <div {...stylex.props(styles.row)}>
+        <div {...stylex.props(styles.heading)}>
+          <Text variant="h5">{title}</Text>
+          {description != null && (
+            <Text variant="body2" color="text.secondary">
+              {description}
+            </Text>
+          )}
+        </div>
+        {actions != null && <div {...stylex.props(styles.actions)}>{actions}</div>}
+      </div>
+      {children}
+    </header>
+  );
+};

--- a/packages/hobom-design-system/src/components/PageHeader/index.ts
+++ b/packages/hobom-design-system/src/components/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageHeader";

--- a/packages/hobom-design-system/src/components/SectionCard/SectionCard.doc.ts
+++ b/packages/hobom-design-system/src/components/SectionCard/SectionCard.doc.ts
@@ -1,0 +1,51 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "SectionCard",
+  description:
+    "A titled content block: a bordered surface with an optional header (title, description, right-aligned action) and a free-form body with consistent vertical rhythm.",
+  features: [
+    "Owns the frame, header row, and 16px body gap so screens stop hand-rolling section CSS",
+    "`outlined` (bordered surface) or `plain` (heading + rhythm only) variants",
+    "Header collapses entirely when no title/description/action is passed",
+    "Renders a semantic <section>; spreads the rest of the div props",
+  ],
+  props: [
+    { name: "title", type: "ReactNode", description: "Heading at the top of the section." },
+    { name: "description", type: "ReactNode", description: "Supporting line under the title." },
+    {
+      name: "action",
+      type: "ReactNode",
+      description: "Right-aligned header slot, e.g. a link or ghost button.",
+    },
+    {
+      name: "variant",
+      type: '"outlined" | "plain"',
+      description: "Bordered surface, or heading + rhythm with no frame.",
+      default: '"outlined"',
+    },
+    { name: "children", type: "ReactNode", description: "Section body — compose freely." },
+  ],
+  examples: [
+    {
+      label: "Titled section with an action",
+      code: `<Hb.SectionCard title="우리 아이들" description="입양을 기다리는 32마리" action={<Hb.Button size="small" variant="ghost">전체 보기</Hb.Button>}>
+  <AnimalGrid animals={animals} />
+</Hb.SectionCard>`,
+    },
+    {
+      label: "Plain (no frame)",
+      code: `<Hb.SectionCard variant="plain" title="방문 안내">
+  <Hb.Text variant="body2" color="text.secondary">평일 10:00–18:00</Hb.Text>
+</Hb.SectionCard>`,
+    },
+  ],
+  accessibility: [
+    "Renders a <section>; give it an aria-label or an id-linked heading when several sections share a page.",
+    "The title is an <h6> (Text variant); keep the surrounding heading order sensible.",
+  ],
+  notes: [
+    "Compose Hb.DescriptionList, Hb.StatGroup, or a grid inside — SectionCard only owns the frame.",
+    "For a clickable surface use Hb.Card.Clickable instead.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/SectionCard/SectionCard.stories.tsx
+++ b/packages/hobom-design-system/src/components/SectionCard/SectionCard.stories.tsx
@@ -1,0 +1,58 @@
+import { SectionCard } from "./SectionCard";
+import { Text } from "../Text/Text";
+import { Button } from "../Button/Button";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/SectionCard",
+  component: SectionCard,
+  parameters: {
+    // The `plain` variant renders text.secondary (#737373) on the canvas at
+    // 13px (~4.19:1) — the DS-wide small-secondary-text tradeoff. Other a11y
+    // checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof SectionCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  render: () => (
+    <SectionCard title="보호소 소개" style={{ maxWidth: 420 }}>
+      <Text variant="body2" color="text.secondary">
+        11년간 유기견을 구조하고 입양을 이어온 비영리 보호소입니다.
+      </Text>
+    </SectionCard>
+  ),
+};
+
+export const WithDescriptionAndAction: Story = {
+  render: () => (
+    <SectionCard
+      title="우리 아이들"
+      description="입양을 기다리는 32마리"
+      action={
+        <Button size="small" variant="ghost">
+          전체 보기
+        </Button>
+      }
+      style={{ maxWidth: 420 }}
+    >
+      <Text variant="body2" color="text.secondary">
+        카드 그리드 등 본문을 자유롭게 배치하세요.
+      </Text>
+    </SectionCard>
+  ),
+};
+
+export const Plain: Story = {
+  render: () => (
+    <SectionCard variant="plain" title="방문 안내" style={{ maxWidth: 420 }}>
+      <Text variant="body2" color="text.secondary">
+        테두리 없이 제목과 본문의 리듬만 제공합니다.
+      </Text>
+    </SectionCard>
+  ),
+};

--- a/packages/hobom-design-system/src/components/SectionCard/SectionCard.tsx
+++ b/packages/hobom-design-system/src/components/SectionCard/SectionCard.tsx
@@ -1,0 +1,85 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Text } from "../Text/Text";
+
+type SectionCardVariant = "outlined" | "plain";
+
+interface SectionCardProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  /** Heading rendered at the top of the section. */
+  title?: ReactNode;
+  /** Supporting line under the title. */
+  description?: ReactNode;
+  /** Right-aligned slot in the header row (e.g. a link or button). */
+  action?: ReactNode;
+  /** `"outlined"` (bordered surface) or `"plain"` (no border/background).
+   *  Defaults to `"outlined"`. */
+  variant?: SectionCardVariant;
+  children?: ReactNode;
+}
+
+const styles = stylex.create({
+  root: {
+    boxSizing: "border-box",
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+  },
+  outlined: {
+    padding: 20,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 12,
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  header: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  heading: { display: "flex", flexDirection: "column", gap: 4, minWidth: 0 },
+  action: { flexShrink: 0 },
+});
+
+/**
+ * A titled content block — the recurring "bordered section with a heading and
+ * body" that screens otherwise hand-roll. Compose freely inside; the card only
+ * owns the frame, the header row, and the vertical rhythm.
+ */
+export const SectionCard = ({
+  title,
+  description,
+  action,
+  variant = "outlined",
+  className,
+  style,
+  children,
+  ...rest
+}: SectionCardProps) => {
+  const sx = stylex.props(styles.root, variant === "outlined" && styles.outlined);
+  const hasHeader = title != null || description != null || action != null;
+
+  return (
+    <section
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {hasHeader && (
+        <div {...stylex.props(styles.header)}>
+          <div {...stylex.props(styles.heading)}>
+            {title != null && <Text variant="h6">{title}</Text>}
+            {description != null && (
+              <Text variant="body2" color="text.secondary">
+                {description}
+              </Text>
+            )}
+          </div>
+          {action != null && <div {...stylex.props(styles.action)}>{action}</div>}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+};

--- a/packages/hobom-design-system/src/components/SectionCard/index.ts
+++ b/packages/hobom-design-system/src/components/SectionCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./SectionCard";

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.doc.ts
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.doc.ts
@@ -1,0 +1,58 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "StatGroup",
+  description:
+    "A row (or grid) of headline stats — the recurring '240+ 누적 입양 · 32 보호 중 · 11년 운영' pattern for landing and About sections. Each item stacks a big value over a caption label.",
+  features: [
+    "Renders a semantic <dl>; each item is a value <dd> above a label <dt>",
+    "Default flex wrap layout, or an equal-column grid via `columns`",
+    "Fixed 24px gap so screens stop hand-rolling stat CSS",
+    "Value uses the accent color and 700 weight; label is muted caption",
+  ],
+  props: [
+    {
+      name: "StatGroup.Root columns",
+      type: "number",
+      description: "Lay out as this many equal columns; omit to wrap in a flex row.",
+    },
+    {
+      name: "StatGroup.Item value",
+      type: "ReactNode",
+      description: "The prominent figure, e.g. `240+`.",
+      required: true,
+    },
+    {
+      name: "StatGroup.Item label",
+      type: "ReactNode",
+      description: "The line describing the figure, e.g. `누적 입양`.",
+      required: true,
+    },
+  ],
+  examples: [
+    {
+      label: "Inline stat row",
+      code: `<Hb.StatGroup.Root>
+  <Hb.StatGroup.Item value="240+" label="누적 입양" />
+  <Hb.StatGroup.Item value="32" label="보호 중" />
+  <Hb.StatGroup.Item value="11년" label="운영" />
+</Hb.StatGroup.Root>`,
+    },
+    {
+      label: "Three-column grid",
+      code: `<Hb.StatGroup.Root columns={3}>
+  <Hb.StatGroup.Item value="240+" label="누적 입양" />
+  <Hb.StatGroup.Item value="32" label="보호 중" />
+  <Hb.StatGroup.Item value="11년" label="운영" />
+</Hb.StatGroup.Root>`,
+    },
+  ],
+  accessibility: [
+    "Renders a <dl> with each stat as a <dd> (value) and <dt> (label); the value comes first for visual emphasis.",
+    "Give the <dl> an aria-label when the surrounding context does not already name the stats.",
+  ],
+  notes: [
+    "Compose inside Hb.SectionCard for a titled stats block.",
+    "value/label take ReactNode, so units or icons can be mixed into the figure.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.stories.tsx
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.stories.tsx
@@ -1,0 +1,40 @@
+import { StatGroup } from "./StatGroup";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/StatGroup",
+  component: StatGroup.Root,
+  parameters: {
+    // The stat label uses text.secondary (#737373); on the canvas at 13px it
+    // sits at ~4.19:1 — the DS-wide small-secondary-text tradeoff. Other a11y
+    // checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+} satisfies Meta<typeof StatGroup.Root>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Inline: Story = {
+  render: () => (
+    <StatGroup.Root>
+      <StatGroup.Item value="240+" label="누적 입양" />
+      <StatGroup.Item value="32" label="보호 중" />
+      <StatGroup.Item value="11년" label="운영" />
+    </StatGroup.Root>
+  ),
+};
+
+export const Grid: Story = {
+  render: () => (
+    <StatGroup.Root columns={3} style={{ maxWidth: 420 }}>
+      <StatGroup.Item value="240+" label="누적 입양" />
+      <StatGroup.Item value="32" label="보호 중" />
+      <StatGroup.Item value="11년" label="운영" />
+      <StatGroup.Item value="1,800" label="후원자" />
+      <StatGroup.Item value="97%" label="입양 성공률" />
+      <StatGroup.Item value="24시간" label="긴급 구조" />
+    </StatGroup.Root>
+  ),
+};

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.tsx
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.tsx
@@ -1,0 +1,67 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Text } from "../Text/Text";
+
+interface StatGroupRootProps extends HTMLAttributes<HTMLDListElement> {
+  /** When set, lay out as a grid of this many equal columns; otherwise wrap in a flex row. */
+  columns?: number;
+  children?: ReactNode;
+}
+
+interface StatGroupItemProps {
+  /** The prominent figure (e.g. `"240+"`). */
+  value: ReactNode;
+  /** The line describing the figure (e.g. `"누적 입양"`). */
+  label: ReactNode;
+}
+
+const styles = stylex.create({
+  root: {
+    margin: 0,
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 24,
+  },
+  grid: {
+    display: "grid",
+    gap: 24,
+  },
+  item: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+  },
+});
+
+const Root = ({ columns, className, style, children, ...rest }: StatGroupRootProps) => {
+  const sx = stylex.props(columns != null ? styles.grid : styles.root);
+
+  const dynamic: CSSProperties = {
+    gridTemplateColumns: columns != null ? `repeat(${columns}, 1fr)` : undefined,
+  };
+
+  return (
+    <dl
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...dynamic, ...style }}
+    >
+      {children}
+    </dl>
+  );
+};
+
+const Item = ({ value, label }: StatGroupItemProps) => {
+  return (
+    <div {...stylex.props(styles.item)}>
+      <Text variant="h5" fontWeight={700} component="dd" color="primary" style={{ margin: 0 }}>
+        {value}
+      </Text>
+      <Text variant="caption" color="text.secondary" component="dt">
+        {label}
+      </Text>
+    </div>
+  );
+};
+
+export const StatGroup = { Root, Item };

--- a/packages/hobom-design-system/src/components/StatGroup/index.ts
+++ b/packages/hobom-design-system/src/components/StatGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./StatGroup";

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.doc.ts
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.doc.ts
@@ -1,0 +1,65 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "Tabs",
+  description:
+    "A controlled tab bar (Root + Item) with an optional matching Panel. Root holds the selected value; Items render the underlined triggers; Panels reveal content for the active value.",
+  features: [
+    "Controlled: you own `value` and `onChange` on Root",
+    "Index-based fallback — Items without an explicit `value` use their position",
+    "`Tabs.Panel value` shows its children only when active; `keepMounted` keeps it in the DOM (hidden)",
+    "Wired for a11y: role=tablist/tab/tabpanel with aria-selected/hidden",
+  ],
+  props: [
+    {
+      name: "Root.value",
+      type: "string | number",
+      description: "The selected tab value.",
+      required: true,
+    },
+    {
+      name: "Root.onChange",
+      type: "(event, value) => void",
+      description: "Fires with the clicked tab's value.",
+      required: true,
+    },
+    { name: "Item.value", type: "string | number", description: "Falls back to positional index." },
+    { name: "Item.label", type: "ReactNode", description: "Tab text." },
+    { name: "Item.icon", type: "ReactNode", description: "Optional leading/trailing icon." },
+    { name: "Item.disabled", type: "boolean", description: "Disable the tab.", default: "false" },
+    {
+      name: "Panel.value",
+      type: "string | number",
+      description: "Shown when it equals Root's value.",
+      required: true,
+    },
+    {
+      name: "Panel.keepMounted",
+      type: "boolean",
+      description: "Keep mounted (hidden) when inactive.",
+      default: "false",
+    },
+  ],
+  examples: [
+    {
+      label: "Tabs with panels",
+      code: `const [tab, setTab] = useState("about");
+<>
+  <Hb.Tabs.Root value={tab} onChange={(_, v) => setTab(v)}>
+    <Hb.Tabs.Item value="about" label="소개" />
+    <Hb.Tabs.Item value="animals" label="동물" />
+  </Hb.Tabs.Root>
+  <Hb.Tabs.Panel value="about"><AboutTab /></Hb.Tabs.Panel>
+  <Hb.Tabs.Panel value="animals"><AnimalsTab /></Hb.Tabs.Panel>
+</>`,
+    },
+  ],
+  accessibility: [
+    "Root is role=tablist, Items are role=tab (aria-selected), Panels are role=tabpanel (hidden when inactive).",
+    "Keep each Panel's value in sync with its Item's value.",
+  ],
+  keyboard: "Items are buttons — Tab moves focus, Enter/Space activates. (No arrow-key roving yet.)",
+  notes: [
+    "Controlled only; persist the value in URL state (e.g. useSearchParamsState) for deep-linkable tabs.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
@@ -144,4 +144,25 @@ const Item = ({
   );
 };
 
-export const Tabs = { Root, Item };
+interface PanelProps extends HTMLAttributes<HTMLDivElement> {
+  /** The tab value this panel belongs to; shown when it matches `Root`'s value. */
+  value: TabValue;
+  /** Keep the panel mounted (just hidden) when inactive. Defaults to false. */
+  keepMounted?: boolean;
+  children?: ReactNode;
+}
+
+const Panel = ({ value, keepMounted = false, className, style, children, ...rest }: PanelProps) => {
+  const ctx = useContext(TabsContext);
+  const active = ctx?.value === value;
+
+  if (!active && !keepMounted) return null;
+
+  return (
+    <div role="tabpanel" hidden={!active} className={className} style={style} {...rest}>
+      {active || keepMounted ? children : null}
+    </div>
+  );
+};
+
+export const Tabs = { Root, Item, Panel };

--- a/packages/hobom-design-system/src/components/index.ts
+++ b/packages/hobom-design-system/src/components/index.ts
@@ -36,6 +36,13 @@ import { Form } from "./Form";
 import { Table } from "./Table";
 import { Radio } from "./Radio";
 import { Accordion } from "./Accordion";
+// Batch 3 — composition patterns
+import { SectionCard } from "./SectionCard";
+import { PageHeader } from "./PageHeader";
+import { Breadcrumb } from "./Breadcrumb";
+import { DescriptionList } from "./DescriptionList";
+import { StatGroup } from "./StatGroup";
+import { Gallery } from "./Gallery";
 // Batch 2 — infra
 import { CssBaseline, GlobalStyles } from "./Infra";
 import { ColorSchemeProvider } from "../foundations/color-scheme";
@@ -80,6 +87,13 @@ export const Hb = {
   Table,
   Radio,
   Accordion,
+  // Batch 3 — composition patterns
+  SectionCard,
+  PageHeader,
+  Breadcrumb,
+  DescriptionList,
+  StatGroup,
+  Gallery,
   // Batch 2 — infra
   CssBaseline,
   GlobalStyles,

--- a/packages/hobom-design-system/src/foundations/docs.ts
+++ b/packages/hobom-design-system/src/foundations/docs.ts
@@ -1,0 +1,44 @@
+/**
+ * Agent-facing component documentation.
+ *
+ * Each component ships a co-located `<Component>.doc.ts` exporting a `docs`
+ * object typed by {@link ComponentDoc}. It is the single, structured source of
+ * truth an agent (or a docs CLI) can read *instead of the source* to learn a
+ * component's props, composition recipes, and accessibility contract.
+ *
+ * Keep it English-first and example-driven: props/types/defaults live here once,
+ * and the `hobom-ds` skill's component index links back to these files.
+ */
+
+export interface ComponentDocProp {
+  name: string;
+  /** TypeScript type as written, e.g. `"outlined" | "plain"`. */
+  type: string;
+  description: string;
+  /** Omit or `false` when the prop is optional. */
+  required?: boolean;
+  /** Default value as source, e.g. `"outlined"` or `false`. */
+  default?: string;
+}
+
+export interface ComponentDocExample {
+  label: string;
+  /** A self-contained JSX snippet showing the component in a realistic use. */
+  code: string;
+}
+
+export interface ComponentDoc {
+  /** The `Hb.*` access path, e.g. `"SectionCard"` or `"Breadcrumb.Item"`. */
+  name: string;
+  description: string;
+  /** One line each — what the component gives you for free. */
+  features: string[];
+  props: ComponentDocProp[];
+  examples: ComponentDocExample[];
+  /** ARIA/semantics guidance the consumer must not break. */
+  accessibility?: string[];
+  /** Keyboard interaction summary, when the component is interactive. */
+  keyboard?: string;
+  /** Gotchas, composition tips, related components. */
+  notes?: string[];
+}

--- a/packages/hobom-schema/README.md
+++ b/packages/hobom-schema/README.md
@@ -1,0 +1,164 @@
+# hobom-schema
+
+A tiny, dependency-free runtime schema validation kit for HoBom — a Zod-like
+API for describing the shape of untrusted data (API responses, form input) and
+turning it into typed, validated values at runtime.
+
+It ships only the primitives it needs: a handful of schema builders, `parse` /
+`safeParse`, and a static type helper. No dependencies, no bundle weight beyond
+what you import.
+
+## Installation
+
+This package is part of the pnpm workspace and is consumed via the workspace
+protocol:
+
+```jsonc
+// consumer package.json
+"dependencies": {
+  "hobom-schema": "workspace:*"
+}
+```
+
+## Import
+
+Everything is exported from the package root — never reach into internal paths.
+
+```ts
+import { HoBomSchema, type Infer } from "hobom-schema";
+import type { Schema, SafeParseResult, ValidationIssue } from "hobom-schema";
+import { SchemaError } from "hobom-schema";
+```
+
+## Quick start
+
+Define a schema by composing builders off the `HoBomSchema` namespace, then
+validate a value with `parse` (throws) or `safeParse` (returns a result).
+
+```ts
+import { HoBomSchema, type Infer } from "hobom-schema";
+
+const animalSchema = HoBomSchema.object({
+  id: HoBomSchema.number(),
+  name: HoBomSchema.string().min(1),
+  status: HoBomSchema.enum(["protecting", "adopted"] as const),
+  photos: HoBomSchema.array(HoBomSchema.string()),
+  adoptedAt: HoBomSchema.string().nullable(),
+});
+
+// Derive the static type from the schema — single source of truth.
+type Animal = Infer<typeof animalSchema>;
+// {
+//   id: number;
+//   name: string;
+//   status: "protecting" | "adopted";
+//   photos: string[];
+//   adoptedAt: string | null;
+// }
+
+// parse: returns the typed value, throws SchemaError on mismatch.
+const animal = animalSchema.parse(payload);
+
+// safeParse: returns a discriminated result, never throws.
+const result = animalSchema.safeParse(payload);
+if (result.success) {
+  result.data; // Animal
+} else {
+  result.error.issues; // readonly ValidationIssue[]
+}
+```
+
+`SchemaError` (thrown by `parse`) carries the same issues as its `.issues`
+property, and its message is every issue message joined by `, `.
+
+## API
+
+### Builders — `HoBomSchema.*`
+
+| Builder | Accepts | `Infer` type |
+| --- | --- | --- |
+| `HoBomSchema.string()` | a `string` | `string` |
+| `HoBomSchema.number()` | a finite `number` (rejects `NaN` / `Infinity`) | `number` |
+| `HoBomSchema.boolean()` | a `boolean` | `boolean` |
+| `HoBomSchema.date()` | a date **string** (`Date.parse`-able); kept as a string | `string` |
+| `HoBomSchema.enum(values)` | a `string` in `values` (pass `as const`) | union of `values` |
+| `HoBomSchema.object(shape)` | a non-null, non-array object matching `shape` | `{ [K]: Infer<shape[K]> }` |
+| `HoBomSchema.array(element)` | an array whose items each match `element` | `Infer<element>[]` |
+
+### Validators (chainable, return a new schema)
+
+Validators are immutable — each returns a fresh schema, so the base builder is
+never mutated. Every validator takes an optional custom `message`.
+
+| Schema | Validators |
+| --- | --- |
+| `string()` | `.min(n)`, `.max(n)`, `.regex(pattern)` |
+| `number()` | `.min(n)`, `.max(n)`, `.positive()` |
+| `boolean()`, `date()`, `enum()`, `object()`, `array()` | none |
+
+There is no `.email()`, `.url()`, `.int()`, etc. — the set above is the whole
+surface. Compose `.regex(...)` for anything more specific.
+
+`enum()` also exposes a read-only `.options` getter returning the allowed values.
+
+### Base methods (on every schema)
+
+| Method | Behavior |
+| --- | --- |
+| `.parse(input)` | Returns the typed value, or **throws** `SchemaError`. |
+| `.safeParse(input)` | Returns `SafeParseResult<T>` — never throws. |
+| `.optional()` | Wraps the schema so `undefined` passes through as `undefined`. |
+| `.nullable()` | Wraps the schema so `null` passes through as `null`. |
+
+`.optional()` vs `.nullable()`: `optional` only lets `undefined` through
+(`T | undefined`); `nullable` only lets `null` through (`T | null`). They are
+distinct — pick the one that matches the wire contract, or chain both if a field
+can be either.
+
+### Result types
+
+```ts
+type SafeParseResult<T> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly error: { readonly issues: readonly ValidationIssue[] } };
+
+interface ValidationIssue {
+  readonly message: string;
+}
+```
+
+Issue messages are path-prefixed as they bubble up: an object field prefixes
+with `"<key>: "` and an array item with `"[<index>]: "`, so a nested failure
+reads e.g. `photos: [0]: Expected string`.
+
+## Object behavior — unknown keys are stripped
+
+`object()` reads only the keys declared in its `shape`. Any extra keys on the
+input are **dropped** from the output — the result is built on a fresh
+`Object.create(null)` and only declared keys are copied over. There is no
+`strict`/`passthrough` mode; unknown-key stripping is the only behavior.
+
+A field is validated with `record[key]`, so a **missing** key is validated as
+`undefined` — mark such fields `.optional()` if they may be absent.
+
+## The API-boundary pattern (in the app, not here)
+
+This package intentionally stops at the primitives (`parse` / `safeParse`). It
+does **not** export a `parseResponse` helper.
+
+The Angel app builds that boundary wrapper on top of these primitives in
+`apps/hobom-angel/src/shared/api/parse-response.api.ts`. `parseResponse(schema,
+context)` runs `schema.safeParse(data)` and, on a mismatch, reports the contract
+violation (via `reportError`) and passes the raw payload through instead of
+throwing — advisory validation, so backend drift is logged but never breaks the
+screen. Reach for `parseResponse` in the app's API layer; reach for `parse` /
+`safeParse` directly anywhere you want strict, throwing validation.
+
+## Scripts
+
+```bash
+pnpm --filter hobom-schema typecheck
+pnpm --filter hobom-schema lint
+pnpm --filter hobom-schema test
+pnpm --filter hobom-schema test:coverage
+```

--- a/packages/hobom-utils/README.md
+++ b/packages/hobom-utils/README.md
@@ -1,0 +1,97 @@
+# hobom-utils
+
+An in-house, Remeda-style functional utility library for HoBom. Data-last,
+tree-shakeable, fully typed — array, object, guard, math, flow, and PII-masking
+helpers with **zero third-party runtime dependency**. Reach for these instead of
+hand-rolling loops or pulling in lodash.
+
+## Why it exists
+
+- **No lodash.** One less dependency to audit and version. The whole kit is
+  authored in-house and lives in the workspace.
+- **Tree-shakeable.** `"sideEffects": false` plus per-function modules — import
+  three helpers and only three ship to the bundle.
+- **Data-last, built for `pipe`.** Curried helpers compose left-to-right without
+  intermediate variables, the same ergonomics as Remeda.
+- **Typed narrowing.** Guards (`isDefined`, `isString`, …) narrow types, and
+  `filter`/`find`/`partition` propagate `value is S` predicates through to the
+  result type.
+
+## Installation
+
+Part of the pnpm workspace; consumed via the workspace protocol:
+
+```jsonc
+// consumer package.json
+"dependencies": {
+  "hobom-utils": "workspace:*"
+}
+```
+
+## Import styles
+
+Two ways to import — both tree-shake identically. Prefer whichever reads best.
+
+```ts
+// 1. Named imports (recommended) — only what you use is bundled.
+import { pipe, filter, map, groupBy, isDefined } from "hobom-utils";
+
+// 2. Namespace — grouped under `Bom` to avoid clashing with local names.
+import { Bom } from "hobom-utils";
+Bom.pipe(users, Bom.filter(isActive), Bom.map(Bom.prop("name")));
+```
+
+## Quick start
+
+Most helpers are **dual**: call data-first `filter(arr, fn)` directly, or
+data-last `filter(fn)` to get a `(arr) => …` operation for `pipe`.
+
+```ts
+import { pipe, filter, map, sortBy, uniqBy, isDefined } from "hobom-utils";
+
+interface User {
+  id: number;
+  name: string;
+  age: number;
+  team: string | null;
+}
+
+// pipe: value first, then a chain of data-last operations.
+const names = pipe(
+  users,
+  filter((u: User) => u.age >= 18),
+  uniqBy((u) => u.id),
+  sortBy((u) => u.age),
+  map((u) => u.name),
+);
+
+// Data-first, one-off — no pipe needed.
+const adults = filter(users, (u) => u.age >= 18);
+
+// Guards narrow types.
+const teams = users.map((u) => u.team).filter(isDefined); // string[]
+```
+
+## At a glance
+
+| Category | Functions |
+| --- | --- |
+| Collections | `map` `filter` `find` `findIndex` `reduce` `forEach` `every` `some` `flatMap` `partition` `countBy` `groupBy` `sortBy` `uniq` `uniqBy` `take` `drop` `first` `last` |
+| Objects | `pick` `omit` `keys` `values` `entries` `mapValues` `prop` |
+| Guards | `isArray` `isDate` `isDefined` `isEmpty` `isFunction` `isNotNull` `isNullish` `isNumber` `isString` `isTruthy` |
+| Function / flow | `pipe` `curry` `identity` `constant` `conditional` `when` `tap` `not` |
+| Math | `add` `subtract` `sum` `clamp` |
+| PII masking | `maskEmail` `maskName` `maskPhone` |
+| Misc | `clone` |
+
+Full catalog with every signature (data-first + data-last) and an example per
+function: **[.claude/skills/hobom-utils/references/functions.md](../../.claude/skills/hobom-utils/references/functions.md)**.
+
+## Scripts
+
+```bash
+pnpm --filter hobom-utils typecheck
+pnpm --filter hobom-utils lint
+pnpm --filter hobom-utils test
+pnpm --filter hobom-utils test:coverage
+```


### PR DESCRIPTION
## Why

Screens keep re-writing the same StyleX for section frames, term/value grids, breadcrumbs, and stat rows. That's the design system's job. This promotes those recurring layouts into `Hb.*` so screens compose them, and fills in the developer-facing docs that were missing across the workspace.

## Design system — new composition patterns

Each ships with a Storybook story and a co-located `*.doc.ts`:

- **`Hb.SectionCard`** — titled bordered section (title / description / action / `plain` variant)
- **`Hb.PageHeader`** — screen title block (title / description / actions / breadcrumb slot)
- **`Hb.Breadcrumb`** — `Root` + `Item current` trail
- **`Hb.DescriptionList`** — `Root` + `Item term=` attribute grid (grid / stacked)
- **`Hb.StatGroup`** — `Root` + `Item value= label=` stat row
- **`Hb.Gallery`** — main image + thumbnail strip (composes `Hb.Image`)
- **`Hb.Tabs.Panel`** — panel that reveals content for the active tab

New **`ComponentDoc` convention** (`foundations/docs.ts`): a structured, agent-readable source of truth per component (name, features, props, examples, a11y, notes), applied to every new component plus `Tabs`.

## Docs & skills

- READMEs for the packages that had none — **hobom-data**, **hobom-schema**, **hobom-utils** — plus both apps (**hobom-angel**, **hobom-system**). All written against the real source.
- Per-package skills under `.claude/skills/` (**hobom-ds**, **hobom-data**, **hobom-schema**, **hobom-utils**) so the component catalog, package APIs, gotchas, and conventions are version-controlled and easy to find. `hobom-ds` also carries a full component index so the catalog is one lookup instead of reading each source.

## Verification

- `hobom-design-system`: `typecheck`, `lint`, and `test` (198 story tests, incl. a browser a11y pass) all green.
- Docs are source-verified — no fabricated signatures.

## Notes

- Known token tradeoff surfaced by the a11y pass: `text.secondary` on the canvas at 13px is ~4.19:1, just under WCAG AA 4.5:1. It's a DS-wide palette decision already shipped app-wide; the affected stories disable only the `color-contrast` rule (other checks still run), mirroring the existing `Card` story. Worth revisiting the secondary shade separately.
- Existing hand-styled screens don't adopt these automatically — that's an incremental migration. The shelter microsite is the first consumer and lands next.