### PR TITLE
Add the shelter microsite

### DIFF
--- a/.claude/skills/hobom-ds/SKILL.md
+++ b/.claude/skills/hobom-ds/SKILL.md
@@ -51,7 +51,7 @@ will reach for most when laying out a screen:
 | Term/value attribute grid | `Hb.DescriptionList.Root` / `.Item term=` |
 | Stat row (240+ 입양 · 32 보호중) | `Hb.StatGroup.Root` / `.Item value= label=` |
 | Photo gallery (main + thumbs) | `Hb.Gallery images=` (composes `Hb.Image`) |
-| Tabbed content | `Hb.Tabs.Root` + `.Item` + `.Panel value=` |
+| Tabbed content | `Hb.Tabs.Provider` wrapping `.Root` + `.Item` + `.Panel value=` (Provider needed for panels) |
 | Vertical/horizontal spacing | `Hb.Stack spacing=` (× 8px), `direction` |
 | 12-col responsive layout | `Hb.Grid container spacing size={{ xs, md }}` |
 | Empty/error placeholder | `EmptyState` (from `hobom-design-system`) |

--- a/.claude/skills/hobom-ds/references/component-index.md
+++ b/.claude/skills/hobom-ds/references/component-index.md
@@ -36,7 +36,7 @@ Icons: `import { IconName } from "hobom-design-system/icons"` (see
 
 ## Navigation
 
-- **`Hb.Tabs`** = `{ Root, Item, Panel }`. `Root.value` + `onChange` (controlled). `Item.value?` (falls back to index), `label`, `icon?`, `iconPosition?`, `disabled?`. `Panel.value` (shown when active), `keepMounted?`. role=tablist/tab/tabpanel.
+- **`Hb.Tabs`** = `{ Provider, Root, Item, Panel }`. Standalone bar: `Root.value` + `onChange` (controlled) + `Item`s. For panels, wrap `Root` + sibling `Panel`s in `Tabs.Provider value onChange` (Root then drops value/onChange and inherits). `Item.value?` (falls back to index), `label`, `icon?`, `iconPosition?`, `disabled?`. `Panel.value` (shown when active), `keepMounted?`. role=tablist/tab/tabpanel.
 - **`Hb.Menu`** = `{ Root, Item }`. `Root` controlled list (`Omit onChange`), `Item.onClick` via context. Popover-style menu.
 - **`Hb.List`** = `{ Root, Item, ItemText, ItemIcon, ItemButton, ItemAvatar, Subheader }`. Semantic `<ul>` list with rich rows.
 - **`Hb.Table`** = `{ Container, Root, Head, Body, Row, Cell }`. `Root.size?` `"small" | "medium"`, `Container.variant?`, `Cell.align?`. Semantic `<table>` scaffolding.

--- a/apps/hobom-angel/e2e/footer.spec.ts
+++ b/apps/hobom-angel/e2e/footer.spec.ts
@@ -1,14 +1,17 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("global footer", () => {
-  test("shows on desktop with quick + legal links", async ({ page }) => {
+  test("shows on desktop with legal + info links", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("./");
 
     const footer = page.getByRole("contentinfo");
     await expect(footer).toBeVisible();
     await expect(footer.getByRole("link", { name: "이용약관" })).toBeVisible();
-    await expect(footer.getByRole("link", { name: "입양" })).toBeVisible();
+    await expect(footer.getByRole("link", { name: "사업자 정보" })).toBeVisible();
+    await expect(footer.getByRole("link", { name: "동물보호법 고지" })).toBeVisible();
+
+    await footer.screenshot({ path: "e2e-artifacts/footer.png" });
   });
 
   test("is hidden on mobile (bottom tab carries navigation)", async ({ page }) => {

--- a/apps/hobom-angel/e2e/shelter-microsite.spec.ts
+++ b/apps/hobom-angel/e2e/shelter-microsite.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§04 shelter microsite", () => {
+  test("shows the header, verification badge, and the about tab", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter");
+
+    await expect(page.getByRole("heading", { name: "행복보호소", level: 1 })).toBeVisible();
+    await expect(page.getByText("인증 보호소")).toBeVisible();
+    await expect(page.getByRole("tab", { name: /동물 \d+/ })).toBeVisible();
+    await expect(page.getByText("인사말")).toBeVisible();
+    await expect(page.getByText("누적 입양")).toBeVisible();
+    await expect(page.getByText("보호 중")).toBeVisible();
+    await expect(page.getByText("우리 보호소 아이들")).toBeVisible();
+    await expect(page.getByText("방문·후원 안내")).toBeVisible();
+    await expect(page.getByRole("link", { name: "봉사 신청하기" })).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/shelter.png", fullPage: true });
+  });
+
+  test("switches tabs and syncs the active tab to the URL", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter");
+
+    await page.getByRole("tab", { name: /동물 \d+/ }).click();
+    await expect(page).toHaveURL(/tab=animals/);
+    await expect(page.getByRole("link", { name: /상세 보기/ }).first()).toBeVisible();
+
+    await page.getByRole("tab", { name: "공지·소식" }).click();
+    await expect(page).toHaveURL(/tab=notices/);
+    await expect(page.getByText("설 연휴 임시보호 봉사자를 찾습니다")).toBeVisible();
+
+    await page.getByRole("tab", { name: "봉사" }).click();
+    await expect(page).toHaveURL(/tab=volunteer/);
+    await expect(page.getByText("주말 산책 봉사")).toBeVisible();
+
+    await page.getByRole("tab", { name: "FAQ" }).click();
+    await expect(page).toHaveURL(/tab=faq/);
+    await expect(page.getByText("입양 절차가 어떻게 되나요?")).toBeVisible();
+  });
+
+  test("deep-links straight to a tab from the URL", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter?tab=faq");
+
+    await expect(page.getByRole("tab", { name: "FAQ" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByText("임시보호도 신청할 수 있나요?")).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -28,6 +28,9 @@ const AnimalDetailPage = lazy(() =>
 const ApplyAdoptionPage = lazy(() =>
   import("@/pages/apply-adoption").then((module) => ({ default: module.ApplyAdoptionPage })),
 );
+const ShelterDetailPage = lazy(() =>
+  import("@/pages/shelter-detail").then((module) => ({ default: module.ShelterDetailPage })),
+);
 
 // Warm the auth route chunks during idle time so navigating to them is instant.
 const prefetchRoutes = () => {
@@ -40,7 +43,6 @@ const SECTION_ROUTES = [
   ROUTES.FOSTER,
   ROUTES.VOLUNTEER,
   ROUTES.SHELTERS,
-  ROUTES.SHELTER_DETAIL,
   ROUTES.FAVORITES,
   ROUTES.APPLICATIONS,
   ROUTES.MY,
@@ -61,10 +63,13 @@ export const AppRouter = () => {
             {/* Public info surfaces (footer links). */}
             <Route path={ROUTES.TERMS} element={<ComingSoonPage />} />
             <Route path={ROUTES.PRIVACY} element={<ComingSoonPage />} />
+            <Route path={ROUTES.BUSINESS_INFO} element={<ComingSoonPage />} />
+            <Route path={ROUTES.ANIMAL_LAW} element={<ComingSoonPage />} />
             <Route element={<ProtectedRoute />}>
               <Route path={ROUTES.ANIMALS} element={<AnimalsPage />} />
             <Route path={ROUTES.ANIMAL_DETAIL} element={<AnimalDetailPage />} />
             <Route path={ROUTES.APPLY} element={<ApplyAdoptionPage />} />
+            <Route path={ROUTES.SHELTER_DETAIL} element={<ShelterDetailPage />} />
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />
               ))}

--- a/apps/hobom-angel/src/entities/animal/api/animal.api.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.api.ts
@@ -2,7 +2,7 @@ import { httpClient, parseResponse } from "@/shared/api";
 import { toQueryString } from "@/shared/lib";
 import { toAnimal } from "../lib/to-animal.lib";
 import { toAnimalDetail } from "../lib/to-animal-detail.lib";
-import { animalDetailSchema, animalPageSchema } from "./animal.schema";
+import { animalDetailSchema, animalListSchema, animalPageSchema } from "./animal.schema";
 import type { Animal, AnimalDetail } from "../model/animal.model";
 import type { AnimalSearchParams } from "./animal.type";
 
@@ -14,6 +14,7 @@ export interface AnimalPageResult {
 }
 
 const parsePage = parseResponse(animalPageSchema, "GET /animals");
+const parseList = parseResponse(animalListSchema, "GET /shelters/:id/animals");
 const parseDetail = parseResponse(animalDetailSchema, "GET /animals/:id");
 
 /** Search/browse animals (filters + cursor pagination). */
@@ -33,3 +34,10 @@ export const searchAnimals = (
 /** Fetch a single animal's full profile (§02). */
 export const getAnimal = (id: string, signal?: AbortSignal): Promise<AnimalDetail> =>
   httpClient.get(`/animals/${id}`, { signal }).then(parseDetail).then(toAnimalDetail);
+
+/** Fetch a shelter's animal roster (§04). The backend returns a plain array. */
+export const getShelterAnimals = (shelterId: string, signal?: AbortSignal): Promise<Animal[]> =>
+  httpClient
+    .get(`/shelters/${shelterId}/animals`, { signal })
+    .then(parseList)
+    .then((items) => items.map(toAnimal));

--- a/apps/hobom-angel/src/entities/animal/api/animal.queries.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.queries.ts
@@ -1,5 +1,5 @@
 import { infiniteQueryOptions, queryOptions } from "hobom-data";
-import { getAnimal, searchAnimals } from "./animal.api";
+import { getAnimal, getShelterAnimals, searchAnimals } from "./animal.api";
 import type { AnimalSearchParams } from "./animal.type";
 
 /** Everything except the cursor — the cursor is managed by the infinite query. */
@@ -21,5 +21,11 @@ export const animalQueries = {
     queryOptions({
       queryKey: [...animalQueries.all(), "detail", id] as const,
       queryFn: ({ signal }) => getAnimal(id, signal),
+    }),
+
+  byShelter: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...animalQueries.all(), "byShelter", shelterId] as const,
+      queryFn: ({ signal }) => getShelterAnimals(shelterId, signal),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
@@ -32,6 +32,9 @@ export const animalPageSchema: Schema<AnimalPage> = HoBomSchema.object({
   hasNext: HoBomSchema.boolean(),
 });
 
+/** `GET /shelters/:id/animals` — the shelter roster is a plain array, not a page. */
+export const animalListSchema: Schema<RawAnimal[]> = HoBomSchema.array(animalSchema);
+
 /** `GET /animals/:id` response schema — the list fields plus health and intake. */
 export const animalDetailSchema: Schema<RawAnimalDetail> = HoBomSchema.object({
   ...animalFields,

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -1,0 +1,61 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toShelter, toShelterAnnouncement, toShelterFaq } from "../lib/to-shelter.lib";
+import {
+  shelterAnnouncementsSchema,
+  shelterFaqsSchema,
+  shelterSchema,
+  shelterStatsSchema,
+} from "./shelter.schema";
+import type {
+  Shelter,
+  ShelterAnnouncement,
+  ShelterFaq,
+  ShelterStats,
+} from "../model/shelter.model";
+
+const parseShelter = parseResponse(shelterSchema, "GET /shelters/:slug");
+const parseAnnouncements = parseResponse(
+  shelterAnnouncementsSchema,
+  "GET /shelters/:id/announcements",
+);
+const parseFaqs = parseResponse(shelterFaqsSchema, "GET /shelters/:id/faqs");
+const parseStats = parseResponse(shelterStatsSchema, "GET /shelters/:id/stats");
+
+/** Fetch a shelter's public microsite profile by slug (§04). */
+export const getShelterBySlug = (slug: string, signal?: AbortSignal): Promise<Shelter> =>
+  httpClient.get(`/shelters/${slug}`, { signal }).then(parseShelter).then(toShelter);
+
+/** Fetch a shelter's notices/news, pinned first. */
+export const getShelterAnnouncements = (
+  shelterId: string,
+  signal?: AbortSignal,
+): Promise<ShelterAnnouncement[]> =>
+  httpClient
+    .get(`/shelters/${shelterId}/announcements`, { signal })
+    .then(parseAnnouncements)
+    .then((items) =>
+      items
+        .map(toShelterAnnouncement)
+        .sort((a, b) => Number(b.pinned) - Number(a.pinned)),
+    );
+
+/** Fetch a shelter's FAQ entries. */
+export const getShelterFaqs = (
+  shelterId: string,
+  signal?: AbortSignal,
+): Promise<ShelterFaq[]> =>
+  httpClient
+    .get(`/shelters/${shelterId}/faqs`, { signal })
+    .then(parseFaqs)
+    .then((items) => items.map(toShelterFaq));
+
+const EMPTY_STATS: ShelterStats = { adoptedCount: 0, shelteredCount: 0, availableCount: 0 };
+
+/** Fetch a shelter's aggregate counts (adopted / sheltered / available).
+ *  Normalized so a missing/partial payload degrades to zeros instead of
+ *  crashing the microsite (advisory validation can pass raw data through). */
+export const getShelterStats = (shelterId: string, signal?: AbortSignal): Promise<ShelterStats> =>
+  httpClient
+    .get(`/shelters/${shelterId}/stats`, { signal })
+    .then(parseStats)
+    .then((raw): ShelterStats => ({ ...EMPTY_STATS, ...raw }));

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
@@ -1,0 +1,35 @@
+import { queryOptions } from "hobom-data";
+import {
+  getShelterAnnouncements,
+  getShelterBySlug,
+  getShelterFaqs,
+  getShelterStats,
+} from "./shelter.api";
+
+export const shelterQueries = {
+  all: () => ["shelters"] as const,
+
+  detail: (slug: string) =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), "detail", slug] as const,
+      queryFn: ({ signal }) => getShelterBySlug(slug, signal),
+    }),
+
+  announcements: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), shelterId, "announcements"] as const,
+      queryFn: ({ signal }) => getShelterAnnouncements(shelterId, signal),
+    }),
+
+  faqs: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), shelterId, "faqs"] as const,
+      queryFn: ({ signal }) => getShelterFaqs(shelterId, signal),
+    }),
+
+  stats: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), shelterId, "stats"] as const,
+      queryFn: ({ signal }) => getShelterStats(shelterId, signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -1,0 +1,65 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type {
+  RawShelter,
+  RawShelterAnnouncement,
+  RawShelterFaq,
+  RawShelterStats,
+} from "./shelter.type";
+
+/** `GET /shelters/:slug` — validates the wire contract at the boundary. */
+export const shelterSchema: Schema<RawShelter> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  name: HoBomSchema.string(),
+  slug: HoBomSchema.string(),
+  status: HoBomSchema.enum(["PENDING_VERIFICATION", "VERIFIED", "REJECTED", "SUSPENDED"]),
+  trustTier: HoBomSchema.enum(["A", "B"]).nullable(),
+  addressVisibility: HoBomSchema.enum(["FULL", "PARTIAL", "HIDDEN"]),
+  address: HoBomSchema.object({
+    region: HoBomSchema.string(),
+    city: HoBomSchema.string().optional(),
+    roadAddress: HoBomSchema.string().optional(),
+    lat: HoBomSchema.number().optional(),
+    lng: HoBomSchema.number().optional(),
+  }),
+  facilityPhotos: HoBomSchema.array(
+    HoBomSchema.object({
+      objectKey: HoBomSchema.string(),
+      kind: HoBomSchema.enum(["EXTERIOR", "INTERIOR", "OTHER"]),
+      caption: HoBomSchema.string().optional(),
+    }),
+  ),
+  intro: HoBomSchema.string().nullable(),
+  operatingSince: HoBomSchema.string().nullable(),
+  representativeName: HoBomSchema.string().nullable(),
+  visitGuide: HoBomSchema.string().nullable(),
+  supportGuide: HoBomSchema.string().nullable(),
+  coverImageKey: HoBomSchema.string().nullable(),
+});
+
+/** `GET /shelters/:shelterId/announcements`. */
+export const shelterAnnouncementsSchema: Schema<RawShelterAnnouncement[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    id: HoBomSchema.string(),
+    title: HoBomSchema.string(),
+    body: HoBomSchema.string(),
+    pinned: HoBomSchema.boolean(),
+    createdAt: HoBomSchema.string().nullable(),
+  }),
+);
+
+/** `GET /shelters/:shelterId/faqs`. */
+export const shelterFaqsSchema: Schema<RawShelterFaq[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    id: HoBomSchema.string(),
+    question: HoBomSchema.string(),
+    answer: HoBomSchema.string(),
+  }),
+);
+
+/** `GET /shelters/:shelterId/stats`. */
+export const shelterStatsSchema: Schema<RawShelterStats> = HoBomSchema.object({
+  adoptedCount: HoBomSchema.number(),
+  shelteredCount: HoBomSchema.number(),
+  availableCount: HoBomSchema.number(),
+});

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -1,0 +1,61 @@
+import type {
+  AddressVisibility,
+  FacilityPhotoKind,
+  ShelterStatus,
+  TrustTier,
+} from "../model/shelter.model";
+
+export interface RawShelterAddress {
+  region: string;
+  city?: string;
+  roadAddress?: string;
+  lat?: number;
+  lng?: number;
+}
+
+export interface RawFacilityPhoto {
+  objectKey: string;
+  kind: FacilityPhotoKind;
+  caption?: string;
+}
+
+/** `GET /shelters/:slug` response. */
+export interface RawShelter {
+  id: string;
+  name: string;
+  slug: string;
+  status: ShelterStatus;
+  trustTier: TrustTier | null;
+  addressVisibility: AddressVisibility;
+  address: RawShelterAddress;
+  facilityPhotos: RawFacilityPhoto[];
+  intro: string | null;
+  operatingSince: string | null;
+  representativeName: string | null;
+  visitGuide: string | null;
+  supportGuide: string | null;
+  coverImageKey: string | null;
+}
+
+/** `GET /shelters/:shelterId/announcements` item. */
+export interface RawShelterAnnouncement {
+  id: string;
+  title: string;
+  body: string;
+  pinned: boolean;
+  createdAt: string | null;
+}
+
+/** `GET /shelters/:shelterId/faqs` item. */
+export interface RawShelterFaq {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+/** `GET /shelters/:shelterId/stats` response. */
+export interface RawShelterStats {
+  adoptedCount: number;
+  shelteredCount: number;
+  availableCount: number;
+}

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -1,0 +1,21 @@
+export { shelterQueries } from "./api/shelter.queries";
+export { toShelter } from "./lib/to-shelter.lib";
+export { formatShelterAddress } from "./lib/format-shelter-address.lib";
+export { operatingYears } from "./lib/operating-years.lib";
+export {
+  isShelterVerified,
+  isPreciseAddress,
+  TRUST_TIER_LABEL,
+} from "./model/shelter.model";
+export type {
+  Shelter,
+  ShelterAddress,
+  ShelterAnnouncement,
+  ShelterFaq,
+  ShelterStats,
+  ShelterStatus,
+  TrustTier,
+  AddressVisibility,
+  FacilityPhoto,
+  FacilityPhotoKind,
+} from "./model/shelter.model";

--- a/apps/hobom-angel/src/entities/shelter/lib/format-shelter-address.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/format-shelter-address.lib.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatShelterAddress } from "./format-shelter-address.lib";
+import type { ShelterAddress } from "../model/shelter.model";
+
+const base: ShelterAddress = {
+  region: "서울",
+  city: null,
+  roadAddress: null,
+  lat: null,
+  lng: null,
+};
+
+describe("formatShelterAddress", () => {
+  it("joins region, city, and road address when the policy is FULL", () => {
+    expect(formatShelterAddress({ ...base, city: "강남구", roadAddress: "테헤란로 123" })).toBe(
+      "서울 강남구 테헤란로 123",
+    );
+  });
+
+  it("drops the hidden road address for a PARTIAL policy", () => {
+    expect(formatShelterAddress({ ...base, city: "강남구" })).toBe("서울 강남구");
+  });
+
+  it("shows only the region for a HIDDEN policy", () => {
+    expect(formatShelterAddress(base)).toBe("서울");
+  });
+});

--- a/apps/hobom-angel/src/entities/shelter/lib/format-shelter-address.lib.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/format-shelter-address.lib.ts
@@ -1,0 +1,6 @@
+import type { ShelterAddress } from "../model/shelter.model";
+
+/** Join whatever address parts the disclosure policy exposed into one line,
+ *  e.g. "서울 강남구 테헤란로 123" (FULL) or "서울 강남구" (PARTIAL) or "서울" (HIDDEN). */
+export const formatShelterAddress = (address: ShelterAddress): string =>
+  [address.region, address.city, address.roadAddress].filter(Boolean).join(" ");

--- a/apps/hobom-angel/src/entities/shelter/lib/operating-years.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/operating-years.lib.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { operatingYears } from "./operating-years.lib";
+
+const now = new Date("2026-07-15T00:00:00.000Z");
+
+describe("operatingYears", () => {
+  it("counts whole years since the start date", () => {
+    expect(operatingYears("2015-03-01T00:00:00.000Z", now)).toBe(11);
+  });
+
+  it("does not count the current year before the anniversary", () => {
+    expect(operatingYears("2015-12-31T00:00:00.000Z", now)).toBe(10);
+  });
+
+  it("returns null for a missing or invalid date", () => {
+    expect(operatingYears(null, now)).toBeNull();
+    expect(operatingYears("not-a-date", now)).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/entities/shelter/lib/operating-years.lib.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/operating-years.lib.ts
@@ -1,0 +1,18 @@
+/** Whole years the shelter has been operating, from its start date to `now`.
+ *  Null when there's no (valid) start date. */
+export const operatingYears = (operatingSince: string | null, now: Date): number | null => {
+  if (!operatingSince) return null;
+
+  const start = new Date(operatingSince);
+
+  if (Number.isNaN(start.getTime())) return null;
+
+  let years = now.getFullYear() - start.getFullYear();
+  const beforeAnniversary =
+    now.getMonth() < start.getMonth() ||
+    (now.getMonth() === start.getMonth() && now.getDate() < start.getDate());
+
+  if (beforeAnniversary) years -= 1;
+
+  return Math.max(years, 0);
+};

--- a/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { toShelter } from "./to-shelter.lib";
+import type { RawShelter } from "../api/shelter.type";
+
+const raw: RawShelter = {
+  id: "shelter-1",
+  name: "행복보호소",
+  slug: "haengbok",
+  status: "VERIFIED",
+  trustTier: "A",
+  addressVisibility: "PARTIAL",
+  address: { region: "서울", city: "강남구" },
+  facilityPhotos: [
+    { objectKey: "a.jpg", kind: "EXTERIOR", caption: "외관" },
+    { objectKey: "b.jpg", kind: "OTHER" },
+  ],
+  intro: "인사말 본문",
+  operatingSince: "2015-03-01T00:00:00.000Z",
+  representativeName: "김보호",
+  visitGuide: "방문 안내",
+  supportGuide: "후원 안내",
+  coverImageKey: "https://cdn.example.com/cover.jpg",
+};
+
+describe("toShelter", () => {
+  it("normalizes address parts the policy omitted to null", () => {
+    const shelter = toShelter(raw);
+
+    expect(shelter.address.city).toBe("강남구");
+    expect(shelter.address.roadAddress).toBeNull();
+    expect(shelter.address.lat).toBeNull();
+  });
+
+  it("maps facility photo objectKey to url and absent caption to null", () => {
+    const shelter = toShelter(raw);
+
+    expect(shelter.facilityPhotos[0]).toEqual({ url: "a.jpg", kind: "EXTERIOR", caption: "외관" });
+    expect(shelter.facilityPhotos[1]?.caption).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.ts
@@ -1,0 +1,49 @@
+import type {
+  RawShelter,
+  RawShelterAnnouncement,
+  RawShelterFaq,
+} from "../api/shelter.type";
+import type { Shelter, ShelterAnnouncement, ShelterFaq } from "../model/shelter.model";
+
+/** Anti-corruption: flatten the API shelter (optional address parts, objectKey
+ *  photos) into the UI model, normalizing absent fields to null. */
+export const toShelter = (raw: RawShelter): Shelter => ({
+  id: raw.id,
+  slug: raw.slug,
+  name: raw.name,
+  status: raw.status,
+  trustTier: raw.trustTier,
+  addressVisibility: raw.addressVisibility,
+  address: {
+    region: raw.address.region,
+    city: raw.address.city ?? null,
+    roadAddress: raw.address.roadAddress ?? null,
+    lat: raw.address.lat ?? null,
+    lng: raw.address.lng ?? null,
+  },
+  facilityPhotos: raw.facilityPhotos.map((photo) => ({
+    url: photo.objectKey,
+    kind: photo.kind,
+    caption: photo.caption ?? null,
+  })),
+  intro: raw.intro,
+  operatingSince: raw.operatingSince,
+  representativeName: raw.representativeName,
+  visitGuide: raw.visitGuide,
+  supportGuide: raw.supportGuide,
+  coverImageUrl: raw.coverImageKey,
+});
+
+export const toShelterAnnouncement = (raw: RawShelterAnnouncement): ShelterAnnouncement => ({
+  id: raw.id,
+  title: raw.title,
+  body: raw.body,
+  pinned: raw.pinned,
+  createdAt: raw.createdAt,
+});
+
+export const toShelterFaq = (raw: RawShelterFaq): ShelterFaq => ({
+  id: raw.id,
+  question: raw.question,
+  answer: raw.answer,
+});

--- a/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
+++ b/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
@@ -1,0 +1,77 @@
+export type ShelterStatus = "PENDING_VERIFICATION" | "VERIFIED" | "REJECTED" | "SUSPENDED";
+export type TrustTier = "A" | "B";
+export type AddressVisibility = "FULL" | "PARTIAL" | "HIDDEN";
+export type FacilityPhotoKind = "EXTERIOR" | "INTERIOR" | "OTHER";
+
+/** The shelter's address, projected by the backend per its disclosure policy —
+ *  fields the policy hides simply arrive absent (null here). */
+export interface ShelterAddress {
+  region: string;
+  city: string | null;
+  roadAddress: string | null;
+  lat: number | null;
+  lng: number | null;
+}
+
+export interface FacilityPhoto {
+  url: string;
+  kind: FacilityPhotoKind;
+  caption: string | null;
+}
+
+/** The shelter the microsite renders — a flattened, display-ready view. */
+export interface Shelter {
+  id: string;
+  slug: string;
+  name: string;
+  status: ShelterStatus;
+  trustTier: TrustTier | null;
+  addressVisibility: AddressVisibility;
+  address: ShelterAddress;
+  facilityPhotos: FacilityPhoto[];
+  /** Editor-authored greeting/introduction (Markdown). */
+  intro: string | null;
+  /** ISO date the shelter began operating — the client derives years active. */
+  operatingSince: string | null;
+  representativeName: string | null;
+  /** Visit guidance (Markdown). */
+  visitGuide: string | null;
+  /** Donation/support guidance (Markdown). */
+  supportGuide: string | null;
+  /** Microsite cover/hero image URL. */
+  coverImageUrl: string | null;
+}
+
+/** A shelter notice/news post (공지·소식 tab). */
+export interface ShelterAnnouncement {
+  id: string;
+  title: string;
+  body: string;
+  pinned: boolean;
+  createdAt: string | null;
+}
+
+/** A shelter FAQ entry (FAQ tab). */
+export interface ShelterFaq {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+/** Aggregate counts shown on the About tab (§04). */
+export interface ShelterStats {
+  adoptedCount: number;
+  shelteredCount: number;
+  availableCount: number;
+}
+
+/** Only VERIFIED shelters show the ✓ badge and get PII privileges. */
+export const isShelterVerified = (status: ShelterStatus): boolean => status === "VERIFIED";
+
+/** The precise road address is only shown when the policy is FULL. */
+export const isPreciseAddress = (visibility: AddressVisibility): boolean => visibility === "FULL";
+
+export const TRUST_TIER_LABEL: Record<TrustTier, string> = {
+  A: "인증 단체",
+  B: "인증 활동가",
+};

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
@@ -1,0 +1,19 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toVolunteerEvent } from "../lib/to-volunteer-event.lib";
+import { volunteerEventsSchema } from "./volunteer-event.schema";
+import type { VolunteerEvent } from "../model/volunteer-event.model";
+
+const parseVolunteerEvents = parseResponse(
+  volunteerEventsSchema,
+  "GET /shelters/:id/volunteer-events",
+);
+
+/** Fetch a shelter's volunteer events (§04 봉사 tab). */
+export const getShelterVolunteerEvents = (
+  shelterId: string,
+  signal?: AbortSignal,
+): Promise<VolunteerEvent[]> =>
+  httpClient
+    .get(`/shelters/${shelterId}/volunteer-events`, { signal })
+    .then(parseVolunteerEvents)
+    .then((items) => items.map(toVolunteerEvent));

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from "hobom-data";
+import { getShelterVolunteerEvents } from "./volunteer-event.api";
+
+export const volunteerEventQueries = {
+  all: () => ["volunteer-events"] as const,
+
+  byShelter: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...volunteerEventQueries.all(), shelterId] as const,
+      queryFn: ({ signal }) => getShelterVolunteerEvents(shelterId, signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
@@ -1,0 +1,18 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { RawVolunteerEvent } from "./volunteer-event.type";
+
+/** `GET /shelters/:shelterId/volunteer-events` — validates the wire contract at
+ *  the boundary. shelterId is omitted; object() strips unknown keys. */
+export const volunteerEventsSchema: Schema<RawVolunteerEvent[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    id: HoBomSchema.string(),
+    title: HoBomSchema.string(),
+    description: HoBomSchema.string(),
+    startAt: HoBomSchema.string(),
+    endAt: HoBomSchema.string(),
+    capacity: HoBomSchema.number(),
+    signedUpCount: HoBomSchema.number(),
+    status: HoBomSchema.enum(["OPEN", "CLOSED", "CANCELLED"]),
+  }),
+);

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
@@ -1,0 +1,15 @@
+import type { VolunteerEventStatus } from "../model/volunteer-event.model";
+
+/** `GET /shelters/:shelterId/volunteer-events` item. The wire sends `shelterId`,
+ *  but the schema strips it (redundant — the caller already holds it), so it is
+ *  absent from the parsed shape. */
+export interface RawVolunteerEvent {
+  id: string;
+  title: string;
+  description: string;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+  signedUpCount: number;
+  status: VolunteerEventStatus;
+}

--- a/apps/hobom-angel/src/entities/volunteer-event/index.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/index.ts
@@ -1,0 +1,3 @@
+export { volunteerEventQueries } from "./api/volunteer-event.queries";
+export { VOLUNTEER_STATUS_LABEL } from "./model/volunteer-event.model";
+export type { VolunteerEvent, VolunteerEventStatus } from "./model/volunteer-event.model";

--- a/apps/hobom-angel/src/entities/volunteer-event/lib/to-volunteer-event.lib.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/lib/to-volunteer-event.lib.ts
@@ -1,0 +1,15 @@
+import type { RawVolunteerEvent } from "../api/volunteer-event.type";
+import type { VolunteerEvent } from "../model/volunteer-event.model";
+
+/** Anti-corruption: map the API event to the UI model (straight field copy;
+ *  kept for consistency with the entity's other boundaries). */
+export const toVolunteerEvent = (raw: RawVolunteerEvent): VolunteerEvent => ({
+  id: raw.id,
+  title: raw.title,
+  description: raw.description,
+  startAt: raw.startAt,
+  endAt: raw.endAt,
+  capacity: raw.capacity,
+  signedUpCount: raw.signedUpCount,
+  status: raw.status,
+});

--- a/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
@@ -1,0 +1,21 @@
+export type VolunteerEventStatus = "OPEN" | "CLOSED" | "CANCELLED";
+
+/** A shelter's volunteer event as the microsite renders it (§04 봉사 tab). */
+export interface VolunteerEvent {
+  id: string;
+  title: string;
+  description: string;
+  /** ISO date the event starts. */
+  startAt: string;
+  /** ISO date the event ends. */
+  endAt: string;
+  capacity: number;
+  signedUpCount: number;
+  status: VolunteerEventStatus;
+}
+
+export const VOLUNTEER_STATUS_LABEL: Record<VolunteerEventStatus, string> = {
+  OPEN: "모집 중",
+  CLOSED: "마감",
+  CANCELLED: "취소됨",
+};

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalResults.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalResults.tsx
@@ -28,7 +28,8 @@ export const AnimalResults = ({ filters, activeChips, onReset }: AnimalResultsPr
             key={chip.label}
             label={chip.label}
             size="small"
-            variant="outlined"
+            variant="soft"
+            color="primary"
             onDelete={chip.onRemove}
           />
         ))}

--- a/apps/hobom-angel/src/features/shelter-microsite/index.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/index.ts
@@ -1,0 +1,1 @@
+export { ShelterMicrosite } from "./ui/ShelterMicrosite";

--- a/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.spec.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isShelterTab } from "./shelter-tabs.lib";
+
+describe("isShelterTab", () => {
+  it("accepts the known tab values", () => {
+    expect(isShelterTab("about")).toBe(true);
+    expect(isShelterTab("animals")).toBe(true);
+    expect(isShelterTab("notices")).toBe(true);
+    expect(isShelterTab("volunteer")).toBe(true);
+    expect(isShelterTab("faq")).toBe(true);
+  });
+
+  it("rejects unknown values and null", () => {
+    expect(isShelterTab("stats")).toBe(false);
+    expect(isShelterTab(null)).toBe(false);
+  });
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.ts
@@ -1,0 +1,16 @@
+export type ShelterTab = "about" | "animals" | "notices" | "volunteer" | "faq";
+
+export const SHELTER_TABS: { value: ShelterTab; label: string }[] = [
+  { value: "about", label: "소개" },
+  { value: "animals", label: "동물" },
+  { value: "notices", label: "공지·소식" },
+  { value: "volunteer", label: "봉사" },
+  { value: "faq", label: "FAQ" },
+];
+
+export const isShelterTab = (value: string | null): value is ShelterTab =>
+  value === "about" ||
+  value === "animals" ||
+  value === "notices" ||
+  value === "volunteer" ||
+  value === "faq";

--- a/apps/hobom-angel/src/features/shelter-microsite/model/useShelterMicrosite.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/model/useShelterMicrosite.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from "hobom-data";
+import { shelterQueries } from "@/entities/shelter";
+import type { Shelter } from "@/entities/shelter";
+
+/** Suspense-backed shelter profile by slug (§04). A missing/failed fetch bubbles
+ *  to the route boundary. */
+export const useShelterMicrosite = (slug: string): Shelter => {
+  const { data } = useSuspenseQuery(shelterQueries.detail(slug));
+
+  return data;
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/model/useShelterTab.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/model/useShelterTab.ts
@@ -1,0 +1,17 @@
+import { useSearchParamsState } from "@/shared/model";
+import type { SearchParamsCodec } from "@/shared/model";
+import { isShelterTab } from "../lib/shelter-tabs.lib";
+import type { ShelterTab } from "../lib/shelter-tabs.lib";
+
+// `?tab=` keeps the active tab in the URL so it's shareable and survives reload.
+// The default tab ("about") encodes to an empty query for a clean URL.
+const TAB_CODEC: SearchParamsCodec<ShelterTab> = {
+  decode: (params) => {
+    const tab = params.get("tab");
+
+    return isShelterTab(tab) ? tab : "about";
+  },
+  encode: (tab) => new URLSearchParams(tab === "about" ? {} : { tab }),
+};
+
+export const useShelterTab = () => useSearchParamsState(TAB_CODEC);

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.styles.ts
@@ -1,0 +1,22 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  row: {
+    display: "flex",
+    alignItems: "center",
+    gap: 16,
+  },
+  avatar: {
+    width: 60,
+    height: 60,
+    borderRadius: 16,
+    flexShrink: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "var(--hb-color-success-subtle)",
+    color: "var(--hb-color-success)",
+    fontSize: "1.5rem",
+    fontWeight: 700,
+  },
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.tsx
@@ -1,0 +1,54 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { formatShelterAddress, isShelterVerified, TRUST_TIER_LABEL } from "@/entities/shelter";
+import type { AddressVisibility, Shelter } from "@/entities/shelter";
+import { styles } from "./ShelterHeader.styles";
+
+const VISIBILITY_NOTE: Record<AddressVisibility, string> = {
+  FULL: "",
+  PARTIAL: " (상세주소 부분공개)",
+  HIDDEN: " (지역만 공개)",
+};
+
+/** §04 microsite header: cover image, avatar, name + verification/trust badges,
+ *  and the address·representative line. Composed from DS primitives. */
+export const ShelterHeader = ({ shelter }: { shelter: Shelter }) => {
+  const rep = shelter.representativeName ? ` · 대표 ${shelter.representativeName}` : "";
+  const addressLine = `${formatShelterAddress(shelter.address)}${VISIBILITY_NOTE[shelter.addressVisibility]}${rep}`;
+
+  return (
+    <Hb.Stack spacing={2}>
+      {shelter.coverImageUrl && (
+        <Hb.Image
+          src={shelter.coverImageUrl}
+          alt={`${shelter.name} 커버 이미지`}
+          ratio="16 / 5"
+          priority
+          style={{ borderRadius: 16 }}
+        />
+      )}
+
+      <div {...stylex.props(styles.row)}>
+        <span {...stylex.props(styles.avatar)} aria-hidden="true">
+          {shelter.name.slice(0, 1)}
+        </span>
+        <Hb.Stack spacing={0.5}>
+          <Hb.Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
+            <Hb.Text variant="h4" component="h1">
+              {shelter.name}
+            </Hb.Text>
+            {isShelterVerified(shelter.status) && (
+              <Hb.Chip label="인증 보호소" color="success" variant="soft" size="small" />
+            )}
+            {shelter.trustTier && (
+              <Hb.Chip label={TRUST_TIER_LABEL[shelter.trustTier]} variant="soft" size="small" />
+            )}
+          </Hb.Stack>
+          <Hb.Text variant="body2" color="text.secondary">
+            {addressLine}
+          </Hb.Text>
+        </Hb.Stack>
+      </div>
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.styles.ts
@@ -1,0 +1,17 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  // A tab panel needs a min-height so switching to a suspending tab doesn't
+  // collapse the page height while its data loads.
+  panel: {
+    minHeight: 240,
+    paddingTop: 20,
+  },
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.tsx
@@ -1,0 +1,70 @@
+import { Suspense } from "react";
+import { useSuspenseQuery } from "hobom-data";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { shelterQueries } from "@/entities/shelter";
+import { LoadingState } from "@/shared/ui";
+import { SHELTER_TABS } from "../lib/shelter-tabs.lib";
+import { useShelterMicrosite } from "../model/useShelterMicrosite";
+import { useShelterTab } from "../model/useShelterTab";
+import { ShelterHeader } from "./ShelterHeader";
+import { AboutTab } from "./tabs/AboutTab";
+import { AnimalsTab } from "./tabs/AnimalsTab";
+import { FaqTab } from "./tabs/FaqTab";
+import { NoticesTab } from "./tabs/NoticesTab";
+import { VolunteerTab } from "./tabs/VolunteerTab";
+import { styles } from "./ShelterMicrosite.styles";
+
+/** §04 shelter microsite: header + tabbed content. The active tab is URL-synced;
+ *  each content tab loads its own data and suspends locally. */
+export const ShelterMicrosite = ({ slug }: { slug: string }) => {
+  const shelter = useShelterMicrosite(slug);
+  const { data: stats } = useSuspenseQuery(shelterQueries.stats(shelter.id));
+  const [tab, setTab] = useShelterTab();
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <Hb.Stack spacing={3}>
+        <ShelterHeader shelter={shelter} />
+
+        <Hb.Tabs.Provider value={tab} onChange={(_, value) => setTab(value)}>
+          <Hb.Tabs.Root>
+            {SHELTER_TABS.map((item) => (
+              <Hb.Tabs.Item
+                key={item.value}
+                value={item.value}
+                label={item.value === "animals" ? `동물 ${stats.shelteredCount}` : item.label}
+              />
+            ))}
+          </Hb.Tabs.Root>
+
+          <Hb.Tabs.Panel value="about" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <AboutTab shelter={shelter} stats={stats} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+          <Hb.Tabs.Panel value="animals" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <AnimalsTab shelterId={shelter.id} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+          <Hb.Tabs.Panel value="notices" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <NoticesTab shelterId={shelter.id} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+          <Hb.Tabs.Panel value="volunteer" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <VolunteerTab shelterId={shelter.id} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+          <Hb.Tabs.Panel value="faq" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <FaqTab shelterId={shelter.id} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+        </Hb.Tabs.Provider>
+      </Hb.Stack>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AboutTab.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AboutTab.styles.ts
@@ -1,0 +1,18 @@
+import * as stylex from "@stylexjs/stylex";
+
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  // Main content + sidebar (§04 design: 1.5fr / 1fr).
+  grid: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [DESKTOP]: "1.5fr 1fr" },
+    gap: 24,
+    alignItems: "start",
+  },
+  preview: {
+    display: "grid",
+    gridTemplateColumns: { default: "repeat(2, 1fr)", [DESKTOP]: "repeat(4, 1fr)" },
+    gap: 12,
+  },
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AboutTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AboutTab.tsx
@@ -1,0 +1,94 @@
+import { Link } from "react-router-dom";
+import { useSuspenseQuery } from "hobom-data";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { AnimalCard, STATUS_LABEL, animalMeta, animalQueries } from "@/entities/animal";
+import { formatShelterAddress, operatingYears } from "@/entities/shelter";
+import { ROUTES, animalDetailPath } from "@/shared/config";
+import type { Shelter, ShelterStats } from "@/entities/shelter";
+import { styles } from "./AboutTab.styles";
+
+/** 소개 tab — greeting, stat cards, and an animal preview on the left; visit /
+ *  support guidance and a volunteer CTA in the sidebar. Matches the §04 design. */
+export const AboutTab = ({ shelter, stats }: { shelter: Shelter; stats: ShelterStats }) => {
+  const { data: roster } = useSuspenseQuery(animalQueries.byShelter(shelter.id));
+  const years = operatingYears(shelter.operatingSince, new Date());
+  const preview = roster.slice(0, 4);
+
+  const statItems = [
+    { value: stats.adoptedCount.toLocaleString(), label: "누적 입양" },
+    { value: stats.shelteredCount.toLocaleString(), label: "보호 중" },
+    ...(years != null ? [{ value: `${years}년`, label: "운영" }] : []),
+  ];
+
+  return (
+    <div {...stylex.props(styles.grid)}>
+      <Hb.Stack spacing={3}>
+        {shelter.facilityPhotos.length > 0 && (
+          <Hb.Gallery
+            images={shelter.facilityPhotos.map((photo) => ({
+              src: photo.url,
+              alt: photo.caption ?? `${shelter.name} 시설 사진`,
+            }))}
+            alt={`${shelter.name} 시설`}
+            ratio="16 / 9"
+          />
+        )}
+
+        {shelter.intro && (
+          <Hb.SectionCard title="인사말">
+            <Hb.Markdown>{shelter.intro}</Hb.Markdown>
+          </Hb.SectionCard>
+        )}
+
+        <Hb.StatGroup.Root columns={statItems.length} variant="card">
+          {statItems.map((item) => (
+            <Hb.StatGroup.Item key={item.label} value={item.value} label={item.label} />
+          ))}
+        </Hb.StatGroup.Root>
+
+        {preview.length > 0 && (
+          <Hb.SectionCard
+            title="우리 보호소 아이들"
+            action={
+              <Link to="?tab=animals" style={{ color: "inherit" }}>
+                <Hb.Button size="small" variant="ghost">
+                  전체 보기
+                </Hb.Button>
+              </Link>
+            }
+          >
+            <div {...stylex.props(styles.preview)}>
+              {preview.map((animal) => (
+                <AnimalCard
+                  key={animal.id}
+                  name={animal.name}
+                  status={STATUS_LABEL[animal.status]}
+                  meta={animalMeta(animal)}
+                  imageUrl={animal.photoUrl}
+                  to={animalDetailPath(animal.id)}
+                />
+              ))}
+            </div>
+          </Hb.SectionCard>
+        )}
+      </Hb.Stack>
+
+      <Hb.SectionCard title="방문·후원 안내">
+        <Hb.DescriptionList.Root layout="stacked">
+          <Hb.DescriptionList.Item term="지역">
+            {formatShelterAddress(shelter.address)}
+          </Hb.DescriptionList.Item>
+          <Hb.DescriptionList.Item term="문의">사이트 메시지로 연락</Hb.DescriptionList.Item>
+        </Hb.DescriptionList.Root>
+        {shelter.visitGuide && <Hb.Markdown>{shelter.visitGuide}</Hb.Markdown>}
+        {shelter.supportGuide && <Hb.Markdown>{shelter.supportGuide}</Hb.Markdown>}
+        <Link to={ROUTES.VOLUNTEER} style={{ textDecoration: "none" }}>
+          <Hb.Button variant="primary" fullWidth>
+            봉사 신청하기
+          </Hb.Button>
+        </Link>
+      </Hb.SectionCard>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AnimalsTab.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AnimalsTab.styles.ts
@@ -1,0 +1,16 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  grid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(2, 1fr)",
+      [TABLET]: "repeat(3, 1fr)",
+      [DESKTOP]: "repeat(4, 1fr)",
+    },
+    gap: { default: 12, [DESKTOP]: 16 },
+  },
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AnimalsTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/AnimalsTab.tsx
@@ -1,0 +1,37 @@
+import { useSuspenseQuery } from "hobom-data";
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState } from "hobom-design-system";
+import { InboxOutlined } from "hobom-design-system/icons";
+import { AnimalCard, STATUS_LABEL, animalMeta, animalQueries } from "@/entities/animal";
+import { animalDetailPath } from "@/shared/config";
+import { styles } from "./AnimalsTab.styles";
+
+/** 우리 아이들 tab — the shelter's animal roster (first page). Reuses the
+ *  entity's AnimalCard so cards match the browse/landing screens. */
+export const AnimalsTab = ({ shelterId }: { shelterId: string }) => {
+  const { data: animals } = useSuspenseQuery(animalQueries.byShelter(shelterId));
+
+  if (animals.length === 0) {
+    return (
+      <EmptyState
+        icon={<InboxOutlined style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />}
+        message="아직 소개할 아이가 없어요."
+      />
+    );
+  }
+
+  return (
+    <div {...stylex.props(styles.grid)}>
+      {animals.map((animal) => (
+        <AnimalCard
+          key={animal.id}
+          name={animal.name}
+          status={STATUS_LABEL[animal.status]}
+          meta={animalMeta(animal)}
+          imageUrl={animal.photoUrl}
+          to={animalDetailPath(animal.id)}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/FaqTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/FaqTab.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useSuspenseQuery } from "hobom-data";
+import { EmptyState, Hb } from "hobom-design-system";
+import { ArticleOutlined, ExpandMore } from "hobom-design-system/icons";
+import { shelterQueries } from "@/entities/shelter";
+import type { ShelterFaq } from "@/entities/shelter";
+
+const FaqItem = ({ faq }: { faq: ShelterFaq }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Hb.Accordion.Root expanded={open} onChange={(_, next) => setOpen(next)}>
+      <Hb.Accordion.Summary expandIcon={<ExpandMore />}>{faq.question}</Hb.Accordion.Summary>
+      <Hb.Accordion.Details>
+        <Hb.Text variant="body2" color="text.secondary" style={{ whiteSpace: "pre-line" }}>
+          {faq.answer}
+        </Hb.Text>
+      </Hb.Accordion.Details>
+    </Hb.Accordion.Root>
+  );
+};
+
+/** FAQ tab — each entry an independently toggled accordion. */
+export const FaqTab = ({ shelterId }: { shelterId: string }) => {
+  const { data } = useSuspenseQuery(shelterQueries.faqs(shelterId));
+
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={<ArticleOutlined style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />}
+        message="등록된 FAQ가 없어요."
+      />
+    );
+  }
+
+  return (
+    <Hb.Stack spacing={1}>
+      {data.map((faq) => (
+        <FaqItem key={faq.id} faq={faq} />
+      ))}
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/NoticesTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/NoticesTab.tsx
@@ -1,0 +1,50 @@
+import { useSuspenseQuery } from "hobom-data";
+import { EmptyState, Hb } from "hobom-design-system";
+import { NotificationsNoneOutlined } from "hobom-design-system/icons";
+import { shelterQueries } from "@/entities/shelter";
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" });
+
+/** 공지·소식 tab — the shelter's notices (pinned first), each as a SectionCard. */
+export const NoticesTab = ({ shelterId }: { shelterId: string }) => {
+  const { data } = useSuspenseQuery(shelterQueries.announcements(shelterId));
+
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <NotificationsNoneOutlined
+            style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }}
+          />
+        }
+        message="아직 등록된 소식이 없어요."
+      />
+    );
+  }
+
+  return (
+    <Hb.Stack spacing={2}>
+      {data.map((post) => (
+        <Hb.SectionCard
+          key={post.id}
+          title={post.title}
+          action={
+            post.pinned ? (
+              <Hb.Chip label="고정" size="small" variant="soft" color="primary" />
+            ) : undefined
+          }
+        >
+          <Hb.Text variant="body2" color="text.secondary" style={{ whiteSpace: "pre-line" }}>
+            {post.body}
+          </Hb.Text>
+          {post.createdAt && (
+            <Hb.Text variant="caption" color="text.secondary">
+              {formatDate(post.createdAt)}
+            </Hb.Text>
+          )}
+        </Hb.SectionCard>
+      ))}
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/VolunteerTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/VolunteerTab.tsx
@@ -1,0 +1,64 @@
+import { useSuspenseQuery } from "hobom-data";
+import { EmptyState, Hb } from "hobom-design-system";
+import { CalendarTodayOutlined } from "hobom-design-system/icons";
+import { VOLUNTEER_STATUS_LABEL, volunteerEventQueries } from "@/entities/volunteer-event";
+import type { VolunteerEventStatus } from "@/entities/volunteer-event";
+
+type ChipColor = "primary" | "default" | "error";
+
+const STATUS_COLOR: Record<VolunteerEventStatus, ChipColor> = {
+  OPEN: "primary",
+  CLOSED: "default",
+  CANCELLED: "error",
+};
+
+const formatDateTime = (iso: string): string =>
+  new Date(iso).toLocaleString("ko-KR", { dateStyle: "medium", timeStyle: "short" });
+
+const formatEventPeriod = (startAt: string, endAt: string): string =>
+  `${formatDateTime(startAt)} – ${formatDateTime(endAt)}`;
+
+/** 봉사 tab — a shelter's volunteer events, each as a SectionCard. */
+export const VolunteerTab = ({ shelterId }: { shelterId: string }) => {
+  const { data } = useSuspenseQuery(volunteerEventQueries.byShelter(shelterId));
+
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <CalendarTodayOutlined style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />
+        }
+        message="예정된 봉사 일정이 없어요."
+      />
+    );
+  }
+
+  return (
+    <Hb.Stack spacing={2}>
+      {data.map((event) => (
+        <Hb.SectionCard
+          key={event.id}
+          title={event.title}
+          action={
+            <Hb.Chip
+              label={VOLUNTEER_STATUS_LABEL[event.status]}
+              size="small"
+              variant="soft"
+              color={STATUS_COLOR[event.status]}
+            />
+          }
+        >
+          <Hb.Text variant="body2" color="text.secondary">
+            {formatEventPeriod(event.startAt, event.endAt)}
+          </Hb.Text>
+          <Hb.Text variant="body2" color="text.secondary" style={{ whiteSpace: "pre-line" }}>
+            {event.description}
+          </Hb.Text>
+          <Hb.Text variant="caption" color="text.secondary">
+            모집 {event.signedUpCount}/{event.capacity}명
+          </Hb.Text>
+        </Hb.SectionCard>
+      ))}
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -1,6 +1,7 @@
 import { authHandlers } from "./auth.handlers";
 import { userHandlers } from "./user.handlers";
 import { animalHandlers } from "./animal.handlers";
+import { shelterHandlers } from "./shelter.handlers";
 import { questionnaireHandlers } from "./questionnaire.handlers";
 import { adoptionHandlers } from "./adoption.handlers";
 
@@ -9,6 +10,7 @@ export const handlers = [
   ...authHandlers,
   ...userHandlers,
   ...animalHandlers,
+  ...shelterHandlers,
   ...questionnaireHandlers,
   ...adoptionHandlers,
 ];

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -1,0 +1,159 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+const SHELTER = {
+  id: "shelter-1",
+  name: "행복보호소",
+  slug: "haengbok-shelter",
+  status: "VERIFIED",
+  trustTier: "A",
+  addressVisibility: "PARTIAL",
+  address: { region: "서울", city: "강남구" },
+  facilityPhotos: [
+    {
+      objectKey: "https://picsum.photos/seed/shelter1-a/800/450",
+      kind: "EXTERIOR",
+      caption: "보호소 외관",
+    },
+    {
+      objectKey: "https://picsum.photos/seed/shelter1-b/800/450",
+      kind: "INTERIOR",
+      caption: "실내 견사",
+    },
+    { objectKey: "https://picsum.photos/seed/shelter1-c/800/450", kind: "OTHER" },
+  ],
+  intro:
+    "2015년부터 유기견·유기묘를 구조하고 새로운 가족을 찾아주는 비영리 보호소입니다. 건강한 입양 문화를 위해 투명하게 운영하고 있어요.",
+  operatingSince: "2015-03-01T00:00:00.000Z",
+  representativeName: "김보호",
+  visitGuide: "방문은 평일 10:00–18:00, 사전 예약제로 운영해요. 예약은 상담 신청 후 안내드립니다.",
+  supportGuide: "정기 후원과 물품 후원 모두 환영합니다. 후원 문의는 보호소에 남겨주세요.",
+  coverImageKey: "https://picsum.photos/seed/shelter1-cover/1200/375",
+};
+
+const VOLUNTEER_EVENTS = [
+  {
+    id: "vol-1",
+    shelterId: "shelter-1",
+    title: "주말 산책 봉사",
+    description: "아이들과 함께 동네를 산책하며 사회성을 길러주는 봉사예요.",
+    startAt: "2026-08-02T01:00:00.000Z",
+    endAt: "2026-08-02T04:00:00.000Z",
+    capacity: 10,
+    signedUpCount: 6,
+    status: "OPEN",
+  },
+  {
+    id: "vol-2",
+    shelterId: "shelter-1",
+    title: "견사 청소 봉사",
+    description: "보호소 견사를 청소하고 정비하는 활동입니다.",
+    startAt: "2026-07-05T01:00:00.000Z",
+    endAt: "2026-07-05T03:00:00.000Z",
+    capacity: 8,
+    signedUpCount: 8,
+    status: "CLOSED",
+  },
+];
+
+const ANNOUNCEMENTS = [
+  {
+    id: "ann-1",
+    title: "설 연휴 임시보호 봉사자를 찾습니다",
+    body: "연휴 기간 동안 아이들과 함께해 주실 임시보호 봉사자를 모집해요. 자세한 내용은 방문 상담 시 안내드립니다.",
+    pinned: true,
+    createdAt: "2026-02-10T00:00:00.000Z",
+  },
+  {
+    id: "ann-2",
+    title: "겨울 방한용품 후원에 감사드립니다",
+    body: "따뜻한 마음 덕분에 아이들이 포근한 겨울을 보내고 있어요. 정말 감사합니다.",
+    pinned: false,
+    createdAt: "2026-01-20T00:00:00.000Z",
+  },
+];
+
+const FAQS = [
+  {
+    id: "faq-1",
+    question: "입양 절차가 어떻게 되나요?",
+    answer: "관심 있는 아이의 프로필에서 입양 신청서를 작성하시면, 상담 후 방문·매칭 절차가 진행됩니다.",
+    order: 1,
+  },
+  {
+    id: "faq-2",
+    question: "임시보호도 신청할 수 있나요?",
+    answer: "네, 각 아이 상세 페이지에서 임시보호 신청이 가능하며 보호소가 개별적으로 연락드립니다.",
+    order: 2,
+  },
+];
+
+const NAMES = ["콩이", "보리", "초코", "나비", "깜냥", "단추"];
+const SPECIES = ["DOG", "CAT", "OTHER"] as const;
+const SIZES = ["SMALL", "MEDIUM", "LARGE"] as const;
+
+const ROSTER = NAMES.map((name, i) => ({
+  id: `shelter1-animal-${i + 1}`,
+  shelterId: "shelter-1",
+  name,
+  species: SPECIES[i % SPECIES.length],
+  description: "행복보호소에서 새 가족을 기다리는 아이예요.",
+  status: i % 4 === 3 ? "RESERVED" : "AVAILABLE",
+  traits: {
+    sex: i % 2 === 0 ? "FEMALE" : "MALE",
+    size: SIZES[i % SIZES.length],
+    ageMonths: (i % 5) * 6 + 4,
+    weightKg: (i % 4) + 3,
+    breed: "믹스",
+    color: "아이보리",
+    personality: "온순·사교적",
+  },
+  photos: [{ objectKey: `https://picsum.photos/seed/shelter1-roster${i + 1}/600/450` }],
+}));
+
+const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+
+/** §04 shelter microsite mock handlers — profile, notices, FAQs, and roster. */
+export const shelterHandlers = [
+  http.get(mockUrl("/shelters/:slug"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    if (params.slug !== SHELTER.slug) {
+      return HttpResponse.json({ message: "보호소를 찾을 수 없어요." }, { status: 404 });
+    }
+
+    return ok(SHELTER);
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/announcements"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(ANNOUNCEMENTS);
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/faqs"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(FAQS);
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/animals"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(ROSTER);
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/stats"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok({ adoptedCount: 240, shelteredCount: 32, availableCount: 18 });
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/volunteer-events"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(VOLUNTEER_EVENTS);
+  }),
+];

--- a/apps/hobom-angel/src/pages/shelter-detail/index.ts
+++ b/apps/hobom-angel/src/pages/shelter-detail/index.ts
@@ -1,0 +1,1 @@
+export { ShelterDetailPage } from "./ui/ShelterDetailPage";

--- a/apps/hobom-angel/src/pages/shelter-detail/ui/ShelterDetailPage.tsx
+++ b/apps/hobom-angel/src/pages/shelter-detail/ui/ShelterDetailPage.tsx
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom";
+import { ShelterMicrosite } from "@/features/shelter-microsite";
+import { NotFoundState, RouteBoundary } from "@/shared/ui";
+
+export const ShelterDetailPage = () => {
+  const { shelterSlug } = useParams<{ shelterSlug: string }>();
+
+  if (!shelterSlug) return <NotFoundState />;
+
+  return (
+    <RouteBoundary>
+      <ShelterMicrosite slug={shelterSlug} />
+    </RouteBoundary>
+  );
+};

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -22,6 +22,8 @@ export const ROUTES = {
   // Public info (footer).
   TERMS: "/terms",
   PRIVACY: "/privacy",
+  BUSINESS_INFO: "/business",
+  ANIMAL_LAW: "/animal-law-notice",
 } as const;
 
 /** Build the concrete path to an animal's detail page. */

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.styles.ts
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.styles.ts
@@ -1,56 +1,110 @@
 import * as stylex from "@stylexjs/stylex";
 
 const DESKTOP = "@media (min-width: 1024px)";
+const WIDE = "@media (min-width: 1200px)";
 
 export const styles = stylex.create({
-  // Desktop only — the mobile bottom tab carries navigation.
+  // Desktop only — the mobile bottom tab carries navigation. Dark surface.
   root: {
     display: { default: "none", [DESKTOP]: "block" },
     marginTop: 40,
-    borderTopWidth: 1,
-    borderTopStyle: "solid",
-    borderTopColor: "var(--hb-color-border)",
-    backgroundColor: "var(--hb-color-surface)",
+    backgroundColor: "oklch(0.235 0.012 240)",
+    color: "oklch(0.82 0.01 240)",
   },
-  // Single compact row: identity on the left, links on the right.
-  inner: {
+  // Brand column (wider) + three link columns.
+  top: {
     maxWidth: 1200,
     marginInline: "auto",
-    paddingInline: "clamp(16px, 4vw, 32px)",
-    paddingBlock: 18,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 20,
-    flexWrap: "wrap",
+    paddingInline: "clamp(24px, 4vw, 44px)",
+    paddingBlock: 40,
+    display: "grid",
+    gridTemplateColumns: { default: "1.4fr 1fr 1fr", [WIDE]: "1.6fr 1fr 1fr 1fr" },
+    gap: 32,
   },
-  identity: {
+  brand: {
+    gridColumn: { default: "1 / -1", [WIDE]: "auto" },
+  },
+  brandRow: {
     display: "flex",
     alignItems: "center",
     gap: 10,
+    marginBottom: 14,
   },
-  brand: {
-    fontSize: "0.9375rem",
-    fontWeight: 800,
-    color: "var(--hb-color-text-primary)",
+  logo: {
+    width: 30,
+    height: 30,
+    borderRadius: 10,
+    backgroundColor: "oklch(0.56 0.078 155)",
+    flexShrink: 0,
   },
-  copyright: {
-    fontSize: "0.8125rem",
-    color: "var(--hb-color-text-secondary)",
+  brandName: {
+    fontSize: "1.125rem",
+    fontWeight: 700,
+    color: "oklch(0.96 0.01 240)",
   },
-  nav: {
+  brandDesc: {
+    margin: 0,
+    fontSize: "0.84375rem",
+    lineHeight: 1.7,
+    color: "oklch(0.72 0.01 240)",
+    maxWidth: 300,
+  },
+  socials: {
+    display: "flex",
+    gap: 10,
+    marginTop: 18,
+  },
+  social: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: "oklch(0.28 0.015 240)",
+  },
+  colHeading: {
+    margin: 0,
+    marginBottom: 14,
+    fontSize: "0.75rem",
+    fontWeight: 700,
+    color: "oklch(0.62 0.01 240)",
+    textTransform: "uppercase",
+    letterSpacing: "0.08em",
+  },
+  colLinks: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 11,
+  },
+  link: {
+    width: "fit-content",
+    fontSize: "0.84375rem",
+    textDecoration: "none",
+    cursor: "pointer",
+    color: { default: "oklch(0.82 0.01 240)", ":hover": "oklch(0.96 0.01 240)" },
+  },
+  // Darker legal bar.
+  bottom: {
+    backgroundColor: "oklch(0.18 0.012 240)",
+    color: "oklch(0.62 0.01 240)",
+    fontSize: "0.78125rem",
+  },
+  bottomInner: {
+    maxWidth: 1200,
+    marginInline: "auto",
+    paddingInline: "clamp(24px, 4vw, 44px)",
+    paddingBlock: 18,
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  legal: {
     display: "flex",
     alignItems: "center",
     gap: 18,
     flexWrap: "wrap",
   },
-  link: {
-    fontSize: "0.8125rem",
-    fontWeight: 500,
-    textDecoration: "none",
-    color: {
-      default: "var(--hb-color-text-secondary)",
-      ":hover": "var(--hb-color-accent-dark)",
-    },
+  copyright: {
+    color: "oklch(0.62 0.01 240)",
   },
 });

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
@@ -1,34 +1,101 @@
 import { Link } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { ROUTES } from "@/shared/config";
-import { PRIMARY_NAV } from "../model/nav-items";
 import { styles } from "./GlobalFooter.styles";
 
 const YEAR = new Date().getFullYear();
 
-const LINKS = [
-  ...PRIMARY_NAV,
-  { label: "이용약관", to: ROUTES.TERMS },
-  { label: "개인정보처리방침", to: ROUTES.PRIVACY },
+interface FooterLink {
+  label: string;
+  /** When omitted, the item renders as a non-navigable placeholder (its
+   *  destination isn't built yet), matching the design mockup. */
+  to?: string;
+}
+
+const COLUMNS: { heading: string; links: FooterLink[] }[] = [
+  {
+    heading: "둘러보기",
+    links: [
+      { label: "입양하기", to: ROUTES.ANIMALS },
+      { label: "임시보호", to: ROUTES.FOSTER },
+      { label: "봉사활동", to: ROUTES.VOLUNTEER },
+      { label: "보호소 찾기", to: ROUTES.SHELTERS },
+    ],
+  },
+  {
+    heading: "지원",
+    links: [
+      { label: "공지사항" },
+      { label: "자주 묻는 질문" },
+      { label: "구조·학대 제보" },
+      { label: "1:1 문의" },
+    ],
+  },
+  {
+    heading: "보호소·기관",
+    links: [{ label: "보호소 등록 신청" }, { label: "관리 콘솔" }, { label: "운영 정책" }],
+  },
 ];
 
-/** Desktop-only global footer (§0.5) — one concise row. Hidden on mobile,
- *  where the bottom tab carries navigation. */
+const LEGAL: FooterLink[] = [
+  { label: "이용약관", to: ROUTES.TERMS },
+  { label: "개인정보처리방침", to: ROUTES.PRIVACY },
+  { label: "사업자 정보", to: ROUTES.BUSINESS_INFO },
+  { label: "동물보호법 고지", to: ROUTES.ANIMAL_LAW },
+];
+
+const FooterItem = ({ label, to }: FooterLink) =>
+  to ? (
+    <Link to={to} {...stylex.props(styles.link)}>
+      {label}
+    </Link>
+  ) : (
+    <span {...stylex.props(styles.link)}>{label}</span>
+  );
+
+/** Desktop-only global footer (§0.5) — a dark, four-column footer with a brand
+ *  block and a legal bar. Hidden on mobile, where the bottom tab navigates. */
 export const GlobalFooter = () => (
   <footer {...stylex.props(styles.root)}>
-    <div {...stylex.props(styles.inner)}>
-      <div {...stylex.props(styles.identity)}>
-        <span {...stylex.props(styles.brand)}>🐾 호봄엔젤</span>
-        <span {...stylex.props(styles.copyright)}>© {YEAR}</span>
+    <div {...stylex.props(styles.top)}>
+      <div {...stylex.props(styles.brand)}>
+        <div {...stylex.props(styles.brandRow)}>
+          <span {...stylex.props(styles.logo)} aria-hidden="true" />
+          <span {...stylex.props(styles.brandName)}>호봄엔젤</span>
+        </div>
+        <p {...stylex.props(styles.brandDesc)}>
+          유기동물의 새로운 시작을 잇는 따뜻한 다리. 입양·임시보호·봉사로 함께해요.
+        </p>
+        <div {...stylex.props(styles.socials)} aria-hidden="true">
+          <span {...stylex.props(styles.social)} />
+          <span {...stylex.props(styles.social)} />
+          <span {...stylex.props(styles.social)} />
+        </div>
       </div>
 
-      <nav {...stylex.props(styles.nav)} aria-label="바로가기">
-        {LINKS.map((item) => (
-          <Link key={item.to} to={item.to} {...stylex.props(styles.link)}>
-            {item.label}
-          </Link>
-        ))}
-      </nav>
+      {COLUMNS.map((column) => (
+        <nav key={column.heading} aria-label={column.heading}>
+          <h2 {...stylex.props(styles.colHeading)}>{column.heading}</h2>
+          <div {...stylex.props(styles.colLinks)}>
+            {column.links.map((link) => (
+              <FooterItem key={link.label} {...link} />
+            ))}
+          </div>
+        </nav>
+      ))}
+    </div>
+
+    <div {...stylex.props(styles.bottom)}>
+      <div {...stylex.props(styles.bottomInner)}>
+        <nav {...stylex.props(styles.legal)} aria-label="약관 및 정보">
+          {LEGAL.map((link) => (
+            <FooterItem key={link.label} {...link} />
+          ))}
+        </nav>
+        <span {...stylex.props(styles.copyright)}>
+          © {YEAR} HoBom Angel · 비영리 유기동물 입양 플랫폼
+        </span>
+      </div>
     </div>
   </footer>
 );

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
@@ -157,12 +157,19 @@ export const styles = stylex.create({
 
   // ── Content + mobile bottom tab ─────────────────────────
   // The only scroll region. `min-height: 0` lets it shrink inside the flex
-  // shell so its own overflow (not the body) scrolls.
+  // shell so its own overflow (not the body) scrolls. A column layout lets the
+  // main region grow so the footer sits at the bottom on short pages.
   content: {
     flex: 1,
     minHeight: 0,
     overflowY: "auto",
+    display: "flex",
+    flexDirection: "column",
     paddingBottom: { default: 64, [DESKTOP]: 0 },
+  },
+  // Grow to fill the content region so a short page still pushes the footer down.
+  main: {
+    flex: 1,
   },
   bottomTab: {
     display: { default: "flex", [DESKTOP]: "none" },

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.tsx
@@ -17,7 +17,7 @@ export const GlobalNav = ({ children }: { children: ReactNode }) => {
     <div {...stylex.props(styles.shell)}>
       <TopNav user={user} isAuthenticated={isAuthenticated} />
       <div {...stylex.props(styles.content)}>
-        <main>{children}</main>
+        <main {...stylex.props(styles.main)}>{children}</main>
         <GlobalFooter />
       </div>
       {isAuthenticated && <BottomTab />}

--- a/packages/hobom-design-system/package.json
+++ b/packages/hobom-design-system/package.json
@@ -36,7 +36,10 @@
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
     "date-fns": "^4.4.0",
-    "hobom-utils": "workspace:*"
+    "hobom-utils": "workspace:*",
+    "react-markdown": "^10.1.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "peerDependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/hobom-design-system/src/components/Markdown/Markdown.doc.ts
+++ b/packages/hobom-design-system/src/components/Markdown/Markdown.doc.ts
@@ -1,0 +1,47 @@
+import type { ComponentDoc } from "../../foundations/docs";
+
+export const docs: ComponentDoc = {
+  name: "Markdown",
+  description:
+    "The single audited boundary for rendering untrusted, user-authored Markdown (shelter intros, visit/support guides). Renders GitHub-flavored Markdown safely: raw HTML is never executed, the output is sanitized, and link protocols are restricted. Treat the input as a stored-XSS risk.",
+  features: [
+    "GitHub-flavored Markdown (tables, autolinks, strikethrough, task lists) via remark-gfm",
+    "Sanitizes output with rehype-sanitize — strips <script>, event handlers, and raw HTML",
+    "Restricts anchor href protocols to http/https/mailto, dropping javascript:/data: URLs",
+    "Never enables rehype-raw or dangerouslySetInnerHTML",
+    "Maps prose nodes (headings, paragraphs, lists, links, code) to DS typography",
+    "External links open in a new tab with rel=\"noopener noreferrer\"",
+    "Renders nothing when the source is empty or whitespace",
+  ],
+  props: [
+    {
+      name: "children",
+      type: "string",
+      description: "The Markdown source string. Rendered safely — no raw HTML is executed.",
+      required: true,
+    },
+    { name: "className", type: "string", description: "Merged onto the container div." },
+    { name: "style", type: "CSSProperties", description: "Merged onto the container div." },
+  ],
+  examples: [
+    {
+      label: "Render a shelter intro",
+      code: `<Hb.Markdown>{shelter.intro}</Hb.Markdown>`,
+    },
+    {
+      label: "A guide with a width cap",
+      code: `<div style={{ maxWidth: 640 }}>
+  <Hb.Markdown>{shelter.visitGuide}</Hb.Markdown>
+</div>`,
+    },
+  ],
+  accessibility: [
+    "Headings map to Text with modest sizes (h1 → h5, h2..h6 → h6); keep the surrounding heading order sensible.",
+    "External links carry rel=\"noopener noreferrer\" and target=\"_blank\".",
+  ],
+  notes: [
+    "This is the single audited boundary for untrusted Markdown — use it for ANY user-authored content instead of rendering Markdown yourself, so the sanitize policy stays centralized.",
+    "The sanitize schema is derived from rehype-sanitize's defaultSchema with href protocols narrowed to http/https/mailto.",
+    "Unmapped Markdown nodes fall back to react-markdown defaults, which are still passed through the sanitizer.",
+  ],
+};

--- a/packages/hobom-design-system/src/components/Markdown/Markdown.stories.tsx
+++ b/packages/hobom-design-system/src/components/Markdown/Markdown.stories.tsx
@@ -1,0 +1,81 @@
+import { Markdown } from "./Markdown";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "Components/Markdown",
+  component: Markdown,
+  parameters: {
+    // Inline code/headings render body text on the canvas; the small-secondary
+    // color-contrast tradeoff is DS-wide (see SectionCard.stories). Other a11y
+    // checks still run.
+    a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } },
+  },
+  args: {
+    children: [
+      "# 보호소 소개",
+      "",
+      "11년간 유기견을 구조하고 입양을 이어온 **비영리 보호소**입니다.",
+      "함께 걷는 길에 여러분을 초대합니다.",
+      "",
+      "## 우리가 하는 일",
+      "",
+      "- 유기견 구조와 임시 보호",
+      "- 입양 상담 및 사후 관리",
+      "- 지역 사회 반려 문화 교육",
+      "",
+      "자세한 내용은 [공식 웹사이트](https://example.com)에서 확인하세요.",
+    ].join("\n"),
+  },
+} satisfies Meta<typeof Markdown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Rich: Story = {
+  render: (args) => (
+    <div style={{ maxWidth: 480 }}>
+      <Markdown {...args} />
+    </div>
+  ),
+};
+
+// A `javascript:` URL must be neutralized by the sanitize policy — the link
+// text still renders, but the dangerous href is dropped (no executable href).
+export const NeutralizedScriptLink: Story = {
+  args: {
+    children: "이 링크는 [무해화됩니다](javascript:alert(1)) — href가 제거됩니다.",
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 480 }}>
+      <Markdown {...args} />
+    </div>
+  ),
+};
+
+export const GfmTableAndTaskList: Story = {
+  parameters: {
+    // GFM task lists render as disabled, unlabeled checkboxes — the standard
+    // GitHub output. The `label` rule flags them; the content is read-only and
+    // labeled by the adjacent list text. Other a11y checks still run.
+    a11y: { config: { rules: [{ id: "label", enabled: false }] } },
+  },
+  args: {
+    children: [
+      "| 이름 | 상태 |",
+      "| --- | --- |",
+      "| 초코 | 입양 대기 |",
+      "| 보리 | 임시 보호 |",
+      "",
+      "- [x] 건강 검진 완료",
+      "- [ ] 입양 상담 예약",
+      "",
+      "~~취소된 항목~~",
+    ].join("\n"),
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 480 }}>
+      <Markdown {...args} />
+    </div>
+  ),
+};

--- a/packages/hobom-design-system/src/components/Markdown/Markdown.tsx
+++ b/packages/hobom-design-system/src/components/Markdown/Markdown.tsx
@@ -1,0 +1,143 @@
+import type { CSSProperties } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import * as stylex from "@stylexjs/stylex";
+import { Text } from "../Text/Text";
+import { Link } from "../Link/Link";
+
+interface MarkdownProps {
+  /** The Markdown source string. Rendered safely (no raw HTML executed). */
+  children: string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+// The single audited sanitize policy for untrusted, user-authored Markdown.
+// Starts from rehype-sanitize's `defaultSchema` (which already strips <script>,
+// event handlers, and raw HTML the way GitHub does), then narrows the allowed
+// anchor `href` protocols to http/https/mailto — so `javascript:` and `data:`
+// URLs are dropped rather than rendered.
+const schema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: ["http", "https", "mailto"],
+  },
+};
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  list: {
+    margin: 0,
+    paddingInlineStart: 24,
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+  code: {
+    fontFamily: "'SFMono-Regular', 'Menlo', 'Consolas', monospace",
+    fontSize: "0.85em",
+    backgroundColor: "var(--hb-color-canvas)",
+    borderRadius: 4,
+    paddingBlock: 2,
+    paddingInline: 4,
+  },
+  pre: {
+    margin: 0,
+    overflowX: "auto",
+    fontFamily: "'SFMono-Regular', 'Menlo', 'Consolas', monospace",
+    fontSize: "0.85em",
+    backgroundColor: "var(--hb-color-canvas)",
+    borderRadius: 8,
+    padding: 12,
+  },
+});
+
+// Map the common prose nodes to DS typography. Unmapped nodes fall back to
+// react-markdown defaults, which are still passed through the sanitizer above.
+const components: Components = {
+  p: ({ children }) => (
+    <Text variant="body1" component="p">
+      {children}
+    </Text>
+  ),
+  a: ({ href, children }) => (
+    <Link href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </Link>
+  ),
+  strong: ({ children }) => <strong>{children}</strong>,
+  em: ({ children }) => <em>{children}</em>,
+  h1: ({ children }) => (
+    <Text variant="h5" component="h1">
+      {children}
+    </Text>
+  ),
+  h2: ({ children }) => (
+    <Text variant="h6" component="h2">
+      {children}
+    </Text>
+  ),
+  h3: ({ children }) => (
+    <Text variant="h6" component="h3">
+      {children}
+    </Text>
+  ),
+  h4: ({ children }) => (
+    <Text variant="h6" component="h4">
+      {children}
+    </Text>
+  ),
+  h5: ({ children }) => (
+    <Text variant="h6" component="h5">
+      {children}
+    </Text>
+  ),
+  h6: ({ children }) => (
+    <Text variant="h6" component="h6">
+      {children}
+    </Text>
+  ),
+  ul: ({ children }) => <ul {...stylex.props(styles.list)}>{children}</ul>,
+  ol: ({ children }) => <ol {...stylex.props(styles.list)}>{children}</ol>,
+  li: ({ children }) => (
+    <Text variant="body1" component="li">
+      {children}
+    </Text>
+  ),
+  code: ({ children }) => <code {...stylex.props(styles.code)}>{children}</code>,
+  pre: ({ children }) => <pre {...stylex.props(styles.pre)}>{children}</pre>,
+};
+
+/**
+ * The single audited boundary for rendering untrusted, user-authored Markdown
+ * (shelter intros, visit/support guides). Content is treated as a stored-XSS
+ * risk: GFM is enabled, raw HTML is never executed, output is sanitized, and
+ * link protocols are restricted to http/https/mailto. Use this for any
+ * user-authored Markdown rather than rendering it yourself.
+ */
+export const Markdown = ({ children, className, style }: MarkdownProps) => {
+  if (children.trim() === "") return null;
+
+  const sx = stylex.props(styles.root);
+
+  return (
+    <div
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[[rehypeSanitize, schema]]}
+        components={components}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};

--- a/packages/hobom-design-system/src/components/Markdown/index.ts
+++ b/packages/hobom-design-system/src/components/Markdown/index.ts
@@ -1,0 +1,1 @@
+export * from "./Markdown";

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.doc.ts
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.doc.ts
@@ -9,12 +9,18 @@ export const docs: ComponentDoc = {
     "Default flex wrap layout, or an equal-column grid via `columns`",
     "Fixed 24px gap so screens stop hand-rolling stat CSS",
     "Value uses the accent color and 700 weight; label is muted caption",
+    "`variant=\"card\"` wraps each stat in a bordered surface — for the §04 shelter card layout",
   ],
   props: [
     {
       name: "StatGroup.Root columns",
       type: "number",
       description: "Lay out as this many equal columns; omit to wrap in a flex row.",
+    },
+    {
+      name: "StatGroup.Root variant",
+      type: `"plain" | "card"`,
+      description: "`plain` (bare column) or `card` (each stat in a bordered surface). Defaults to `plain`.",
     },
     {
       name: "StatGroup.Item value",
@@ -42,6 +48,14 @@ export const docs: ComponentDoc = {
       label: "Three-column grid",
       code: `<Hb.StatGroup.Root columns={3}>
   <Hb.StatGroup.Item value="240+" label="누적 입양" />
+  <Hb.StatGroup.Item value="32" label="보호 중" />
+  <Hb.StatGroup.Item value="11년" label="운영" />
+</Hb.StatGroup.Root>`,
+    },
+    {
+      label: "Bordered stat cards",
+      code: `<Hb.StatGroup.Root columns={3} variant="card">
+  <Hb.StatGroup.Item value="240" label="누적 입양" />
   <Hb.StatGroup.Item value="32" label="보호 중" />
   <Hb.StatGroup.Item value="11년" label="운영" />
 </Hb.StatGroup.Root>`,

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.stories.tsx
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.stories.tsx
@@ -38,3 +38,13 @@ export const Grid: Story = {
     </StatGroup.Root>
   ),
 };
+
+export const Cards: Story = {
+  render: () => (
+    <StatGroup.Root columns={3} variant="card" style={{ maxWidth: 480 }}>
+      <StatGroup.Item value="240" label="누적 입양" />
+      <StatGroup.Item value="32" label="보호 중" />
+      <StatGroup.Item value="11년" label="운영" />
+    </StatGroup.Root>
+  ),
+};

--- a/packages/hobom-design-system/src/components/StatGroup/StatGroup.tsx
+++ b/packages/hobom-design-system/src/components/StatGroup/StatGroup.tsx
@@ -1,10 +1,16 @@
-import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import { createContext, useContext, type CSSProperties, type HTMLAttributes, type ReactNode } from "react";
 import * as stylex from "@stylexjs/stylex";
 import { Text } from "../Text/Text";
+
+type StatGroupVariant = "plain" | "card";
+
+const StatGroupContext = createContext<StatGroupVariant>("plain");
 
 interface StatGroupRootProps extends HTMLAttributes<HTMLDListElement> {
   /** When set, lay out as a grid of this many equal columns; otherwise wrap in a flex row. */
   columns?: number;
+  /** `"plain"` (bare value/label column) or `"card"` (each stat in a bordered surface). Defaults to `"plain"`. */
+  variant?: StatGroupVariant;
   children?: ReactNode;
 }
 
@@ -31,9 +37,17 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: 2,
   },
+  card: {
+    backgroundColor: "var(--hb-color-surface)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 14,
+    padding: 16,
+  },
 });
 
-const Root = ({ columns, className, style, children, ...rest }: StatGroupRootProps) => {
+const Root = ({ columns, variant = "plain", className, style, children, ...rest }: StatGroupRootProps) => {
   const sx = stylex.props(columns != null ? styles.grid : styles.root);
 
   const dynamic: CSSProperties = {
@@ -41,19 +55,24 @@ const Root = ({ columns, className, style, children, ...rest }: StatGroupRootPro
   };
 
   return (
-    <dl
-      {...rest}
-      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
-      style={{ ...sx.style, ...dynamic, ...style }}
-    >
-      {children}
-    </dl>
+    <StatGroupContext.Provider value={variant}>
+      <dl
+        {...rest}
+        className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+        style={{ ...sx.style, ...dynamic, ...style }}
+      >
+        {children}
+      </dl>
+    </StatGroupContext.Provider>
   );
 };
 
 const Item = ({ value, label }: StatGroupItemProps) => {
+  const variant = useContext(StatGroupContext);
+  const sx = stylex.props(styles.item, variant === "card" && styles.card);
+
   return (
-    <div {...stylex.props(styles.item)}>
+    <div {...sx}>
       <Text variant="h5" fontWeight={700} component="dd" color="primary" style={{ margin: 0 }}>
         {value}
       </Text>

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.doc.ts
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.doc.ts
@@ -5,8 +5,9 @@ export const docs: ComponentDoc = {
   description:
     "A controlled tab bar (Root + Item) with an optional matching Panel. Root holds the selected value; Items render the underlined triggers; Panels reveal content for the active value.",
   features: [
-    "Controlled: you own `value` and `onChange` on Root",
+    "Controlled: you own `value` and `onChange` (on Root standalone, or on Tabs.Provider)",
     "Index-based fallback — Items without an explicit `value` use their position",
+    "`Tabs.Provider` scopes Root + sibling `Tabs.Panel`s so they share the value",
     "`Tabs.Panel value` shows its children only when active; `keepMounted` keeps it in the DOM (hidden)",
     "Wired for a11y: role=tablist/tab/tabpanel with aria-selected/hidden",
   ],
@@ -42,16 +43,24 @@ export const docs: ComponentDoc = {
   ],
   examples: [
     {
-      label: "Tabs with panels",
+      label: "Standalone tab bar (no panels)",
+      code: `const [tab, setTab] = useState("board");
+<Hb.Tabs.Root value={tab} onChange={(_, v) => setTab(v)}>
+  <Hb.Tabs.Item value="board" label="보드" />
+  <Hb.Tabs.Item value="backlog" label="백로그" />
+</Hb.Tabs.Root>`,
+    },
+    {
+      label: "Tabs with panels — wrap Root + Panels in a Provider",
       code: `const [tab, setTab] = useState("about");
-<>
-  <Hb.Tabs.Root value={tab} onChange={(_, v) => setTab(v)}>
+<Hb.Tabs.Provider value={tab} onChange={(_, v) => setTab(v)}>
+  <Hb.Tabs.Root>
     <Hb.Tabs.Item value="about" label="소개" />
     <Hb.Tabs.Item value="animals" label="동물" />
   </Hb.Tabs.Root>
   <Hb.Tabs.Panel value="about"><AboutTab /></Hb.Tabs.Panel>
   <Hb.Tabs.Panel value="animals"><AnimalsTab /></Hb.Tabs.Panel>
-</>`,
+</Hb.Tabs.Provider>`,
     },
   ],
   accessibility: [
@@ -60,6 +69,8 @@ export const docs: ComponentDoc = {
   ],
   keyboard: "Items are buttons — Tab moves focus, Enter/Space activates. (No arrow-key roving yet.)",
   notes: [
+    "Panels must sit inside a Tabs.Provider (they read the value via context); a standalone Root only renders the bar.",
+    "In Provider mode, drop `value`/`onChange` from Root — it inherits them from the Provider.",
     "Controlled only; persist the value in URL state (e.g. useSearchParamsState) for deep-linkable tabs.",
   ],
 };

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.stories.tsx
@@ -41,5 +41,26 @@ const ValuesDemo = () => {
   );
 };
 
+// A Tabs.Provider scopes Root + sibling Panels so they share the selected value.
+const PanelsDemo = () => {
+  const [tab, setTab] = useState("about");
+
+  return (
+    <Tabs.Provider value={tab} onChange={(_, v) => setTab(String(v))}>
+      <Tabs.Root>
+        <Tabs.Item value="about" label="소개" />
+        <Tabs.Item value="animals" label="우리 아이들" />
+      </Tabs.Root>
+      <Tabs.Panel value="about" style={{ paddingTop: 16 }}>
+        소개 패널 내용입니다.
+      </Tabs.Panel>
+      <Tabs.Panel value="animals" style={{ paddingTop: 16 }}>
+        동물 목록 패널입니다.
+      </Tabs.Panel>
+    </Tabs.Provider>
+  );
+};
+
 export const Basic: Story = { render: () => <BasicDemo /> };
 export const WithValues: Story = { render: () => <ValuesDemo /> };
+export const WithPanels: Story = { render: () => <PanelsDemo /> };

--- a/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
+++ b/packages/hobom-design-system/src/components/Tabs/Tabs.tsx
@@ -64,10 +64,14 @@ const styles = stylex.create({
 
 interface RootProps<T extends TabValue = TabValue>
   extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
-  value: T;
-  onChange: (event: SyntheticEvent, value: T) => void;
+  /** The selected tab value. Omit when a parent `Tabs.Provider` supplies it. */
+  value?: T;
+  /** Fires with the clicked tab's value. Omit when inside a `Tabs.Provider`. */
+  onChange?: (event: SyntheticEvent, value: T) => void;
   children?: ReactNode;
 }
+
+const noop = () => {};
 
 const Root = <T extends TabValue>({
   value,
@@ -85,16 +89,26 @@ const Root = <T extends TabValue>({
     isValidElement(child) ? cloneElement(child as ReactElement<ItemProps>, { index: index++ }) : child,
   );
 
+  const bar = (
+    <div
+      role="tablist"
+      {...rest}
+      className={[sx.className, className].filter(Boolean).join(" ") || undefined}
+      style={{ ...sx.style, ...style }}
+    >
+      {items}
+    </div>
+  );
+
+  // Inside a Tabs.Provider the context already exists (and reaches sibling
+  // Panels); a standalone Root owns its value and provides context to its Items.
+  if (value === undefined) return bar;
+
   return (
-    <TabsContext.Provider value={{ value, onChange: onChange as TabsContextValue["onChange"] }}>
-      <div
-        role="tablist"
-        {...rest}
-        className={[sx.className, className].filter(Boolean).join(" ") || undefined}
-        style={{ ...sx.style, ...style }}
-      >
-        {items}
-      </div>
+    <TabsContext.Provider
+      value={{ value, onChange: (onChange ?? noop) as TabsContextValue["onChange"] }}
+    >
+      {bar}
     </TabsContext.Provider>
   );
 };
@@ -165,4 +179,18 @@ const Panel = ({ value, keepMounted = false, className, style, children, ...rest
   );
 };
 
-export const Tabs = { Root, Item, Panel };
+interface ProviderProps<T extends TabValue = TabValue> {
+  value: T;
+  onChange: (event: SyntheticEvent, value: T) => void;
+  children?: ReactNode;
+}
+
+/** Scopes a tab group so `Tabs.Root`'s items and sibling `Tabs.Panel`s share the
+ *  selected value. Wrap Root + Panels in this when you render panels. */
+const Provider = <T extends TabValue>({ value, onChange, children }: ProviderProps<T>) => (
+  <TabsContext.Provider value={{ value, onChange: onChange as TabsContextValue["onChange"] }}>
+    {children}
+  </TabsContext.Provider>
+);
+
+export const Tabs = { Provider, Root, Item, Panel };

--- a/packages/hobom-design-system/src/components/index.ts
+++ b/packages/hobom-design-system/src/components/index.ts
@@ -43,6 +43,7 @@ import { Breadcrumb } from "./Breadcrumb";
 import { DescriptionList } from "./DescriptionList";
 import { StatGroup } from "./StatGroup";
 import { Gallery } from "./Gallery";
+import { Markdown } from "./Markdown";
 // Batch 2 — infra
 import { CssBaseline, GlobalStyles } from "./Infra";
 import { ColorSchemeProvider } from "../foundations/color-scheme";
@@ -94,6 +95,7 @@ export const Hb = {
   DescriptionList,
   StatGroup,
   Gallery,
+  Markdown,
   // Batch 2 — infra
   CssBaseline,
   GlobalStyles,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,9 +265,18 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.7)
       react-router-dom:
         specifier: '>=7.18.1'
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.4.6
@@ -1674,6 +1683,9 @@ packages:
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1683,14 +1695,26 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@25.9.4':
     resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
@@ -1714,6 +1738,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -1786,6 +1816,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1995,6 +2028,9 @@ packages:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2031,6 +2067,9 @@ packages:
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2038,6 +2077,18 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -2061,6 +2112,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   comment-parser@1.4.5:
     resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
@@ -2145,6 +2199,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2171,6 +2228,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -2218,6 +2278,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
@@ -2303,6 +2367,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2316,6 +2383,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2438,6 +2508,15 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
@@ -2453,6 +2532,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2470,6 +2552,9 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
@@ -2477,9 +2562,18 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -2498,6 +2592,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -2509,6 +2606,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2662,6 +2763,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2690,12 +2794,144 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2785,6 +3021,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -2853,6 +3092,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
@@ -2923,6 +3165,12 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.7
+
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
@@ -2957,6 +3205,21 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3049,6 +3312,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
@@ -3085,6 +3351,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3104,6 +3373,12 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styleq@0.2.1:
     resolution: {integrity: sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==}
@@ -3176,6 +3451,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3224,6 +3505,24 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -3247,6 +3546,12 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: 19.2.7
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -3435,6 +3740,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4674,17 +4982,35 @@ snapshots:
 
   '@types/d3-time@3.0.4': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
   '@types/esrecurse@4.3.1': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@25.9.4':
     dependencies:
@@ -4708,6 +5034,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -4809,6 +5139,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -5028,6 +5360,8 @@ snapshots:
 
   axe-core@4.12.1: {}
 
+  bail@2.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -5062,6 +5396,8 @@ snapshots:
 
   caniuse-lite@1.0.30001778: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -5071,6 +5407,14 @@ snapshots:
       pathval: 2.0.1
 
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
 
@@ -5089,6 +5433,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   comment-parser@1.4.5: {}
 
@@ -5162,6 +5508,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5178,6 +5528,10 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@3.0.0:
     dependencies:
@@ -5235,6 +5589,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -5350,6 +5706,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -5359,6 +5717,8 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5475,6 +5835,36 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.3
+      unist-util-position: 5.0.0
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
@@ -5494,6 +5884,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-url-attributes@3.0.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5502,15 +5894,26 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  inline-style-parser@0.2.7: {}
+
   internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -5522,6 +5925,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -5529,6 +5934,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -5675,6 +6082,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5703,9 +6112,355 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -5839,6 +6594,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -5891,6 +6656,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  property-information@7.2.0: {}
 
   prosemirror-changeset@2.4.1:
     dependencies:
@@ -6000,6 +6767,24 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -6034,6 +6819,45 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -6116,6 +6940,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stable-hash-x@0.2.0: {}
 
   stackback@0.0.2: {}
@@ -6158,6 +6984,11 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6171,6 +7002,14 @@ snapshots:
   strip-indent@4.1.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styleq@0.2.1: {}
 
@@ -6226,6 +7065,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -6266,6 +7109,39 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici@7.28.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unplugin@2.3.11:
     dependencies:
@@ -6313,6 +7189,16 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
@@ -6435,3 +7321,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
The shelter route was a ComingSoon placeholder. This builds the full shelter microsite against the real backend contract, and adds the design-system pieces it needed.

## Microsite

- **Header** — cover image, avatar, name with verification/trust badges, and the address disclosed per the shelter's policy (region / partial / full) with the representative.
- **Tabs** — 소개 / 동물 (with a live count) / 공지·소식 / 봉사 / FAQ. The active tab is URL-synced and deep-linkable; each content tab loads its own data and suspends locally so switching never tears down the header.
- **About** — the shelter's greeting, stat cards (누적 입양 / 보호 중 / 운영 연수), a preview of the shelter's animals, and a visit/support sidebar with a volunteer CTA.
- **Notices / FAQ / Volunteer** tabs list the shelter's announcements, FAQs, and volunteer events.
- New `shelter` and `volunteer-event` entities (model + schema + anti-corruption libs), wired to `/shelters/:slug`, `/shelters/:id/{stats,announcements,faqs,volunteer-events}`, and the shelter roster. Stats are normalized at the API boundary, so a missing payload degrades to zeros instead of crashing the page.

## Design system

- **`Hb.Markdown`** — the single audited boundary for rendering shelter-authored Markdown: GFM, sanitized (no raw HTML, link protocols restricted to http/https/mailto, external links get `rel=noopener`), mapped to DS typography. Used for the intro and the visit/support guides.
- **`Hb.StatGroup`** gains a `card` variant for the bordered stat cards.
- **`Hb.Tabs`** gains a `Provider` so a `Root` and its sibling `Panel`s can share the selected value — that's how the microsite renders tab content (the previous sibling-context arrangement never reached the panels).

## Also

- Redesign the global footer to the four-column brand + links layout with a legal bar.
- Give the content region a min-height so the footer sits at the bottom on short pages.
- Active browse filters now read as tinted chips instead of near-invisible outlined ones.

## Verification

- `hobom-design-system`: typecheck, lint, 203 tests (browser a11y pass included).
- `hobom-angel`: typecheck, lint, 63 unit tests, and the full Playwright e2e suite (23) pass.

## Notes

- The greeting and guides render as Markdown; the authoring side (shelter admin console) should emit GFM to match.
- Volunteer events are listed here; the full volunteer calendar is its own screen.