### PR TITLE
Add the volunteer activities screen

### DIFF
--- a/apps/hobom-angel/e2e/volunteer.spec.ts
+++ b/apps/hobom-angel/e2e/volunteer.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§05 volunteer", () => {
+  test("shows the calendar and signs up for an event", async ({ page }) => {
+    await login(page);
+    await page.getByRole("banner").getByRole("link", { name: "봉사활동" }).click();
+    await expect(page).toHaveURL(/\/volunteer$/);
+
+    await expect(page.getByRole("heading", { name: "봉사활동", level: 1 })).toBeVisible();
+    // The calendar opens on the earliest event's day, so its card is shown.
+    await expect(page.getByText("주말 유기견 산책 봉사")).toBeVisible();
+    await expect(page.getByText(/모집 5\/12명/)).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/volunteer.png", fullPage: true });
+
+    await page.getByRole("button", { name: "봉사 신청하기" }).click();
+    await expect(page.getByText("봉사 신청이 접수됐어요.")).toBeVisible();
+    await expect(page.getByText(/모집 6\/12명/)).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/e2e/volunteer.spec.ts
+++ b/apps/hobom-angel/e2e/volunteer.spec.ts
@@ -22,8 +22,24 @@ test.describe("§05 volunteer", () => {
 
     await page.screenshot({ path: "e2e-artifacts/volunteer.png", fullPage: true });
 
+    // Signing up is a commitment, so it goes through a confirmation dialog.
     await page.getByRole("button", { name: "봉사 신청하기" }).click();
+    await expect(page.getByText("이 봉사에 신청할까요?")).toBeVisible();
+    await page.getByRole("button", { name: "신청하기", exact: true }).click();
+
+    // The button and count re-derive from the refetched, viewer-aware event.
     await expect(page.getByText("봉사 신청이 접수됐어요.")).toBeVisible();
     await expect(page.getByText(/모집 6\/12명/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "신청 취소" })).toBeVisible();
+    await expect(page.getByText("승인 대기")).toBeVisible();
+
+    // Withdrawing flips everything back — again straight from the cache.
+    await page.getByRole("button", { name: "신청 취소" }).click();
+    await expect(page.getByText("신청을 취소할까요?")).toBeVisible();
+    await page.getByRole("button", { name: "취소하기", exact: true }).click();
+
+    await expect(page.getByText("신청을 취소했어요.")).toBeVisible();
+    await expect(page.getByText(/모집 5\/12명/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "봉사 신청하기" })).toBeVisible();
   });
 });

--- a/apps/hobom-angel/package.json
+++ b/apps/hobom-angel/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.19.0",
+    "date-fns": "^4.4.0",
     "hobom-data": "workspace:*",
     "hobom-design-system": "workspace:*",
     "hobom-schema": "workspace:*",

--- a/apps/hobom-angel/src/apps/ui/AppProvider.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppProvider.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { DataLot, DataLotProvider } from "hobom-data";
+import { OverlayProvider } from "hobom-design-system";
 
 const STALE_TIME = 5 * 60 * 1000;
 const GC_TIME = 10 * 60 * 1000;
@@ -20,5 +21,7 @@ interface Props {
 }
 
 export const AppProvider = ({ children }: Props) => (
-  <DataLotProvider client={dataLot}>{children}</DataLotProvider>
+  <DataLotProvider client={dataLot}>
+    <OverlayProvider>{children}</OverlayProvider>
+  </DataLotProvider>
 );

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -34,6 +34,9 @@ const ShelterDetailPage = lazy(() =>
 const ShelterListPage = lazy(() =>
   import("@/pages/shelters").then((module) => ({ default: module.ShelterListPage })),
 );
+const VolunteerPage = lazy(() =>
+  import("@/pages/volunteer").then((module) => ({ default: module.VolunteerPage })),
+);
 
 // Warm the common route chunks during idle time so navigating to them shows the
 // screen's own skeleton (data Suspense) rather than the chunk-load spinner.
@@ -45,13 +48,7 @@ const prefetchRoutes = () => {
 };
 
 // Sections still on the ComingSoon placeholder until their screens land.
-const SECTION_ROUTES = [
-  ROUTES.FOSTER,
-  ROUTES.VOLUNTEER,
-  ROUTES.FAVORITES,
-  ROUTES.APPLICATIONS,
-  ROUTES.MY,
-];
+const SECTION_ROUTES = [ROUTES.FOSTER, ROUTES.FAVORITES, ROUTES.APPLICATIONS, ROUTES.MY];
 
 export const AppRouter = () => {
   useRouteMeta();
@@ -76,6 +73,7 @@ export const AppRouter = () => {
             <Route path={ROUTES.APPLY} element={<ApplyAdoptionPage />} />
             <Route path={ROUTES.SHELTERS} element={<ShelterListPage />} />
             <Route path={ROUTES.SHELTER_DETAIL} element={<ShelterDetailPage />} />
+            <Route path={ROUTES.VOLUNTEER} element={<VolunteerPage />} />
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />
               ))}

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -2,10 +2,12 @@ import { httpClient, parseResponse } from "@/shared/api";
 import { toQueryString } from "@/shared/lib";
 import { toShelter, toShelterAnnouncement, toShelterFaq } from "../lib/to-shelter.lib";
 import { toShelterListItem } from "../lib/to-shelter-list-item.lib";
+import { toShelterMarker } from "../lib/to-shelter-marker.lib";
 import {
   shelterAnnouncementsSchema,
   shelterFaqsSchema,
   shelterListPageSchema,
+  shelterMarkersSchema,
   shelterSchema,
   shelterStatsSchema,
 } from "./shelter.schema";
@@ -14,6 +16,7 @@ import type {
   ShelterAnnouncement,
   ShelterFaq,
   ShelterListItem,
+  ShelterMarker,
   ShelterStats,
 } from "../model/shelter.model";
 import type { ShelterSearchParams } from "./shelter.type";
@@ -33,6 +36,7 @@ const parseAnnouncements = parseResponse(
 );
 const parseFaqs = parseResponse(shelterFaqsSchema, "GET /shelters/:id/faqs");
 const parseStats = parseResponse(shelterStatsSchema, "GET /shelters/:id/stats");
+const parseMarkers = parseResponse(shelterMarkersSchema, "GET /shelters/map");
 
 /** Browse verified shelters (region filter + cursor pagination) (§3.5). */
 export const searchShelters = (
@@ -47,6 +51,13 @@ export const searchShelters = (
       nextCursor: page.nextCursor,
       hasNext: page.hasNext,
     }));
+
+/** Fetch all shelter markers — resolves a shelterId to name/slug/region. */
+export const getShelterMarkers = (signal?: AbortSignal): Promise<ShelterMarker[]> =>
+  httpClient
+    .get("/shelters/map", { signal })
+    .then(parseMarkers)
+    .then((items) => items.map(toShelterMarker));
 
 /** Fetch a shelter's public microsite profile by slug (§04). */
 export const getShelterBySlug = (slug: string, signal?: AbortSignal): Promise<Shelter> =>

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
@@ -3,6 +3,7 @@ import {
   getShelterAnnouncements,
   getShelterBySlug,
   getShelterFaqs,
+  getShelterMarkers,
   getShelterStats,
   searchShelters,
 } from "./shelter.api";
@@ -16,6 +17,12 @@ export const shelterQueries = {
       queryFn: ({ pageParam, signal }) => searchShelters({ region, cursor: pageParam }, signal),
       getNextPageParam: (last) => (last.hasNext ? (last.nextCursor ?? undefined) : undefined),
       initialPageParam: undefined as string | undefined,
+    }),
+
+  markers: () =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), "markers"] as const,
+      queryFn: ({ signal }) => getShelterMarkers(signal),
     }),
 
   detail: (slug: string) =>

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -4,6 +4,7 @@ import type {
   RawShelter,
   RawShelterAnnouncement,
   RawShelterFaq,
+  RawShelterMarker,
   RawShelterStats,
   ShelterListPage,
 } from "./shelter.type";
@@ -54,6 +55,18 @@ export const shelterListPageSchema: Schema<ShelterListPage> = HoBomSchema.object
   nextCursor: HoBomSchema.string().nullable(),
   hasNext: HoBomSchema.boolean(),
 });
+
+/** `GET /shelters/map` — plain array of shelter markers. */
+export const shelterMarkersSchema: Schema<RawShelterMarker[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    id: HoBomSchema.string(),
+    name: HoBomSchema.string(),
+    slug: HoBomSchema.string(),
+    region: HoBomSchema.string(),
+    lat: HoBomSchema.number().optional(),
+    lng: HoBomSchema.number().optional(),
+  }),
+);
 
 /** `GET /shelters/:shelterId/announcements`. */
 export const shelterAnnouncementsSchema: Schema<RawShelterAnnouncement[]> = HoBomSchema.array(

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -48,6 +48,16 @@ export interface RawShelterListItem {
   coverImageKey: string | null;
 }
 
+/** `GET /shelters/map` item — a lightweight marker for the shelter map. */
+export interface RawShelterMarker {
+  id: string;
+  name: string;
+  slug: string;
+  region: string;
+  lat?: number;
+  lng?: number;
+}
+
 /** Cursor page envelope for the shelter directory. */
 export interface ShelterListPage {
   items: RawShelterListItem[];

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -14,6 +14,7 @@ export type {
   ShelterAnnouncement,
   ShelterFaq,
   ShelterListItem,
+  ShelterMarker,
   ShelterStats,
   ShelterStatus,
   TrustTier,

--- a/apps/hobom-angel/src/entities/shelter/lib/to-shelter-marker.lib.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/to-shelter-marker.lib.ts
@@ -1,0 +1,12 @@
+import type { RawShelterMarker } from "../api/shelter.type";
+import type { ShelterMarker } from "../model/shelter.model";
+
+/** Anti-corruption: map the API marker into the UI model (absent coords → null). */
+export const toShelterMarker = (raw: RawShelterMarker): ShelterMarker => ({
+  id: raw.id,
+  name: raw.name,
+  slug: raw.slug,
+  region: raw.region,
+  lat: raw.lat ?? null,
+  lng: raw.lng ?? null,
+});

--- a/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
+++ b/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
@@ -53,6 +53,16 @@ export interface ShelterListItem {
   coverImageUrl: string | null;
 }
 
+/** A shelter's map marker — resolves a shelterId to name/slug/region + coords. */
+export interface ShelterMarker {
+  id: string;
+  name: string;
+  slug: string;
+  region: string;
+  lat: number | null;
+  lng: number | null;
+}
+
 /** A shelter notice/news post (공지·소식 tab). */
 export interface ShelterAnnouncement {
   id: string;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
@@ -44,3 +44,7 @@ export const signUpForVolunteerEvent = (id: string): Promise<{ signupId: string 
   httpClient
     .post(`/volunteer-events/${id}/signups`, {})
     .then(parseResponse(volunteerSignupSchema, "POST /volunteer-events/:id/signups"));
+
+/** Withdraw a signup (by its id, from the signup response). */
+export const withdrawVolunteerSignup = (signupId: string): Promise<void> =>
+  httpClient.post(`/volunteer-signups/${signupId}/withdrawal`, {}).then(() => undefined);

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
@@ -1,6 +1,10 @@
 import { httpClient, parseResponse } from "@/shared/api";
 import { toVolunteerEvent } from "../lib/to-volunteer-event.lib";
-import { volunteerEventsSchema } from "./volunteer-event.schema";
+import {
+  volunteerEventSchema,
+  volunteerEventsSchema,
+  volunteerSignupSchema,
+} from "./volunteer-event.schema";
 import type { VolunteerEvent } from "../model/volunteer-event.model";
 
 const parseVolunteerEvents = parseResponse(
@@ -17,3 +21,26 @@ export const getShelterVolunteerEvents = (
     .get(`/shelters/${shelterId}/volunteer-events`, { signal })
     .then(parseVolunteerEvents)
     .then((items) => items.map(toVolunteerEvent));
+
+/** Fetch upcoming volunteer events across all shelters (§05 봉사활동). */
+export const getUpcomingVolunteerEvents = (
+  limit = 30,
+  signal?: AbortSignal,
+): Promise<VolunteerEvent[]> =>
+  httpClient
+    .get(`/volunteer-events?limit=${limit}`, { signal })
+    .then(parseResponse(volunteerEventsSchema, "GET /volunteer-events"))
+    .then((items) => items.map(toVolunteerEvent));
+
+/** Fetch a single volunteer event by id (§05 봉사활동 detail). */
+export const getVolunteerEvent = (id: string, signal?: AbortSignal): Promise<VolunteerEvent> =>
+  httpClient
+    .get(`/volunteer-events/${id}`, { signal })
+    .then(parseResponse(volunteerEventSchema, "GET /volunteer-events/:id"))
+    .then(toVolunteerEvent);
+
+/** Sign the current user up for a volunteer event (requires auth, no body). */
+export const signUpForVolunteerEvent = (id: string): Promise<{ signupId: string }> =>
+  httpClient
+    .post(`/volunteer-events/${id}/signups`, {})
+    .then(parseResponse(volunteerSignupSchema, "POST /volunteer-events/:id/signups"));

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.mutations.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.mutations.ts
@@ -1,0 +1,9 @@
+import { mutationOptions } from "hobom-data";
+import { signUpForVolunteerEvent } from "./volunteer-event.api";
+
+export const volunteerEventMutations = {
+  signup: (eventId: string) =>
+    mutationOptions({
+      mutationFn: () => signUpForVolunteerEvent(eventId),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
@@ -1,5 +1,9 @@
 import { queryOptions } from "hobom-data";
-import { getShelterVolunteerEvents } from "./volunteer-event.api";
+import {
+  getShelterVolunteerEvents,
+  getUpcomingVolunteerEvents,
+  getVolunteerEvent,
+} from "./volunteer-event.api";
 
 export const volunteerEventQueries = {
   all: () => ["volunteer-events"] as const,
@@ -8,5 +12,17 @@ export const volunteerEventQueries = {
     queryOptions({
       queryKey: [...volunteerEventQueries.all(), shelterId] as const,
       queryFn: ({ signal }) => getShelterVolunteerEvents(shelterId, signal),
+    }),
+
+  upcoming: (limit = 30) =>
+    queryOptions({
+      queryKey: [...volunteerEventQueries.all(), "upcoming", limit] as const,
+      queryFn: ({ signal }) => getUpcomingVolunteerEvents(limit, signal),
+    }),
+
+  detail: (id: string) =>
+    queryOptions({
+      queryKey: [...volunteerEventQueries.all(), "detail", id] as const,
+      queryFn: ({ signal }) => getVolunteerEvent(id, signal),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
@@ -2,10 +2,11 @@ import { HoBomSchema } from "hobom-schema";
 import type { Schema } from "hobom-schema";
 import type { RawVolunteerEvent, RawVolunteerSignup } from "./volunteer-event.type";
 
-/** A single volunteer event on the wire. shelterId is omitted; object() strips
- *  unknown keys. Reused for both the global list and single-event endpoints. */
+/** A single volunteer event on the wire — reused for the shelter list, global
+ *  list, and single-event reads (all viewer-aware). */
 export const volunteerEventSchema: Schema<RawVolunteerEvent> = HoBomSchema.object({
   id: HoBomSchema.string(),
+  shelterId: HoBomSchema.string(),
   title: HoBomSchema.string(),
   description: HoBomSchema.string(),
   startAt: HoBomSchema.string(),
@@ -13,6 +14,17 @@ export const volunteerEventSchema: Schema<RawVolunteerEvent> = HoBomSchema.objec
   capacity: HoBomSchema.number(),
   signedUpCount: HoBomSchema.number(),
   status: HoBomSchema.enum(["OPEN", "CLOSED", "CANCELLED"]),
+  type: HoBomSchema.enum(["GENERAL", "OVERSEAS"]),
+  transport: HoBomSchema.object({
+    departure: HoBomSchema.string(),
+    arrival: HoBomSchema.string(),
+    flightAt: HoBomSchema.string(),
+    animalIds: HoBomSchema.array(HoBomSchema.string()),
+    animalCount: HoBomSchema.number(),
+    qualification: HoBomSchema.string().nullable(),
+  }).nullable(),
+  mySignupId: HoBomSchema.string().nullable(),
+  mySignupStatus: HoBomSchema.enum(["PENDING", "APPROVED"]).nullable(),
 });
 
 /** `GET /shelters/:shelterId/volunteer-events` and `GET /volunteer-events` — a

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
@@ -1,18 +1,26 @@
 import { HoBomSchema } from "hobom-schema";
 import type { Schema } from "hobom-schema";
-import type { RawVolunteerEvent } from "./volunteer-event.type";
+import type { RawVolunteerEvent, RawVolunteerSignup } from "./volunteer-event.type";
 
-/** `GET /shelters/:shelterId/volunteer-events` — validates the wire contract at
- *  the boundary. shelterId is omitted; object() strips unknown keys. */
-export const volunteerEventsSchema: Schema<RawVolunteerEvent[]> = HoBomSchema.array(
-  HoBomSchema.object({
-    id: HoBomSchema.string(),
-    title: HoBomSchema.string(),
-    description: HoBomSchema.string(),
-    startAt: HoBomSchema.string(),
-    endAt: HoBomSchema.string(),
-    capacity: HoBomSchema.number(),
-    signedUpCount: HoBomSchema.number(),
-    status: HoBomSchema.enum(["OPEN", "CLOSED", "CANCELLED"]),
-  }),
-);
+/** A single volunteer event on the wire. shelterId is omitted; object() strips
+ *  unknown keys. Reused for both the global list and single-event endpoints. */
+export const volunteerEventSchema: Schema<RawVolunteerEvent> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  title: HoBomSchema.string(),
+  description: HoBomSchema.string(),
+  startAt: HoBomSchema.string(),
+  endAt: HoBomSchema.string(),
+  capacity: HoBomSchema.number(),
+  signedUpCount: HoBomSchema.number(),
+  status: HoBomSchema.enum(["OPEN", "CLOSED", "CANCELLED"]),
+});
+
+/** `GET /shelters/:shelterId/volunteer-events` and `GET /volunteer-events` — a
+ *  plain array of events. */
+export const volunteerEventsSchema: Schema<RawVolunteerEvent[]> =
+  HoBomSchema.array(volunteerEventSchema);
+
+/** `POST /volunteer-events/:eventId/signups` — the created signup's id. */
+export const volunteerSignupSchema: Schema<RawVolunteerSignup> = HoBomSchema.object({
+  signupId: HoBomSchema.string(),
+});

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
@@ -13,3 +13,8 @@ export interface RawVolunteerEvent {
   signedUpCount: number;
   status: VolunteerEventStatus;
 }
+
+/** `POST /volunteer-events/:eventId/signups` response. */
+export interface RawVolunteerSignup {
+  signupId: string;
+}

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
@@ -1,10 +1,25 @@
-import type { VolunteerEventStatus } from "../model/volunteer-event.model";
+import type {
+  VolunteerEventStatus,
+  VolunteerSignupStatus,
+  VolunteerType,
+} from "../model/volunteer-event.model";
 
-/** `GET /shelters/:shelterId/volunteer-events` item. The wire sends `shelterId`,
- *  but the schema strips it (redundant — the caller already holds it), so it is
- *  absent from the parsed shape. */
+/** Flight/transport payload for OVERSEAS events, straight off the wire. */
+export interface RawVolunteerTransport {
+  departure: string;
+  arrival: string;
+  flightAt: string;
+  animalIds: string[];
+  animalCount: number;
+  qualification: string | null;
+}
+
+/** A volunteer event off the wire — shared by the shelter list, global list, and
+ *  single-event reads. All reads are viewer-aware, carrying the caller's own
+ *  live signup (`mySignupId`/`mySignupStatus`, null when not signed up). */
 export interface RawVolunteerEvent {
   id: string;
+  shelterId: string;
   title: string;
   description: string;
   startAt: string;
@@ -12,6 +27,10 @@ export interface RawVolunteerEvent {
   capacity: number;
   signedUpCount: number;
   status: VolunteerEventStatus;
+  type: VolunteerType;
+  transport: RawVolunteerTransport | null;
+  mySignupId: string | null;
+  mySignupStatus: VolunteerSignupStatus | null;
 }
 
 /** `POST /volunteer-events/:eventId/signups` response. */

--- a/apps/hobom-angel/src/entities/volunteer-event/index.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/index.ts
@@ -1,9 +1,17 @@
 export { volunteerEventQueries } from "./api/volunteer-event.queries";
 export { volunteerEventMutations } from "./api/volunteer-event.mutations";
-export { signUpForVolunteerEvent } from "./api/volunteer-event.api";
+export { signUpForVolunteerEvent, withdrawVolunteerSignup } from "./api/volunteer-event.api";
 export {
   VOLUNTEER_STATUS_LABEL,
+  VOLUNTEER_TYPE_LABEL,
+  VOLUNTEER_SIGNUP_STATUS_LABEL,
   spotsLeft,
   isSignUpOpen,
 } from "./model/volunteer-event.model";
-export type { VolunteerEvent, VolunteerEventStatus } from "./model/volunteer-event.model";
+export type {
+  VolunteerEvent,
+  VolunteerEventStatus,
+  VolunteerType,
+  VolunteerTransport,
+  VolunteerSignupStatus,
+} from "./model/volunteer-event.model";

--- a/apps/hobom-angel/src/entities/volunteer-event/index.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/index.ts
@@ -1,3 +1,9 @@
 export { volunteerEventQueries } from "./api/volunteer-event.queries";
-export { VOLUNTEER_STATUS_LABEL } from "./model/volunteer-event.model";
+export { volunteerEventMutations } from "./api/volunteer-event.mutations";
+export { signUpForVolunteerEvent } from "./api/volunteer-event.api";
+export {
+  VOLUNTEER_STATUS_LABEL,
+  spotsLeft,
+  isSignUpOpen,
+} from "./model/volunteer-event.model";
 export type { VolunteerEvent, VolunteerEventStatus } from "./model/volunteer-event.model";

--- a/apps/hobom-angel/src/entities/volunteer-event/lib/to-volunteer-event.lib.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/lib/to-volunteer-event.lib.ts
@@ -5,6 +5,7 @@ import type { VolunteerEvent } from "../model/volunteer-event.model";
  *  kept for consistency with the entity's other boundaries). */
 export const toVolunteerEvent = (raw: RawVolunteerEvent): VolunteerEvent => ({
   id: raw.id,
+  shelterId: raw.shelterId,
   title: raw.title,
   description: raw.description,
   startAt: raw.startAt,
@@ -12,4 +13,16 @@ export const toVolunteerEvent = (raw: RawVolunteerEvent): VolunteerEvent => ({
   capacity: raw.capacity,
   signedUpCount: raw.signedUpCount,
   status: raw.status,
+  type: raw.type,
+  transport: raw.transport
+    ? {
+        departure: raw.transport.departure,
+        arrival: raw.transport.arrival,
+        flightAt: raw.transport.flightAt,
+        animalCount: raw.transport.animalCount,
+        qualification: raw.transport.qualification,
+      }
+    : null,
+  mySignupId: raw.mySignupId,
+  mySignupStatus: raw.mySignupStatus,
 });

--- a/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
@@ -19,3 +19,11 @@ export const VOLUNTEER_STATUS_LABEL: Record<VolunteerEventStatus, string> = {
   CLOSED: "마감",
   CANCELLED: "취소됨",
 };
+
+/** Remaining open spots, floored at 0. */
+export const spotsLeft = (event: VolunteerEvent): number =>
+  Math.max(event.capacity - event.signedUpCount, 0);
+
+/** Whether the event is accepting signups (open and has room). */
+export const isSignUpOpen = (event: VolunteerEvent): boolean =>
+  event.status === "OPEN" && spotsLeft(event) > 0;

--- a/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
@@ -1,8 +1,25 @@
 export type VolunteerEventStatus = "OPEN" | "CLOSED" | "CANCELLED";
 
+export type VolunteerType = "GENERAL" | "OVERSEAS";
+
+/** The viewer's own live signup state. The backend only surfaces "live" states
+ *  (a rejected/withdrawn signup reads back as null). */
+export type VolunteerSignupStatus = "PENDING" | "APPROVED";
+
+/** Flight/transport details, present only for OVERSEAS 이동봉사 events. */
+export interface VolunteerTransport {
+  departure: string;
+  arrival: string;
+  /** ISO datetime of the flight. */
+  flightAt: string;
+  animalCount: number;
+  qualification: string | null;
+}
+
 /** A shelter's volunteer event as the microsite renders it (§04 봉사 tab). */
 export interface VolunteerEvent {
   id: string;
+  shelterId: string;
   title: string;
   description: string;
   /** ISO date the event starts. */
@@ -12,12 +29,29 @@ export interface VolunteerEvent {
   capacity: number;
   signedUpCount: number;
   status: VolunteerEventStatus;
+  type: VolunteerType;
+  /** Transport details for OVERSEAS events; null for GENERAL. */
+  transport: VolunteerTransport | null;
+  /** The viewer's own signup id, used to withdraw; null if not signed up. */
+  mySignupId: string | null;
+  /** The viewer's live signup status, or null if not signed up. */
+  mySignupStatus: VolunteerSignupStatus | null;
 }
 
 export const VOLUNTEER_STATUS_LABEL: Record<VolunteerEventStatus, string> = {
   OPEN: "모집 중",
   CLOSED: "마감",
   CANCELLED: "취소됨",
+};
+
+export const VOLUNTEER_TYPE_LABEL: Record<VolunteerType, string> = {
+  GENERAL: "일반 봉사",
+  OVERSEAS: "해외 이동봉사",
+};
+
+export const VOLUNTEER_SIGNUP_STATUS_LABEL: Record<VolunteerSignupStatus, string> = {
+  PENDING: "승인 대기",
+  APPROVED: "참여 확정",
 };
 
 /** Remaining open spots, floored at 0. */

--- a/apps/hobom-angel/src/features/volunteer/index.ts
+++ b/apps/hobom-angel/src/features/volunteer/index.ts
@@ -1,0 +1,1 @@
+export { VolunteerBoard } from "./ui/VolunteerBoard";

--- a/apps/hobom-angel/src/features/volunteer/lib/enrich-events.lib.spec.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/enrich-events.lib.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { ShelterMarker } from "@/entities/shelter";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { enrichEvents } from "./enrich-events.lib";
+
+const event = (id: string, shelterId: string): VolunteerEvent => ({
+  id,
+  shelterId,
+  title: "봉사",
+  description: "",
+  startAt: "",
+  endAt: "",
+  capacity: 1,
+  signedUpCount: 0,
+  status: "OPEN",
+  type: "GENERAL",
+  transport: null,
+  mySignupId: null,
+  mySignupStatus: null,
+});
+
+const marker = (id: string, name: string): ShelterMarker => ({
+  id,
+  name,
+  slug: `${id}-slug`,
+  region: "서울",
+  lat: null,
+  lng: null,
+});
+
+describe("enrichEvents", () => {
+  it("joins an event to its shelter marker by shelterId", () => {
+    const [enriched] = enrichEvents([event("e1", "s1")], [marker("s1", "행복보호소")]);
+
+    expect(enriched?.shelter).toEqual({ name: "행복보호소", region: "서울", slug: "s1-slug" });
+  });
+
+  it("leaves the shelter null when no marker matches", () => {
+    const [enriched] = enrichEvents([event("e1", "missing")], [marker("s1", "행복보호소")]);
+
+    expect(enriched?.shelter).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/features/volunteer/lib/enrich-events.lib.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/enrich-events.lib.ts
@@ -1,0 +1,26 @@
+import type { ShelterMarker } from "@/entities/shelter";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+
+/** A volunteer event joined with its shelter's public summary (via
+ *  `GET /shelters/map`), since the event itself carries only `shelterId`. */
+export interface EnrichedVolunteerEvent extends VolunteerEvent {
+  shelter: { name: string; region: string; slug: string } | null;
+}
+
+/** Join events with shelter markers by shelterId, so cards can show the shelter
+ *  name/region and link to its microsite. */
+export const enrichEvents = (
+  events: VolunteerEvent[],
+  markers: ShelterMarker[],
+): EnrichedVolunteerEvent[] => {
+  const byId = new Map(markers.map((marker) => [marker.id, marker]));
+
+  return events.map((event) => {
+    const marker = byId.get(event.shelterId);
+
+    return {
+      ...event,
+      shelter: marker ? { name: marker.name, region: marker.region, slug: marker.slug } : null,
+    };
+  });
+};

--- a/apps/hobom-angel/src/features/volunteer/lib/format-event-time.lib.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/format-event-time.lib.ts
@@ -1,0 +1,15 @@
+const time = (value: Date): string =>
+  value.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+/** e.g. "7월 4일 (토) · 14:00–17:00" from the event's start/end ISO datetimes. */
+export const formatEventPeriod = (startAt: string, endAt: string): string => {
+  const start = new Date(startAt);
+  const end = new Date(endAt);
+  const date = start.toLocaleDateString("ko-KR", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+
+  return `${date} · ${time(start)}–${time(end)}`;
+};

--- a/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.spec.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { dateKey, dayKey, eventDayKeys, eventsOnDay, firstEventDate } from "./group-events-by-day.lib";
+
+// Build the ISO from local components so the round-trip through the local-day
+// helpers is timezone-independent in tests.
+const at = (year: number, month: number, day: number, hour = 12): string =>
+  new Date(year, month - 1, day, hour).toISOString();
+
+const event = (id: string, startAt: string): VolunteerEvent => ({
+  id,
+  title: "봉사",
+  description: "",
+  startAt,
+  endAt: startAt,
+  capacity: 10,
+  signedUpCount: 0,
+  status: "OPEN",
+});
+
+describe("group-events-by-day", () => {
+  it("keys an ISO datetime by its local calendar day", () => {
+    expect(dayKey(at(2026, 7, 4))).toBe("2026-07-04");
+    expect(dateKey(new Date(2026, 6, 4))).toBe("2026-07-04");
+  });
+
+  it("collects the distinct days that have events", () => {
+    const days = eventDayKeys([at(2026, 7, 4), at(2026, 7, 4, 15), at(2026, 7, 10)].map((iso, i) => event(String(i), iso)));
+
+    expect(days).toEqual(new Set(["2026-07-04", "2026-07-10"]));
+  });
+
+  it("filters events to the selected day", () => {
+    const events = [event("a", at(2026, 7, 4)), event("b", at(2026, 7, 10))];
+
+    expect(eventsOnDay(events, new Date(2026, 6, 4)).map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("returns the earliest event's date, or null when empty", () => {
+    const events = [event("late", at(2026, 7, 10)), event("early", at(2026, 7, 4))];
+
+    expect(firstEventDate(events)?.getDate()).toBe(4);
+    expect(firstEventDate([])).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.spec.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.spec.ts
@@ -9,6 +9,7 @@ const at = (year: number, month: number, day: number, hour = 12): string =>
 
 const event = (id: string, startAt: string): VolunteerEvent => ({
   id,
+  shelterId: "shelter-1",
   title: "봉사",
   description: "",
   startAt,
@@ -16,6 +17,10 @@ const event = (id: string, startAt: string): VolunteerEvent => ({
   capacity: 10,
   signedUpCount: 0,
   status: "OPEN",
+  type: "GENERAL",
+  transport: null,
+  mySignupId: null,
+  mySignupStatus: null,
 });
 
 describe("group-events-by-day", () => {

--- a/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.ts
@@ -1,4 +1,6 @@
-import type { VolunteerEvent } from "@/entities/volunteer-event";
+interface HasStart {
+  startAt: string;
+}
 
 const keyOf = (date: Date): string => {
   const year = date.getFullYear();
@@ -15,11 +17,12 @@ export const dayKey = (iso: string): string => keyOf(new Date(iso));
 export const dateKey = (date: Date): string => keyOf(date);
 
 /** The distinct local days that have at least one event (for calendar dots). */
-export const eventDayKeys = (events: VolunteerEvent[]): Set<string> =>
+export const eventDayKeys = (events: HasStart[]): Set<string> =>
   new Set(events.map((event) => dayKey(event.startAt)));
 
-/** Events whose start day matches the given date (local). */
-export const eventsOnDay = (events: VolunteerEvent[], date: Date): VolunteerEvent[] => {
+/** Events whose start day matches the given date (local). Generic so it keeps
+ *  the caller's element type (e.g. an enriched event). */
+export const eventsOnDay = <T extends HasStart>(events: T[], date: Date): T[] => {
   const key = dateKey(date);
 
   return events.filter((event) => dayKey(event.startAt) === key);
@@ -27,7 +30,7 @@ export const eventsOnDay = (events: VolunteerEvent[], date: Date): VolunteerEven
 
 /** Start Date of the earliest event, or null — opens the calendar on a day that
  *  actually has volunteering rather than an empty today. */
-export const firstEventDate = (events: VolunteerEvent[]): Date | null => {
+export const firstEventDate = (events: HasStart[]): Date | null => {
   if (events.length === 0) return null;
 
   const earliest = events.reduce((min, event) => (event.startAt < min.startAt ? event : min));

--- a/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.ts
+++ b/apps/hobom-angel/src/features/volunteer/lib/group-events-by-day.lib.ts
@@ -1,0 +1,36 @@
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+
+const keyOf = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+/** Local day key (YYYY-MM-DD) for an ISO datetime — groups events by start day. */
+export const dayKey = (iso: string): string => keyOf(new Date(iso));
+
+/** Local day key for a Date. */
+export const dateKey = (date: Date): string => keyOf(date);
+
+/** The distinct local days that have at least one event (for calendar dots). */
+export const eventDayKeys = (events: VolunteerEvent[]): Set<string> =>
+  new Set(events.map((event) => dayKey(event.startAt)));
+
+/** Events whose start day matches the given date (local). */
+export const eventsOnDay = (events: VolunteerEvent[], date: Date): VolunteerEvent[] => {
+  const key = dateKey(date);
+
+  return events.filter((event) => dayKey(event.startAt) === key);
+};
+
+/** Start Date of the earliest event, or null — opens the calendar on a day that
+ *  actually has volunteering rather than an empty today. */
+export const firstEventDate = (events: VolunteerEvent[]): Date | null => {
+  if (events.length === 0) return null;
+
+  const earliest = events.reduce((min, event) => (event.startAt < min.startAt ? event : min));
+
+  return new Date(earliest.startAt);
+};

--- a/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
+++ b/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
@@ -1,18 +1,41 @@
 import { useState } from "react";
 import { useSuspenseQuery } from "hobom-data";
-import { volunteerEventQueries } from "@/entities/volunteer-event";
+import { shelterQueries } from "@/entities/shelter";
+import { isSignUpOpen, volunteerEventQueries } from "@/entities/volunteer-event";
+import type { VolunteerType } from "@/entities/volunteer-event";
+import { enrichEvents } from "../lib/enrich-events.lib";
 import { eventDayKeys, eventsOnDay, firstEventDate } from "../lib/group-events-by-day.lib";
 
-/** The §05 board state: upcoming events, the calendar's selected day, and the
- *  events on that day. Loading suspends to the route boundary. */
+export type VolunteerView = "calendar" | "list";
+export type VolunteerTypeFilter = "ALL" | VolunteerType;
+
+/** §05 board state: upcoming events joined with shelter names, the view mode,
+ *  type / open-only filters, and the calendar's selected day. */
 export const useVolunteerBoard = () => {
   const { data: events } = useSuspenseQuery(volunteerEventQueries.upcoming());
+  const { data: markers } = useSuspenseQuery(shelterQueries.markers());
+
+  const [view, setView] = useState<VolunteerView>("calendar");
+  const [typeFilter, setTypeFilter] = useState<VolunteerTypeFilter>("ALL");
+  const [openOnly, setOpenOnly] = useState(false);
   const [selected, setSelected] = useState<Date>(() => firstEventDate(events) ?? new Date());
 
+  const filtered = enrichEvents(events, markers).filter(
+    (event) =>
+      (typeFilter === "ALL" || event.type === typeFilter) && (!openOnly || isSignUpOpen(event)),
+  );
+
   return {
-    eventDays: eventDayKeys(events),
+    view,
+    setView,
+    typeFilter,
+    setTypeFilter,
+    openOnly,
+    setOpenOnly,
     selected,
     setSelected,
-    dayEvents: eventsOnDay(events, selected),
+    eventDays: eventDayKeys(filtered),
+    dayEvents: eventsOnDay(filtered, selected),
+    upcoming: [...filtered].sort((a, b) => a.startAt.localeCompare(b.startAt)),
   };
 };

--- a/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
+++ b/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSuspenseQuery } from "hobom-data";
+import { useSuspenseQueries } from "hobom-data";
 import { shelterQueries } from "@/entities/shelter";
 import { isSignUpOpen, volunteerEventQueries } from "@/entities/volunteer-event";
 import type { VolunteerType } from "@/entities/volunteer-event";
@@ -12,8 +12,12 @@ export type VolunteerTypeFilter = "ALL" | VolunteerType;
 /** §05 board state: upcoming events joined with shelter names, the view mode,
  *  type / open-only filters, and the calendar's selected day. */
 export const useVolunteerBoard = () => {
-  const { data: events } = useSuspenseQuery(volunteerEventQueries.upcoming());
-  const { data: markers } = useSuspenseQuery(shelterQueries.markers());
+  // One suspense boundary over both reads so they fetch in parallel — two
+  // separate useSuspenseQuery calls would waterfall (the first suspends before
+  // the second can start).
+  const [{ data: events }, { data: markers }] = useSuspenseQueries({
+    queries: [volunteerEventQueries.upcoming(), shelterQueries.markers()],
+  });
 
   const [view, setView] = useState<VolunteerView>("calendar");
   const [typeFilter, setTypeFilter] = useState<VolunteerTypeFilter>("ALL");

--- a/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
+++ b/apps/hobom-angel/src/features/volunteer/model/useVolunteerBoard.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { useSuspenseQuery } from "hobom-data";
+import { volunteerEventQueries } from "@/entities/volunteer-event";
+import { eventDayKeys, eventsOnDay, firstEventDate } from "../lib/group-events-by-day.lib";
+
+/** The §05 board state: upcoming events, the calendar's selected day, and the
+ *  events on that day. Loading suspends to the route boundary. */
+export const useVolunteerBoard = () => {
+  const { data: events } = useSuspenseQuery(volunteerEventQueries.upcoming());
+  const [selected, setSelected] = useState<Date>(() => firstEventDate(events) ?? new Date());
+
+  return {
+    eventDays: eventDayKeys(events),
+    selected,
+    setSelected,
+    dayEvents: eventsOnDay(events, selected),
+  };
+};

--- a/apps/hobom-angel/src/features/volunteer/model/useVolunteerSignup.ts
+++ b/apps/hobom-angel/src/features/volunteer/model/useVolunteerSignup.ts
@@ -1,0 +1,24 @@
+import { useDataLot, useMutation } from "hobom-data";
+import { signUpForVolunteerEvent, volunteerEventQueries } from "@/entities/volunteer-event";
+import { useToast } from "@/shared/model";
+
+/** Sign up for a volunteer event; refreshes the list count and toasts the
+ *  result. `pendingEventId` marks which card's button is busy. */
+export const useVolunteerSignup = () => {
+  const { openSuccessToast, openErrorToast } = useToast();
+  const dataLot = useDataLot();
+
+  const { mutate, isPending, variables } = useMutation({
+    mutationFn: (eventId: string) => signUpForVolunteerEvent(eventId),
+    onSuccess: () => {
+      openSuccessToast({ message: "봉사 신청이 접수됐어요." });
+      void dataLot.invalidateQueries(volunteerEventQueries.upcoming());
+    },
+    onError: (error: unknown) =>
+      openErrorToast({
+        message: error instanceof Error ? error.message : "신청에 실패했어요.",
+      }),
+  });
+
+  return { signUp: mutate, pendingEventId: isPending ? variables : undefined };
+};

--- a/apps/hobom-angel/src/features/volunteer/model/useVolunteerSignup.ts
+++ b/apps/hobom-angel/src/features/volunteer/model/useVolunteerSignup.ts
@@ -1,24 +1,54 @@
 import { useDataLot, useMutation } from "hobom-data";
-import { signUpForVolunteerEvent, volunteerEventQueries } from "@/entities/volunteer-event";
+import {
+  signUpForVolunteerEvent,
+  volunteerEventQueries,
+  withdrawVolunteerSignup,
+} from "@/entities/volunteer-event";
 import { useToast } from "@/shared/model";
 
-/** Sign up for a volunteer event; refreshes the list count and toasts the
- *  result. `pendingEventId` marks which card's button is busy. */
-export const useVolunteerSignup = () => {
+export interface VolunteerSignupControls {
+  signUp: (eventId: string) => void;
+  withdraw: (signupId: string) => void;
+  /** Event id whose signup is in flight (for the CTA spinner), if any. */
+  pendingSignUpId: string | undefined;
+  /** Signup id whose withdrawal is in flight, if any. */
+  pendingWithdrawId: string | undefined;
+}
+
+/** Sign up for / withdraw from volunteer events. The signup identity lives on the
+ *  server — event reads carry the viewer's own `mySignupId`/`mySignupStatus` — so
+ *  both mutations just invalidate the event cache and let the refetch re-derive
+ *  the button state. No client-side mirror of server state. */
+export const useVolunteerSignup = (): VolunteerSignupControls => {
   const { openSuccessToast, openErrorToast } = useToast();
   const dataLot = useDataLot();
 
-  const { mutate, isPending, variables } = useMutation({
+  const refresh = () => dataLot.invalidateQueries(volunteerEventQueries.upcoming());
+  const toastError = (error: unknown, fallback: string) =>
+    openErrorToast({ message: error instanceof Error ? error.message : fallback });
+
+  const signUp = useMutation({
     mutationFn: (eventId: string) => signUpForVolunteerEvent(eventId),
     onSuccess: () => {
       openSuccessToast({ message: "봉사 신청이 접수됐어요." });
-      void dataLot.invalidateQueries(volunteerEventQueries.upcoming());
+      void refresh();
     },
-    onError: (error: unknown) =>
-      openErrorToast({
-        message: error instanceof Error ? error.message : "신청에 실패했어요.",
-      }),
+    onError: (error: unknown) => toastError(error, "신청에 실패했어요."),
   });
 
-  return { signUp: mutate, pendingEventId: isPending ? variables : undefined };
+  const withdraw = useMutation({
+    mutationFn: (signupId: string) => withdrawVolunteerSignup(signupId),
+    onSuccess: () => {
+      openSuccessToast({ message: "신청을 취소했어요." });
+      void refresh();
+    },
+    onError: (error: unknown) => toastError(error, "취소에 실패했어요."),
+  });
+
+  return {
+    signUp: signUp.mutate,
+    withdraw: withdraw.mutate,
+    pendingSignUpId: signUp.isPending ? signUp.variables : undefined,
+    pendingWithdrawId: withdraw.isPending ? withdraw.variables : undefined,
+  };
 };

--- a/apps/hobom-angel/src/features/volunteer/ui/SignUpButton.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/SignUpButton.tsx
@@ -1,0 +1,91 @@
+import { ConfirmDialog, Hb } from "hobom-design-system";
+import { VOLUNTEER_STATUS_LABEL, isSignUpOpen } from "@/entities/volunteer-event";
+import { useOverlay } from "@/shared/model";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import type { VolunteerSignupControls } from "../model/useVolunteerSignup";
+
+interface SignUpButtonProps {
+  event: VolunteerEvent;
+  controls: VolunteerSignupControls;
+  fullWidth?: boolean;
+  /** Called after an action is confirmed — e.g. to close a host dialog. */
+  onAfter?: () => void;
+}
+
+/** The sign-up CTA in its three states (신청 취소 / 봉사 신청하기 / 마감), each
+ *  guarded by a confirmation since signing up and withdrawing are commitments. */
+export const SignUpButton = ({
+  event,
+  controls,
+  fullWidth = false,
+  onAfter,
+}: SignUpButtonProps) => {
+  const overlay = useOverlay();
+
+  const confirmSignUp = () =>
+    overlay.open(({ close }) => (
+      <ConfirmDialog
+        open
+        onClose={close}
+        title="이 봉사에 신청할까요?"
+        description={`'${event.title}' 일정에 참여를 신청할게요.`}
+        confirmLabel="신청하기"
+        onConfirm={() => {
+          controls.signUp(event.id);
+          close();
+          onAfter?.();
+        }}
+      />
+    ));
+
+  const confirmWithdraw = (signupId: string) =>
+    overlay.open(({ close }) => (
+      <ConfirmDialog
+        open
+        onClose={close}
+        title="신청을 취소할까요?"
+        description={`'${event.title}' 신청을 취소할게요.`}
+        confirmLabel="취소하기"
+        confirmColor="error"
+        onConfirm={() => {
+          controls.withdraw(signupId);
+          close();
+          onAfter?.();
+        }}
+      />
+    ));
+
+  const signupId = event.mySignupId;
+
+  if (signupId) {
+    return (
+      <Hb.Button
+        variant="secondary"
+        fullWidth={fullWidth}
+        loading={controls.pendingWithdrawId === signupId}
+        onClick={() => confirmWithdraw(signupId)}
+      >
+        신청 취소
+      </Hb.Button>
+    );
+  }
+
+  if (isSignUpOpen(event)) {
+    return (
+      <Hb.Button
+        variant="primary"
+        fullWidth={fullWidth}
+        loading={controls.pendingSignUpId === event.id}
+        onClick={confirmSignUp}
+      >
+        봉사 신청하기
+      </Hb.Button>
+    );
+  }
+
+  return (
+    <Hb.Button variant="primary" fullWidth={fullWidth} disabled>
+      {VOLUNTEER_STATUS_LABEL[event.status]}
+    </Hb.Button>
+  );
+};

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
@@ -1,0 +1,38 @@
+import * as stylex from "@stylexjs/stylex";
+
+const DESKTOP = "@media (min-width: 900px)";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: 40,
+    display: "flex",
+    flexDirection: "column",
+    gap: 20,
+  },
+  header: { display: "flex", flexDirection: "column", gap: 6 },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: { margin: 0, fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
+  // Calendar on the left (wider), the selected day's events on the right.
+  board: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [DESKTOP]: "1.4fr 1fr" },
+    gap: 24,
+    alignItems: "start",
+  },
+  listCol: { display: "flex", flexDirection: "column", gap: 12 },
+  dayTitle: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+});

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
@@ -30,11 +30,22 @@ export const styles = stylex.create({
     gap: 24,
     alignItems: "start",
   },
-  listCol: { display: "flex", flexDirection: "column", gap: 12 },
+  listCol: { display: "flex", flexDirection: "column", gap: 12, minHeight: 0 },
   dayTitle: {
     margin: 0,
     fontSize: "1rem",
     fontWeight: 700,
     color: "var(--hb-color-text-primary)",
+  },
+  // Cap the day/upcoming feed so a long list scrolls in place instead of
+  // stretching the column past the calendar. Scrollbar hidden for a clean edge.
+  scrollArea: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+    maxHeight: 560,
+    overflowY: "auto",
+    scrollbarWidth: "none",
+    "::-webkit-scrollbar": { display: "none" },
   },
 });

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.styles.ts
@@ -21,6 +21,8 @@ export const styles = stylex.create({
     color: "var(--hb-color-text-primary)",
   },
   subtitle: { margin: 0, fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
+  controls: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" },
+  listView: { maxWidth: 680, width: "100%" },
   // Calendar on the left (wider), the selected day's events on the right.
   board: {
     display: "grid",

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
@@ -99,11 +99,13 @@ export const VolunteerBoard = () => {
 
           <div {...stylex.props(styles.listCol)}>
             <h2 {...stylex.props(styles.dayTitle)}>{showDay ? dayLabel : "다가오는 봉사"}</h2>
-            {showDay && <VolunteerFeed events={board.dayEvents} controls={controls} />}
-            {!showDay && board.upcoming.length > 0 && (
-              <VolunteerFeed events={board.upcoming} controls={controls} />
-            )}
-            {!showDay && board.upcoming.length === 0 && empty}
+            <div {...stylex.props(styles.scrollArea)}>
+              {showDay && <VolunteerFeed events={board.dayEvents} controls={controls} />}
+              {!showDay && board.upcoming.length > 0 && (
+                <VolunteerFeed events={board.upcoming} controls={controls} />
+              )}
+              {!showDay && board.upcoming.length === 0 && empty}
+            </div>
           </div>
         </div>
       ) : (

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
@@ -1,0 +1,64 @@
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState, Hb } from "hobom-design-system";
+import { CalendarTodayOutlined } from "hobom-design-system/icons";
+import { useVolunteerBoard } from "../model/useVolunteerBoard";
+import { useVolunteerSignup } from "../model/useVolunteerSignup";
+import { VolunteerCalendar } from "./VolunteerCalendar";
+import { VolunteerEventCard } from "./VolunteerEventCard";
+import { styles } from "./VolunteerBoard.styles";
+
+/** §05 봉사활동: a month calendar of upcoming events and the selected day's
+ *  events with sign-up. */
+export const VolunteerBoard = () => {
+  const { eventDays, selected, setSelected, dayEvents } = useVolunteerBoard();
+  const { signUp, pendingEventId } = useVolunteerSignup();
+
+  const dayLabel = selected.toLocaleDateString("ko-KR", {
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  });
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <h1 {...stylex.props(styles.title)}>봉사활동</h1>
+        <p {...stylex.props(styles.subtitle)}>캘린더에서 봉사 일정을 확인하고 신청하세요.</p>
+      </header>
+
+      <div {...stylex.props(styles.board)}>
+        <Hb.Card.Root
+          variant="outlined"
+          style={{ padding: 20, borderRadius: "var(--hb-angel-radius-card)" }}
+        >
+          <VolunteerCalendar value={selected} onSelect={setSelected} eventDays={eventDays} />
+        </Hb.Card.Root>
+
+        <div {...stylex.props(styles.listCol)}>
+          <h2 {...stylex.props(styles.dayTitle)}>{dayLabel}</h2>
+          {dayEvents.length === 0 ? (
+            <EmptyState
+              icon={
+                <CalendarTodayOutlined
+                  style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }}
+                />
+              }
+              message="이 날 예정된 봉사가 없어요."
+            />
+          ) : (
+            <Hb.Stack spacing={2}>
+              {dayEvents.map((event) => (
+                <VolunteerEventCard
+                  key={event.id}
+                  event={event}
+                  onSignUp={signUp}
+                  pending={pendingEventId === event.id}
+                />
+              ))}
+            </Hb.Stack>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerBoard.tsx
@@ -4,20 +4,35 @@ import { CalendarTodayOutlined } from "hobom-design-system/icons";
 import { useVolunteerBoard } from "../model/useVolunteerBoard";
 import { useVolunteerSignup } from "../model/useVolunteerSignup";
 import { VolunteerCalendar } from "./VolunteerCalendar";
-import { VolunteerEventCard } from "./VolunteerEventCard";
+import { VolunteerFeed } from "./VolunteerFeed";
 import { styles } from "./VolunteerBoard.styles";
 
-/** §05 봉사활동: a month calendar of upcoming events and the selected day's
- *  events with sign-up. */
-export const VolunteerBoard = () => {
-  const { eventDays, selected, setSelected, dayEvents } = useVolunteerBoard();
-  const { signUp, pendingEventId } = useVolunteerSignup();
+const TYPE_FILTERS = [
+  { value: "ALL", label: "전체" },
+  { value: "GENERAL", label: "일반" },
+  { value: "OVERSEAS", label: "해외" },
+] as const;
 
-  const dayLabel = selected.toLocaleDateString("ko-KR", {
+/** §05 봉사활동: a calendar (or list) of upcoming events with type / open-only
+ *  filters and sign-up. */
+export const VolunteerBoard = () => {
+  const board = useVolunteerBoard();
+  const controls = useVolunteerSignup();
+
+  const dayLabel = board.selected.toLocaleDateString("ko-KR", {
     month: "long",
     day: "numeric",
     weekday: "long",
   });
+  const showDay = board.dayEvents.length > 0;
+  const empty = (
+    <EmptyState
+      icon={
+        <CalendarTodayOutlined style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />
+      }
+      message="예정된 봉사가 없어요."
+    />
+  );
 
   return (
     <div {...stylex.props(styles.root)}>
@@ -26,39 +41,80 @@ export const VolunteerBoard = () => {
         <p {...stylex.props(styles.subtitle)}>캘린더에서 봉사 일정을 확인하고 신청하세요.</p>
       </header>
 
-      <div {...stylex.props(styles.board)}>
-        <Hb.Card.Root
-          variant="outlined"
-          style={{ padding: 20, borderRadius: "var(--hb-angel-radius-card)" }}
-        >
-          <VolunteerCalendar value={selected} onSelect={setSelected} eventDays={eventDays} />
-        </Hb.Card.Root>
+      <div {...stylex.props(styles.controls)}>
+        <Hb.ToggleButtonGroup variant="segmented" aria-label="보기 방식">
+          <Hb.ToggleButton
+            variant="segmented"
+            value="calendar"
+            selected={board.view === "calendar"}
+            onChange={() => board.setView("calendar")}
+          >
+            캘린더
+          </Hb.ToggleButton>
+          <Hb.ToggleButton
+            variant="segmented"
+            value="list"
+            selected={board.view === "list"}
+            onChange={() => board.setView("list")}
+          >
+            리스트
+          </Hb.ToggleButton>
+        </Hb.ToggleButtonGroup>
 
-        <div {...stylex.props(styles.listCol)}>
-          <h2 {...stylex.props(styles.dayTitle)}>{dayLabel}</h2>
-          {dayEvents.length === 0 ? (
-            <EmptyState
-              icon={
-                <CalendarTodayOutlined
-                  style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }}
-                />
-              }
-              message="이 날 예정된 봉사가 없어요."
+        <Hb.ToggleButtonGroup variant="segmented" aria-label="봉사 유형">
+          {TYPE_FILTERS.map((filter) => (
+            <Hb.ToggleButton
+              key={filter.value}
+              variant="segmented"
+              value={filter.value}
+              selected={board.typeFilter === filter.value}
+              onChange={() => board.setTypeFilter(filter.value)}
+            >
+              {filter.label}
+            </Hb.ToggleButton>
+          ))}
+        </Hb.ToggleButtonGroup>
+
+        <Hb.ToggleButton
+          value="open"
+          selected={board.openOnly}
+          onChange={() => board.setOpenOnly(!board.openOnly)}
+        >
+          모집 중만
+        </Hb.ToggleButton>
+      </div>
+
+      {board.view === "calendar" ? (
+        <div {...stylex.props(styles.board)}>
+          <Hb.Card.Root
+            variant="outlined"
+            style={{ padding: 20, borderRadius: "var(--hb-angel-radius-card)" }}
+          >
+            <VolunteerCalendar
+              value={board.selected}
+              onSelect={board.setSelected}
+              eventDays={board.eventDays}
             />
+          </Hb.Card.Root>
+
+          <div {...stylex.props(styles.listCol)}>
+            <h2 {...stylex.props(styles.dayTitle)}>{showDay ? dayLabel : "다가오는 봉사"}</h2>
+            {showDay && <VolunteerFeed events={board.dayEvents} controls={controls} />}
+            {!showDay && board.upcoming.length > 0 && (
+              <VolunteerFeed events={board.upcoming} controls={controls} />
+            )}
+            {!showDay && board.upcoming.length === 0 && empty}
+          </div>
+        </div>
+      ) : (
+        <div {...stylex.props(styles.listView)}>
+          {board.upcoming.length > 0 ? (
+            <VolunteerFeed events={board.upcoming} controls={controls} />
           ) : (
-            <Hb.Stack spacing={2}>
-              {dayEvents.map((event) => (
-                <VolunteerEventCard
-                  key={event.id}
-                  event={event}
-                  onSignUp={signUp}
-                  pending={pendingEventId === event.id}
-                />
-              ))}
-            </Hb.Stack>
+            empty
           )}
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerCalendar.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerCalendar.tsx
@@ -1,3 +1,4 @@
+import { ko } from "date-fns/locale";
 import { Calendar } from "hobom-design-system/date-pickers";
 import { dateKey } from "../lib/group-events-by-day.lib";
 
@@ -13,6 +14,7 @@ export const VolunteerCalendar = ({ value, onSelect, eventDays }: VolunteerCalen
   <Calendar
     value={value}
     onSelect={onSelect}
+    locale={ko}
     labelFormat="yyyy년 M월"
     style={{ width: "100%" }}
     renderDay={(day) => <Calendar.DayButton {...day} dot={eventDays.has(dateKey(day.date))} />}

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerCalendar.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerCalendar.tsx
@@ -1,0 +1,20 @@
+import { Calendar } from "hobom-design-system/date-pickers";
+import { dateKey } from "../lib/group-events-by-day.lib";
+
+interface VolunteerCalendarProps {
+  value: Date;
+  onSelect: (date: Date) => void;
+  /** Local day keys that have events — rendered with a dot. */
+  eventDays: Set<string>;
+}
+
+/** The month calendar with a dot on days that have volunteer events (§05). */
+export const VolunteerCalendar = ({ value, onSelect, eventDays }: VolunteerCalendarProps) => (
+  <Calendar
+    value={value}
+    onSelect={onSelect}
+    labelFormat="yyyy년 M월"
+    style={{ width: "100%" }}
+    renderDay={(day) => <Calendar.DayButton {...day} dot={eventDays.has(dateKey(day.date))} />}
+  />
+);

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.styles.ts
@@ -1,0 +1,30 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  metaRow: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" },
+  shelterLink: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 3,
+    textDecoration: "none",
+    color: "var(--hb-color-text-secondary)",
+  },
+  clamp: {
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+  },
+  more: {
+    alignSelf: "flex-start",
+    padding: 0,
+    borderWidth: 0,
+    borderStyle: "none",
+    backgroundColor: "transparent",
+    color: "var(--hb-color-accent)",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+  captionRow: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" },
+});

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.tsx
@@ -1,0 +1,52 @@
+import { Hb } from "hobom-design-system";
+import { VOLUNTEER_STATUS_LABEL, isSignUpOpen, spotsLeft } from "@/entities/volunteer-event";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { formatEventPeriod } from "../lib/format-event-time.lib";
+
+const STATUS_COLOR = { OPEN: "primary", CLOSED: "default", CANCELLED: "error" } as const;
+
+interface VolunteerEventCardProps {
+  event: VolunteerEvent;
+  onSignUp: (eventId: string) => void;
+  pending: boolean;
+}
+
+/** One volunteer event with its schedule, capacity, and a sign-up CTA (§05). */
+export const VolunteerEventCard = ({ event, onSignUp, pending }: VolunteerEventCardProps) => {
+  const open = isSignUpOpen(event);
+
+  return (
+    <Hb.SectionCard
+      title={event.title}
+      action={
+        <Hb.Chip
+          label={VOLUNTEER_STATUS_LABEL[event.status]}
+          size="small"
+          variant="soft"
+          color={STATUS_COLOR[event.status]}
+        />
+      }
+    >
+      <Hb.Text variant="body2" color="text.secondary">
+        {formatEventPeriod(event.startAt, event.endAt)}
+      </Hb.Text>
+      {event.description && (
+        <Hb.Text variant="body2" color="text.secondary" style={{ whiteSpace: "pre-line" }}>
+          {event.description}
+        </Hb.Text>
+      )}
+      <Hb.Text variant="caption" color="text.secondary">
+        모집 {event.signedUpCount}/{event.capacity}명 · 남은 자리 {spotsLeft(event)}
+      </Hb.Text>
+      <Hb.Button
+        variant="primary"
+        fullWidth
+        disabled={!open}
+        loading={pending}
+        onClick={() => onSignUp(event.id)}
+      >
+        {open ? "봉사 신청하기" : VOLUNTEER_STATUS_LABEL[event.status]}
+      </Hb.Button>
+    </Hb.SectionCard>
+  );
+};

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventCard.tsx
@@ -1,52 +1,109 @@
+import { Link } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
-import { VOLUNTEER_STATUS_LABEL, isSignUpOpen, spotsLeft } from "@/entities/volunteer-event";
-import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { LocationOnOutlined } from "hobom-design-system/icons";
+import {
+  VOLUNTEER_SIGNUP_STATUS_LABEL,
+  VOLUNTEER_STATUS_LABEL,
+  VOLUNTEER_TYPE_LABEL,
+  isSignUpOpen,
+  spotsLeft,
+} from "@/entities/volunteer-event";
+import { shelterPath } from "@/shared/config";
+import { useOverlay } from "@/shared/model";
+import { SignUpButton } from "./SignUpButton";
+import { VolunteerEventDialog } from "./VolunteerEventDialog";
+import { styles } from "./VolunteerEventCard.styles";
 import { formatEventPeriod } from "../lib/format-event-time.lib";
+import type { EnrichedVolunteerEvent } from "../lib/enrich-events.lib";
+import type { VolunteerSignupControls } from "../model/useVolunteerSignup";
 
 const STATUS_COLOR = { OPEN: "primary", CLOSED: "default", CANCELLED: "error" } as const;
 
 interface VolunteerEventCardProps {
-  event: VolunteerEvent;
-  onSignUp: (eventId: string) => void;
-  pending: boolean;
+  event: EnrichedVolunteerEvent;
+  controls: VolunteerSignupControls;
 }
 
-/** One volunteer event with its schedule, capacity, and a sign-up CTA (§05). */
-export const VolunteerEventCard = ({ event, onSignUp, pending }: VolunteerEventCardProps) => {
-  const open = isSignUpOpen(event);
+/** One volunteer event: schedule, shelter, scarcity, and a sign-up CTA. Opens
+ *  the full detail in an overlay (§05). */
+export const VolunteerEventCard = ({ event, controls }: VolunteerEventCardProps) => {
+  const overlay = useOverlay();
+  const remaining = spotsLeft(event);
+  const progress = event.capacity > 0 ? Math.round((event.signedUpCount / event.capacity) * 100) : 0;
+
+  const openDetail = () =>
+    overlay.open(({ close }) => (
+      <VolunteerEventDialog event={event} controls={controls} onClose={close} />
+    ));
 
   return (
     <Hb.SectionCard
       title={event.title}
       action={
-        <Hb.Chip
-          label={VOLUNTEER_STATUS_LABEL[event.status]}
-          size="small"
-          variant="soft"
-          color={STATUS_COLOR[event.status]}
-        />
+        <Hb.Stack direction="row" spacing={0.5}>
+          {event.mySignupStatus && (
+            <Hb.Chip
+              label={VOLUNTEER_SIGNUP_STATUS_LABEL[event.mySignupStatus]}
+              size="small"
+              variant="soft"
+              color={event.mySignupStatus === "APPROVED" ? "success" : "warning"}
+            />
+          )}
+          <Hb.Chip
+            label={VOLUNTEER_STATUS_LABEL[event.status]}
+            size="small"
+            variant="soft"
+            color={STATUS_COLOR[event.status]}
+          />
+        </Hb.Stack>
       }
     >
-      <Hb.Text variant="body2" color="text.secondary">
-        {formatEventPeriod(event.startAt, event.endAt)}
-      </Hb.Text>
-      {event.description && (
-        <Hb.Text variant="body2" color="text.secondary" style={{ whiteSpace: "pre-line" }}>
-          {event.description}
+      <Hb.Stack spacing={1}>
+        <div {...stylex.props(styles.metaRow)}>
+          <Hb.Chip
+            label={VOLUNTEER_TYPE_LABEL[event.type]}
+            size="small"
+            variant="soft"
+            color={event.type === "OVERSEAS" ? "primary" : "default"}
+          />
+          {event.shelter && (
+            <Link to={shelterPath(event.shelter.slug)} {...stylex.props(styles.shelterLink)}>
+              <LocationOnOutlined fontSize="small" />
+              <Hb.Text variant="caption" color="text.secondary">
+                {event.shelter.name} · {event.shelter.region}
+              </Hb.Text>
+            </Link>
+          )}
+        </div>
+
+        <Hb.Text variant="body2" color="text.secondary">
+          {formatEventPeriod(event.startAt, event.endAt)}
         </Hb.Text>
-      )}
-      <Hb.Text variant="caption" color="text.secondary">
-        모집 {event.signedUpCount}/{event.capacity}명 · 남은 자리 {spotsLeft(event)}
-      </Hb.Text>
-      <Hb.Button
-        variant="primary"
-        fullWidth
-        disabled={!open}
-        loading={pending}
-        onClick={() => onSignUp(event.id)}
-      >
-        {open ? "봉사 신청하기" : VOLUNTEER_STATUS_LABEL[event.status]}
-      </Hb.Button>
+
+        {event.description && (
+          <>
+            <Hb.Text variant="body2" color="text.secondary" {...stylex.props(styles.clamp)}>
+              {event.description}
+            </Hb.Text>
+            <button type="button" {...stylex.props(styles.more)} onClick={openDetail}>
+              자세히 ›
+            </button>
+          </>
+        )}
+
+        <Hb.Progress.Linear variant="determinate" value={progress} />
+        <div {...stylex.props(styles.captionRow)}>
+          <Hb.Text variant="caption" color="text.secondary">
+            모집 {event.signedUpCount}/{event.capacity}명 · 남은 자리 {remaining}
+          </Hb.Text>
+          {isSignUpOpen(event) && remaining <= 3 && (
+            <Hb.Chip label="마감 임박" size="small" variant="soft" color="warning" />
+          )}
+        </div>
+
+        <SignUpButton event={event} controls={controls} fullWidth />
+      </Hb.Stack>
     </Hb.SectionCard>
   );
 };

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventDialog.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventDialog.styles.ts
@@ -1,0 +1,12 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  chips: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" },
+  shelterLink: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 3,
+    textDecoration: "none",
+    color: "var(--hb-color-text-secondary)",
+  },
+});

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventDialog.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerEventDialog.tsx
@@ -1,0 +1,118 @@
+import { Link } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { LocationOnOutlined } from "hobom-design-system/icons";
+import {
+  VOLUNTEER_SIGNUP_STATUS_LABEL,
+  VOLUNTEER_STATUS_LABEL,
+  VOLUNTEER_TYPE_LABEL,
+  spotsLeft,
+} from "@/entities/volunteer-event";
+import { shelterPath } from "@/shared/config";
+import { SignUpButton } from "./SignUpButton";
+import { styles } from "./VolunteerEventDialog.styles";
+import { formatEventPeriod } from "../lib/format-event-time.lib";
+import type { EnrichedVolunteerEvent } from "../lib/enrich-events.lib";
+import type { VolunteerSignupControls } from "../model/useVolunteerSignup";
+
+const STATUS_COLOR = { OPEN: "primary", CLOSED: "default", CANCELLED: "error" } as const;
+
+const formatFlightAt = (flightAt: string): string =>
+  new Date(flightAt).toLocaleString("ko-KR", { dateStyle: "medium", timeStyle: "short" });
+
+interface VolunteerEventDialogProps {
+  event: EnrichedVolunteerEvent;
+  controls: VolunteerSignupControls;
+  onClose: () => void;
+}
+
+/** Full detail for a volunteer event, including OVERSEAS transport info. Mounted
+ *  by the overlay while open; `onClose` unmounts it (§05). */
+export const VolunteerEventDialog = ({ event, controls, onClose }: VolunteerEventDialogProps) => {
+  const progress = event.capacity > 0 ? Math.round((event.signedUpCount / event.capacity) * 100) : 0;
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="sm">
+      <Hb.Dialog.Title>{event.title}</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <Hb.Stack spacing={2}>
+          <div {...stylex.props(styles.chips)}>
+            <Hb.Chip
+              label={VOLUNTEER_TYPE_LABEL[event.type]}
+              size="small"
+              variant="soft"
+              color={event.type === "OVERSEAS" ? "primary" : "default"}
+            />
+            <Hb.Chip
+              label={VOLUNTEER_STATUS_LABEL[event.status]}
+              size="small"
+              variant="soft"
+              color={STATUS_COLOR[event.status]}
+            />
+            {event.mySignupStatus && (
+              <Hb.Chip
+                label={VOLUNTEER_SIGNUP_STATUS_LABEL[event.mySignupStatus]}
+                size="small"
+                variant="soft"
+                color={event.mySignupStatus === "APPROVED" ? "success" : "warning"}
+              />
+            )}
+          </div>
+
+          {event.shelter && (
+            <Link to={shelterPath(event.shelter.slug)} {...stylex.props(styles.shelterLink)}>
+              <LocationOnOutlined fontSize="small" />
+              <Hb.Text variant="body2" color="text.secondary">
+                {event.shelter.name} · {event.shelter.region}
+              </Hb.Text>
+            </Link>
+          )}
+
+          <Hb.Text variant="body2" color="text.secondary">
+            {formatEventPeriod(event.startAt, event.endAt)}
+          </Hb.Text>
+
+          <Hb.Text variant="body2" style={{ whiteSpace: "pre-line" }}>
+            {event.description}
+          </Hb.Text>
+
+          <Hb.Stack spacing={1}>
+            <Hb.Progress.Linear variant="determinate" value={progress} />
+            <Hb.Text variant="caption" color="text.secondary">
+              모집 {event.signedUpCount}/{event.capacity}명 · 남은 자리 {spotsLeft(event)}
+            </Hb.Text>
+          </Hb.Stack>
+
+          {event.type === "OVERSEAS" && event.transport && (
+            <>
+              <Hb.Divider />
+              <Hb.Stack spacing={1}>
+                <Hb.Text variant="subtitle2">이동봉사 정보</Hb.Text>
+                <Hb.Text variant="body2" color="text.secondary">
+                  {event.transport.departure} → {event.transport.arrival}
+                </Hb.Text>
+                <Hb.Text variant="body2" color="text.secondary">
+                  {formatFlightAt(event.transport.flightAt)}
+                </Hb.Text>
+                <Hb.Text variant="body2" color="text.secondary">
+                  동반 동물 {event.transport.animalCount}마리
+                </Hb.Text>
+                {event.transport.qualification && (
+                  <Hb.Text variant="body2" color="text.secondary">
+                    자격: {event.transport.qualification}
+                  </Hb.Text>
+                )}
+              </Hb.Stack>
+            </>
+          )}
+        </Hb.Stack>
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          닫기
+        </Hb.Button>
+        <SignUpButton event={event} controls={controls} onAfter={onClose} />
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/features/volunteer/ui/VolunteerFeed.tsx
+++ b/apps/hobom-angel/src/features/volunteer/ui/VolunteerFeed.tsx
@@ -1,0 +1,19 @@
+import { Hb } from "hobom-design-system";
+import { VolunteerEventCard } from "./VolunteerEventCard";
+import type { EnrichedVolunteerEvent } from "../lib/enrich-events.lib";
+import type { VolunteerSignupControls } from "../model/useVolunteerSignup";
+
+interface VolunteerFeedProps {
+  events: EnrichedVolunteerEvent[];
+  controls: VolunteerSignupControls;
+}
+
+/** A stack of volunteer event cards — reused for a day's events and the upcoming
+ *  feed (§05). */
+export const VolunteerFeed = ({ events, controls }: VolunteerFeedProps) => (
+  <Hb.Stack spacing={2}>
+    {events.map((event) => (
+      <VolunteerEventCard key={event.id} event={event} controls={controls} />
+    ))}
+  </Hb.Stack>
+);

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -2,6 +2,7 @@ import { authHandlers } from "./auth.handlers";
 import { userHandlers } from "./user.handlers";
 import { animalHandlers } from "./animal.handlers";
 import { shelterHandlers } from "./shelter.handlers";
+import { volunteerHandlers } from "./volunteer.handlers";
 import { questionnaireHandlers } from "./questionnaire.handlers";
 import { adoptionHandlers } from "./adoption.handlers";
 
@@ -11,6 +12,7 @@ export const handlers = [
   ...userHandlers,
   ...animalHandlers,
   ...shelterHandlers,
+  ...volunteerHandlers,
   ...questionnaireHandlers,
   ...adoptionHandlers,
 ];

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -44,6 +44,8 @@ const VOLUNTEER_EVENTS = [
     capacity: 10,
     signedUpCount: 6,
     status: "OPEN",
+    mySignupId: null,
+    mySignupStatus: null,
   },
   {
     id: "vol-2",
@@ -55,6 +57,8 @@ const VOLUNTEER_EVENTS = [
     capacity: 8,
     signedUpCount: 8,
     status: "CLOSED",
+    mySignupId: null,
+    mySignupStatus: null,
   },
 ];
 
@@ -136,10 +140,21 @@ const DIRECTORY = DIRECTORY_NAMES.map(([name, slug, region, trustTier], i) => ({
   coverImageKey: `https://picsum.photos/seed/shelter-dir-${i + 1}/800/450`,
 }));
 
+const MARKERS = [
+  { id: "shelter-1", name: "행복보호소", slug: "haengbok-shelter", region: "서울", lat: 37.5, lng: 127.0 },
+  { id: "shelter-2", name: "행복한마음보호소", slug: "haengbok-maeum", region: "경기", lat: 37.4, lng: 127.1 },
+];
+
 const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
 
 /** §04 shelter microsite mock handlers — profile, notices, FAQs, and roster. */
 export const shelterHandlers = [
+  http.get(mockUrl("/shelters/map"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(MARKERS);
+  }),
+
   http.get(mockUrl("/shelters"), ({ request }) => {
     if (!mockSession.isActive()) return unauthorized();
 

--- a/apps/hobom-angel/src/mocks/handlers/volunteer.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/volunteer.handlers.ts
@@ -1,0 +1,86 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+const EVENTS = [
+  {
+    id: "vol-1",
+    shelterId: "shelter-1",
+    title: "주말 유기견 산책 봉사",
+    description: "아이들과 동네를 산책하며 사회성을 길러주는 봉사예요. 편한 복장으로 오세요.",
+    startAt: "2026-07-18T01:00:00.000Z",
+    endAt: "2026-07-18T04:00:00.000Z",
+    capacity: 12,
+    signedUpCount: 5,
+    status: "OPEN",
+  },
+  {
+    id: "vol-2",
+    shelterId: "shelter-1",
+    title: "보호소 대청소",
+    description: "견사와 마당을 정비하는 활동입니다.",
+    startAt: "2026-07-20T00:00:00.000Z",
+    endAt: "2026-07-20T03:00:00.000Z",
+    capacity: 8,
+    signedUpCount: 8,
+    status: "CLOSED",
+  },
+  {
+    id: "vol-3",
+    shelterId: "shelter-2",
+    title: "입양 홍보 부스 운영",
+    description: "주말 플리마켓에서 입양 홍보 부스를 함께 운영해요.",
+    startAt: "2026-07-20T05:00:00.000Z",
+    endAt: "2026-07-20T08:00:00.000Z",
+    capacity: 6,
+    signedUpCount: 2,
+    status: "OPEN",
+  },
+  {
+    id: "vol-4",
+    shelterId: "shelter-1",
+    title: "해외 이동봉사 동행",
+    description: "해외로 입양 가는 아이와 공항까지 동행하는 이동봉사입니다.",
+    startAt: "2026-07-25T02:00:00.000Z",
+    endAt: "2026-07-25T09:00:00.000Z",
+    capacity: 4,
+    signedUpCount: 1,
+    status: "OPEN",
+  },
+];
+
+const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+
+/** §05 volunteer mock handlers — upcoming list, detail, and signup. */
+export const volunteerHandlers = [
+  http.get(mockUrl("/volunteer-events"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(EVENTS);
+  }),
+
+  http.get(mockUrl("/volunteer-events/:eventId"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const event = EVENTS.find((candidate) => candidate.id === params.eventId);
+
+    if (!event) {
+      return HttpResponse.json({ message: "봉사 일정을 찾을 수 없어요." }, { status: 404 });
+    }
+
+    return ok(event);
+  }),
+
+  http.post(mockUrl("/volunteer-events/:eventId/signups"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const event = EVENTS.find((candidate) => candidate.id === params.eventId);
+
+    if (event && event.signedUpCount < event.capacity) {
+      event.signedUpCount += 1;
+    }
+
+    return ok({ signupId: `signup-${params.eventId as string}` });
+  }),
+];

--- a/apps/hobom-angel/src/mocks/handlers/volunteer.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/volunteer.handlers.ts
@@ -14,6 +14,8 @@ const EVENTS = [
     capacity: 12,
     signedUpCount: 5,
     status: "OPEN",
+    type: "GENERAL",
+    transport: null,
   },
   {
     id: "vol-2",
@@ -25,6 +27,8 @@ const EVENTS = [
     capacity: 8,
     signedUpCount: 8,
     status: "CLOSED",
+    type: "GENERAL",
+    transport: null,
   },
   {
     id: "vol-3",
@@ -36,28 +40,52 @@ const EVENTS = [
     capacity: 6,
     signedUpCount: 2,
     status: "OPEN",
+    type: "GENERAL",
+    transport: null,
   },
   {
     id: "vol-4",
     shelterId: "shelter-1",
-    title: "해외 이동봉사 동행",
+    title: "미국행 이동봉사 동행",
     description: "해외로 입양 가는 아이와 공항까지 동행하는 이동봉사입니다.",
     startAt: "2026-07-25T02:00:00.000Z",
     endAt: "2026-07-25T09:00:00.000Z",
     capacity: 4,
     signedUpCount: 1,
     status: "OPEN",
+    type: "OVERSEAS",
+    transport: {
+      departure: "인천 (ICN)",
+      arrival: "로스앤젤레스 (LAX)",
+      flightAt: "2026-07-25T03:30:00.000Z",
+      animalIds: ["animal-1", "animal-2"],
+      animalCount: 2,
+      qualification: "왕복 항공권 소지자",
+    },
   },
 ];
 
 const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
 
-/** §05 volunteer mock handlers — upcoming list, detail, and signup. */
+/** The viewer's own live signups, keyed by eventId → signupId. The mock is
+ *  single-user, so this stands in for the server-side per-user signup state that
+ *  the viewer-aware event reads expose. */
+const mySignups = new Map<string, string>();
+
+/** Attach the caller's own signup to an event, mirroring the backend's
+ *  viewer-aware reads. Mock signups are always PENDING (no staff approval flow). */
+const withViewer = (event: (typeof EVENTS)[number]) => {
+  const signupId = mySignups.get(event.id) ?? null;
+
+  return { ...event, mySignupId: signupId, mySignupStatus: signupId ? "PENDING" : null };
+};
+
+/** §05 volunteer mock handlers — upcoming list, detail, signup, and withdrawal. */
 export const volunteerHandlers = [
   http.get(mockUrl("/volunteer-events"), () => {
     if (!mockSession.isActive()) return unauthorized();
 
-    return ok(EVENTS);
+    return ok(EVENTS.map(withViewer));
   }),
 
   http.get(mockUrl("/volunteer-events/:eventId"), ({ params }) => {
@@ -69,18 +97,36 @@ export const volunteerHandlers = [
       return HttpResponse.json({ message: "봉사 일정을 찾을 수 없어요." }, { status: 404 });
     }
 
-    return ok(event);
+    return ok(withViewer(event));
   }),
 
   http.post(mockUrl("/volunteer-events/:eventId/signups"), ({ params }) => {
     if (!mockSession.isActive()) return unauthorized();
 
-    const event = EVENTS.find((candidate) => candidate.id === params.eventId);
+    const eventId = params.eventId as string;
+    const event = EVENTS.find((candidate) => candidate.id === eventId);
+    const signupId = `signup-${eventId}`;
 
-    if (event && event.signedUpCount < event.capacity) {
+    if (event && event.signedUpCount < event.capacity && !mySignups.has(eventId)) {
       event.signedUpCount += 1;
+      mySignups.set(eventId, signupId);
     }
 
-    return ok({ signupId: `signup-${params.eventId as string}` });
+    return ok({ signupId });
+  }),
+
+  http.post(mockUrl("/volunteer-signups/:signupId/withdrawal"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    // Signup ids are `signup-<eventId>` in the mock, so recover the event.
+    const eventId = String(params.signupId).replace(/^signup-/, "");
+    const event = EVENTS.find((candidate) => candidate.id === eventId);
+
+    if (mySignups.has(eventId)) {
+      if (event && event.signedUpCount > 0) event.signedUpCount -= 1;
+      mySignups.delete(eventId);
+    }
+
+    return ok({ withdrawn: true });
   }),
 ];

--- a/apps/hobom-angel/src/pages/volunteer/index.ts
+++ b/apps/hobom-angel/src/pages/volunteer/index.ts
@@ -1,0 +1,1 @@
+export { VolunteerPage } from "./ui/VolunteerPage";

--- a/apps/hobom-angel/src/pages/volunteer/ui/VolunteerPage.tsx
+++ b/apps/hobom-angel/src/pages/volunteer/ui/VolunteerPage.tsx
@@ -1,0 +1,3 @@
+import { VolunteerBoard } from "@/features/volunteer";
+
+export const VolunteerPage = () => <VolunteerBoard />;

--- a/apps/hobom-angel/src/shared/model/index.ts
+++ b/apps/hobom-angel/src/shared/model/index.ts
@@ -1,5 +1,6 @@
 export { useFunnel } from "./useFunnel";
 export { useToast } from "./useToast";
+export { useOverlay } from "./useOverlay";
 export { useRouteMeta } from "./useRouteMeta";
 export { useInfiniteScroll } from "./useInfiniteScroll";
 export { useSearchParamsState } from "./useSearchParamsState";

--- a/apps/hobom-angel/src/shared/model/useOverlay.ts
+++ b/apps/hobom-angel/src/shared/model/useOverlay.ts
@@ -1,0 +1,42 @@
+import { createElement, useCallback, useContext } from "react";
+import type { ReactNode } from "react";
+import { OverlayContext } from "hobom-design-system";
+
+let overlayCount = 0;
+
+export interface OverlayControl {
+  /** Remove the overlay from the tree. */
+  close: () => void;
+}
+
+interface OverlayHostProps {
+  render: (control: OverlayControl) => ReactNode;
+  remove: () => void;
+}
+
+// A real component instance (not a static snapshot) so the overlay has its own
+// hooks/lifecycle and re-renders normally while it's open.
+const OverlayHost = ({ render, remove }: OverlayHostProps): ReactNode => render({ close: remove });
+
+/** Imperatively mount an overlay (dialog/confirm/sheet) at the app root, so a
+ *  component can open one without owning its render/mount state. The rendered
+ *  content is mounted while open and unmounted on `close`. */
+export const useOverlay = () => {
+  const context = useContext(OverlayContext);
+
+  if (!context) throw new Error("useOverlay must be used within an OverlayProvider");
+
+  const { created, unmount } = context;
+
+  const open = useCallback(
+    (render: (control: OverlayControl) => ReactNode) => {
+      overlayCount += 1;
+      const id = `overlay-${overlayCount}`;
+
+      created(id, createElement(OverlayHost, { render, remove: () => unmount(id) }));
+    },
+    [created, unmount],
+  );
+
+  return { open };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@stylexjs/stylex':
         specifier: ^0.19.0
         version: 0.19.0
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       hobom-data:
         specifier: workspace:*
         version: link:../../packages/hobom-data


### PR DESCRIPTION
The `/volunteer` route was a ComingSoon placeholder. This builds the 봉사활동 screen on the volunteer-events endpoints.

## What's here

- **Month calendar** of upcoming events — a dot marks each day that has volunteering; today is ringed and the selected day filled. Built on the design system's `Calendar` with a custom day renderer.
- **Selected day's events** in the sidebar — each with its schedule, capacity (`모집 N/M명 · 남은 자리`), status chip, and a **봉사 신청하기** button. The calendar opens on the earliest upcoming event's day so the sidebar isn't empty on load.
- **Sign-up** posts to `POST /volunteer-events/:id/signups`, refreshes the list count, and toasts the result; the busy button is per-card.
- Extends the `volunteer-event` entity with `upcoming` / `detail` queries and a signup mutation, wired to `GET /volunteer-events`, `GET /volunteer-events/:id`, and the signup endpoint.

## Deferred (backend gaps)

The `VolunteerEventResponse` contract is `{ id, shelterId, title, description, startAt, endAt, capacity, signedUpCount, status }`, so the design's extras wait on the backend:
- **Event types** (일반 / 해외 이동봉사) — no type field.
- **Post-event reviews** (홍보글·댓글·좋아요·북마크) — not modeled.
- **Shelter name on the card** — the list item carries only `shelterId`.

## Verification

`hobom-angel`: typecheck, lint, 70 unit tests, and the full Playwright e2e suite (26, incl. a new calendar + signup test) pass.