### PR TITLE
Add the favorites screen with an optimistic heart toggle

### DIFF
--- a/apps/hobom-angel/e2e/animal-detail.spec.ts
+++ b/apps/hobom-angel/e2e/animal-detail.spec.ts
@@ -27,15 +27,16 @@ test.describe("§02 animal detail", () => {
     await page.screenshot({ path: "e2e-artifacts/detail.png", fullPage: true });
   });
 
-  test("toggles the bookmark", async ({ page }) => {
+  test("toggles the favorite", async ({ page }) => {
     await login(page);
     await page.goto("animals/animal-1");
 
-    const bookmark = page.getByRole("button", { name: "관심 동물" });
-    await expect(bookmark).toHaveAttribute("aria-pressed", "false");
+    // animal-1 (콩이) is seeded as a favorite; unfavoriting flips it optimistically.
+    const heart = page.getByRole("button", { name: "콩이 찜하기" });
+    await expect(heart).toHaveAttribute("aria-pressed", "true");
 
-    await bookmark.click();
+    await heart.click();
 
-    await expect(bookmark).toHaveAttribute("aria-pressed", "true");
+    await expect(heart).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/apps/hobom-angel/e2e/favorites.spec.ts
+++ b/apps/hobom-angel/e2e/favorites.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§05·부록 favorites", () => {
+  test("lists favorited animals and unfavorites optimistically", async ({ page }) => {
+    await login(page);
+    await page.goto("./favorites");
+
+    await expect(page.getByRole("heading", { name: "찜", level: 1 })).toBeVisible();
+    // Seeded favorites hydrate into cards.
+    await expect(page.getByText("콩이", { exact: true })).toBeVisible();
+    await expect(page.getByText("초코", { exact: true })).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/favorites.png", fullPage: true });
+
+    // Unfavoriting drops the card in place (optimistic — no refetch flicker).
+    await page.getByRole("button", { name: "초코 찜하기" }).click();
+    await expect(page.getByText("초코", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("콩이", { exact: true })).toBeVisible();
+
+    // The followed shelters live under the second tab.
+    await page.getByRole("tab", { name: "팔로우 보호소" }).click();
+    await expect(page.getByText("행복보호소")).toBeVisible();
+  });
+
+  test("favorites an animal from the browse grid", async ({ page }) => {
+    await login(page);
+    await page.getByRole("banner").getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    // Favorite the first (unfavorited) card, whatever it is.
+    const heart = page.locator('button[aria-label$="찜하기"]').first();
+    await expect(heart).toHaveAttribute("aria-pressed", "false");
+    const name = (await heart.getAttribute("aria-label"))!.replace(" 찜하기", "");
+    await heart.click();
+    await expect(heart).toHaveAttribute("aria-pressed", "true");
+
+    // Navigate in-app (the mock's favorites live in memory, so a hard reload
+    // would reseed them) via the profile menu — it now shows up under 찜.
+    await page.getByRole("button", { name: /봄이네님/ }).click();
+    await page.getByRole("link", { name: "관심" }).click();
+    await expect(page).toHaveURL(/\/favorites$/);
+    await expect(page.getByText(name, { exact: true })).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -37,6 +37,9 @@ const ShelterListPage = lazy(() =>
 const VolunteerPage = lazy(() =>
   import("@/pages/volunteer").then((module) => ({ default: module.VolunteerPage })),
 );
+const FavoritesPage = lazy(() =>
+  import("@/pages/favorites").then((module) => ({ default: module.FavoritesPage })),
+);
 
 // Warm the common route chunks during idle time so navigating to them shows the
 // screen's own skeleton (data Suspense) rather than the chunk-load spinner.
@@ -48,7 +51,7 @@ const prefetchRoutes = () => {
 };
 
 // Sections still on the ComingSoon placeholder until their screens land.
-const SECTION_ROUTES = [ROUTES.FOSTER, ROUTES.FAVORITES, ROUTES.APPLICATIONS, ROUTES.MY];
+const SECTION_ROUTES = [ROUTES.FOSTER, ROUTES.APPLICATIONS, ROUTES.MY];
 
 export const AppRouter = () => {
   useRouteMeta();
@@ -74,6 +77,7 @@ export const AppRouter = () => {
             <Route path={ROUTES.SHELTERS} element={<ShelterListPage />} />
             <Route path={ROUTES.SHELTER_DETAIL} element={<ShelterDetailPage />} />
             <Route path={ROUTES.VOLUNTEER} element={<VolunteerPage />} />
+            <Route path={ROUTES.FAVORITES} element={<FavoritesPage />} />
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />
               ))}

--- a/apps/hobom-angel/src/entities/animal/ui/AnimalCard.styles.ts
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalCard.styles.ts
@@ -11,6 +11,7 @@ export const styles = stylex.create({
     transform: { default: "none", ":hover": "translateY(-2px)" },
     boxShadow: { default: "none", ":hover": "var(--hb-angel-shadow)" },
   },
+  media: { position: "relative" },
   body: { paddingInline: 14, paddingTop: 12, paddingBottom: 14 },
   nameRow: { display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 },
   name: { margin: 0, fontSize: "1rem", fontWeight: 700, color: "var(--hb-color-text-primary)" },

--- a/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
@@ -13,6 +14,8 @@ interface AnimalCardProps {
   imageUrl?: string;
   /** When set, the whole card links to the animal's detail page. */
   to?: string;
+  /** Overlaid on the photo's top-right — e.g. a favorite button. */
+  action?: ReactNode;
 }
 
 const STATUS_COLOR = {
@@ -24,13 +27,16 @@ const STATUS_COLOR = {
 } as const;
 
 /** A shelter animal preview card — used on the landing, list, and shelter pages. */
-export const AnimalCard = ({ name, status, meta, imageUrl, to }: AnimalCardProps) => {
+export const AnimalCard = ({ name, status, meta, imageUrl, to, action }: AnimalCardProps) => {
   const card = (
     <Hb.Card.Root
       variant="outlined"
       style={{ overflow: "hidden", borderRadius: "var(--hb-angel-radius-card)", height: "100%" }}
     >
-      <AnimalPhoto src={imageUrl} alt={name} ratio="4 / 3" />
+      <div {...stylex.props(styles.media)}>
+        <AnimalPhoto src={imageUrl} alt={name} ratio="4 / 3" />
+        {action}
+      </div>
       <div {...stylex.props(styles.body)}>
         <div {...stylex.props(styles.nameRow)}>
           <h3 {...stylex.props(styles.name)}>{name}</h3>

--- a/apps/hobom-angel/src/entities/favorite/api/favorite.api.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.api.ts
@@ -1,0 +1,25 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toFavorite } from "../lib/to-favorite.lib";
+import { favoritesSchema } from "./favorite.schema";
+import type { Favorite, FavoriteTargetType } from "../model/favorite.model";
+
+/** Fetch the current user's favorites of one type (찜 animals or 팔로우 shelters). */
+export const getFavorites = (
+  targetType: FavoriteTargetType,
+  signal?: AbortSignal,
+): Promise<Favorite[]> =>
+  httpClient
+    .get(`/favorites?targetType=${targetType}`, { signal })
+    .then(parseResponse(favoritesSchema, "GET /favorites"))
+    .then((items) => items.map(toFavorite));
+
+/** Add a favorite (idempotent — requires auth, no response body). */
+export const addFavorite = (targetType: FavoriteTargetType, targetRef: string): Promise<void> =>
+  httpClient.post("/favorites", { targetType, targetRef }).then(() => undefined);
+
+/** Remove a favorite (requires auth, no response body). */
+export const removeFavorite = (
+  targetType: FavoriteTargetType,
+  targetRef: string,
+): Promise<void> =>
+  httpClient.delete(`/favorites/${targetType}/${targetRef}`).then(() => undefined);

--- a/apps/hobom-angel/src/entities/favorite/api/favorite.queries.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.queries.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from "hobom-data";
+import { getFavorites } from "./favorite.api";
+import type { FavoriteTargetType } from "../model/favorite.model";
+
+export const favoriteQueries = {
+  all: () => ["favorites"] as const,
+
+  list: (targetType: FavoriteTargetType) =>
+    queryOptions({
+      queryKey: [...favoriteQueries.all(), targetType] as const,
+      queryFn: ({ signal }) => getFavorites(targetType, signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/favorite/api/favorite.schema.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.schema.ts
@@ -1,0 +1,13 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { RawFavorite } from "./favorite.type";
+
+/** A single favorite reference on the wire. */
+export const favoriteSchema: Schema<RawFavorite> = HoBomSchema.object({
+  targetType: HoBomSchema.enum(["ANIMAL", "SHELTER"]),
+  targetRef: HoBomSchema.string(),
+  favoritedAt: HoBomSchema.string().nullable(),
+});
+
+/** `GET /favorites` — a plain array of favorite references. */
+export const favoritesSchema: Schema<RawFavorite[]> = HoBomSchema.array(favoriteSchema);

--- a/apps/hobom-angel/src/entities/favorite/api/favorite.type.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.type.ts
@@ -1,0 +1,8 @@
+import type { FavoriteTargetType } from "../model/favorite.model";
+
+/** `GET /favorites` item, straight off the wire. */
+export interface RawFavorite {
+  targetType: FavoriteTargetType;
+  targetRef: string;
+  favoritedAt: string | null;
+}

--- a/apps/hobom-angel/src/entities/favorite/index.ts
+++ b/apps/hobom-angel/src/entities/favorite/index.ts
@@ -1,0 +1,4 @@
+export { favoriteQueries } from "./api/favorite.queries";
+export { useFavoriteToggle } from "./model/useFavoriteToggle";
+export { FavoriteButton } from "./ui/FavoriteButton";
+export type { Favorite, FavoriteTargetType } from "./model/favorite.model";

--- a/apps/hobom-angel/src/entities/favorite/lib/to-favorite.lib.ts
+++ b/apps/hobom-angel/src/entities/favorite/lib/to-favorite.lib.ts
@@ -1,0 +1,10 @@
+import type { RawFavorite } from "../api/favorite.type";
+import type { Favorite } from "../model/favorite.model";
+
+/** Anti-corruption: map the API favorite to the UI model (straight field copy,
+ *  kept for consistency with the entity's other boundaries). */
+export const toFavorite = (raw: RawFavorite): Favorite => ({
+  targetType: raw.targetType,
+  targetRef: raw.targetRef,
+  favoritedAt: raw.favoritedAt,
+});

--- a/apps/hobom-angel/src/entities/favorite/lib/toggle-favorite.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/favorite/lib/toggle-favorite.lib.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { applyFavoriteToggle, isFavorited } from "./toggle-favorite.lib";
+import type { Favorite } from "../model/favorite.model";
+
+const favorite = (targetRef: string): Favorite => ({
+  targetType: "ANIMAL",
+  targetRef,
+  favoritedAt: "2026-07-16T00:00:00.000Z",
+});
+
+describe("isFavorited", () => {
+  it("reports membership by targetRef", () => {
+    const list = [favorite("animal-1"), favorite("animal-2")];
+
+    expect(isFavorited(list, "animal-2")).toBe(true);
+    expect(isFavorited(list, "animal-9")).toBe(false);
+  });
+});
+
+describe("applyFavoriteToggle", () => {
+  it("prepends a placeholder when turning on", () => {
+    const result = applyFavoriteToggle([favorite("animal-1")], "ANIMAL", "animal-2", true);
+
+    expect(result.map((f) => f.targetRef)).toEqual(["animal-2", "animal-1"]);
+    expect(result[0]).toMatchObject({ targetType: "ANIMAL", targetRef: "animal-2", favoritedAt: null });
+  });
+
+  it("is idempotent when turning on an already-favorited ref", () => {
+    const list = [favorite("animal-1")];
+
+    expect(applyFavoriteToggle(list, "ANIMAL", "animal-1", true)).toBe(list);
+  });
+
+  it("drops the ref when turning off", () => {
+    const list = [favorite("animal-1"), favorite("animal-2")];
+
+    expect(applyFavoriteToggle(list, "ANIMAL", "animal-1", false).map((f) => f.targetRef)).toEqual([
+      "animal-2",
+    ]);
+  });
+});

--- a/apps/hobom-angel/src/entities/favorite/lib/toggle-favorite.lib.ts
+++ b/apps/hobom-angel/src/entities/favorite/lib/toggle-favorite.lib.ts
@@ -1,0 +1,23 @@
+import type { Favorite, FavoriteTargetType } from "../model/favorite.model";
+
+/** Whether a target is in the favorites list. */
+export const isFavorited = (favorites: Favorite[], targetRef: string): boolean =>
+  favorites.some((favorite) => favorite.targetRef === targetRef);
+
+/** Apply an optimistic toggle to a cached favorites list: prepend a placeholder
+ *  when turning on (idempotent), drop it when turning off. Pure, so the
+ *  optimistic mutation stays trivial and this can be unit-tested in isolation. */
+export const applyFavoriteToggle = (
+  favorites: Favorite[],
+  targetType: FavoriteTargetType,
+  targetRef: string,
+  next: boolean,
+): Favorite[] => {
+  if (!next) {
+    return favorites.filter((favorite) => favorite.targetRef !== targetRef);
+  }
+
+  if (isFavorited(favorites, targetRef)) return favorites;
+
+  return [{ targetType, targetRef, favoritedAt: null }, ...favorites];
+};

--- a/apps/hobom-angel/src/entities/favorite/model/favorite.model.ts
+++ b/apps/hobom-angel/src/entities/favorite/model/favorite.model.ts
@@ -1,0 +1,11 @@
+export type FavoriteTargetType = "ANIMAL" | "SHELTER";
+
+/** A member's favorite — an animal (찜) or a shelter (팔로우). The list read
+ *  returns only the reference; the target is hydrated separately. */
+export interface Favorite {
+  targetType: FavoriteTargetType;
+  /** The favorited animal or shelter id. */
+  targetRef: string;
+  /** ISO datetime the favorite was added, or null. */
+  favoritedAt: string | null;
+}

--- a/apps/hobom-angel/src/entities/favorite/model/useFavoriteToggle.ts
+++ b/apps/hobom-angel/src/entities/favorite/model/useFavoriteToggle.ts
@@ -1,0 +1,55 @@
+import { useDataLot, useMutation, useQuery } from "hobom-data";
+import { useToast } from "@/shared/model";
+import { addFavorite, removeFavorite } from "../api/favorite.api";
+import { favoriteQueries } from "../api/favorite.queries";
+import { applyFavoriteToggle, isFavorited } from "../lib/toggle-favorite.lib";
+import type { Favorite, FavoriteTargetType } from "../model/favorite.model";
+
+interface ToggleVariables {
+  targetRef: string;
+  next: boolean;
+}
+
+interface ToggleContext {
+  previous: Favorite[] | undefined;
+}
+
+/** Read the viewer's favorites of one type and toggle them optimistically: the
+ *  heart flips instantly (onMutate patches the cache), rolls back on error, and
+ *  reconciles with the server on settle. Call once per screen and pass
+ *  `isFavorited`/`toggle` down to the presentational buttons. */
+export const useFavoriteToggle = (targetType: FavoriteTargetType) => {
+  const dataLot = useDataLot();
+  const { openErrorToast } = useToast();
+  const options = favoriteQueries.list(targetType);
+  const { data } = useQuery(options);
+  const favorites = data ?? [];
+
+  const mutation = useMutation<void, Error, ToggleVariables, ToggleContext>({
+    mutationFn: ({ targetRef, next }) =>
+      next ? addFavorite(targetType, targetRef) : removeFavorite(targetType, targetRef),
+    onMutate: async ({ targetRef, next }) => {
+      await dataLot.cancelQueries(options);
+      const previous = dataLot.getQueryData<Favorite[]>(options.queryKey);
+
+      dataLot.setQueryData<Favorite[]>(options.queryKey, (old) =>
+        applyFavoriteToggle(old ?? [], targetType, targetRef, next),
+      );
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) dataLot.setQueryData(options.queryKey, context.previous);
+      openErrorToast({ message: "잠시 후 다시 시도해 주세요." });
+    },
+    onSettled: () => {
+      void dataLot.invalidateQueries(options);
+    },
+  });
+
+  return {
+    isFavorited: (targetRef: string) => isFavorited(favorites, targetRef),
+    toggle: (targetRef: string) =>
+      mutation.mutate({ targetRef, next: !isFavorited(favorites, targetRef) }),
+  };
+};

--- a/apps/hobom-angel/src/entities/favorite/ui/FavoriteButton.styles.ts
+++ b/apps/hobom-angel/src/entities/favorite/ui/FavoriteButton.styles.ts
@@ -1,0 +1,32 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  button: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    width: 34,
+    height: 34,
+    padding: 0,
+    borderRadius: 999,
+    borderWidth: 0,
+    borderStyle: "none",
+    cursor: "pointer",
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-color-canvas)" },
+    transitionProperty: "color, background-color",
+    transitionDuration: "0.15s",
+  },
+  // Floats over card media, so it needs a legible backdrop.
+  overlay: {
+    position: "absolute",
+    top: 10,
+    insetInlineEnd: 10,
+    backgroundColor: { default: "rgba(255, 255, 255, 0.92)", ":hover": "rgba(255, 255, 255, 1)" },
+    boxShadow: "var(--hb-angel-shadow)",
+  },
+  on: {
+    color: "var(--hb-color-accent-dark)",
+  },
+});

--- a/apps/hobom-angel/src/entities/favorite/ui/FavoriteButton.tsx
+++ b/apps/hobom-angel/src/entities/favorite/ui/FavoriteButton.tsx
@@ -1,0 +1,36 @@
+import * as stylex from "@stylexjs/stylex";
+import { Favorite, FavoriteBorder } from "hobom-design-system/icons";
+import { styles } from "./FavoriteButton.styles";
+
+interface FavoriteButtonProps {
+  favorited: boolean;
+  onToggle: () => void;
+  /** Names the target for assistive tech, e.g. the animal or shelter name. */
+  label: string;
+  /** Float over card media (translucent backdrop) instead of sitting inline. */
+  overlay?: boolean;
+}
+
+/** A heart toggle. Presentational — its state and handler come from a
+ *  useFavoriteToggle owner. Swallows the click so it works inside a card link
+ *  without triggering navigation. */
+export const FavoriteButton = ({
+  favorited,
+  onToggle,
+  label,
+  overlay = false,
+}: FavoriteButtonProps) => (
+  <button
+    type="button"
+    aria-label={`${label} 찜하기`}
+    aria-pressed={favorited}
+    {...stylex.props(styles.button, overlay && styles.overlay, favorited && styles.on)}
+    onClick={(event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onToggle();
+    }}
+  >
+    {favorited ? <Favorite fontSize="small" /> : <FavoriteBorder fontSize="small" />}
+  </button>
+);

--- a/apps/hobom-angel/src/features/animal-detail/ui/AnimalDetail.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/AnimalDetail.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { SPECIES_LABEL } from "@/entities/animal";
+import { useFavoriteToggle } from "@/entities/favorite";
 import { ROUTES } from "@/shared/config";
 import { useAnimalDetail } from "../model/useAnimalDetail";
 import { AnimalAttributes } from "./AnimalAttributes";
@@ -12,6 +13,7 @@ import { styles } from "./AnimalDetail.styles";
  *  health / traits / rescue attribute grids. */
 export const AnimalDetail = ({ animalId }: { animalId: string }) => {
   const animal = useAnimalDetail(animalId);
+  const favorites = useFavoriteToggle("ANIMAL");
 
   return (
     <div {...stylex.props(styles.root)}>
@@ -32,7 +34,11 @@ export const AnimalDetail = ({ animalId }: { animalId: string }) => {
 
       <div {...stylex.props(styles.topGrid)}>
         <AnimalGallery photos={animal.photos} name={animal.name} />
-        <ApplyCard animal={animal} />
+        <ApplyCard
+          animal={animal}
+          favorited={favorites.isFavorited(animal.id)}
+          onToggleFavorite={() => favorites.toggle(animal.id)}
+        />
       </div>
 
       {animal.description && (

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
@@ -1,14 +1,18 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AnimalDetail } from "@/entities/animal";
 import { ApplyCard } from "./ApplyCard";
 
-const renderCard = (detail: AnimalDetail) =>
+const renderCard = (
+  detail: AnimalDetail,
+  favorited = false,
+  onToggleFavorite: () => void = vi.fn(),
+) =>
   render(
     <MemoryRouter>
-      <ApplyCard animal={detail} />
+      <ApplyCard animal={detail} favorited={favorited} onToggleFavorite={onToggleFavorite} />
     </MemoryRouter>,
   );
 
@@ -50,14 +54,22 @@ describe("ApplyCard", () => {
     expect(screen.queryByRole("button", { name: "임시보호 신청" })).toBeNull();
   });
 
-  it("toggles the bookmark on click", () => {
-    renderCard(animal("AVAILABLE"));
-    const bookmark = button("관심 동물");
+  it("reflects the favorited state and calls onToggleFavorite on click", () => {
+    const onToggleFavorite = vi.fn();
+
+    renderCard(animal("AVAILABLE"), false, onToggleFavorite);
+    const bookmark = button("콩이 찜하기");
 
     expect(bookmark.getAttribute("aria-pressed")).toBe("false");
 
     fireEvent.click(bookmark);
 
-    expect(bookmark.getAttribute("aria-pressed")).toBe("true");
+    expect(onToggleFavorite).toHaveBeenCalledOnce();
+  });
+
+  it("shows the filled heart when favorited", () => {
+    renderCard(animal("AVAILABLE"), true);
+
+    expect(button("콩이 찜하기").getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
@@ -9,6 +8,13 @@ import { useToast } from "@/shared/model";
 import type { AnimalDetail } from "@/entities/animal";
 import { applyCta } from "../lib/apply-cta.lib";
 import { styles } from "./ApplyCard.styles";
+
+interface ApplyCardProps {
+  animal: AnimalDetail;
+  /** Whether the viewer has favorited this animal (owned by the container). */
+  favorited: boolean;
+  onToggleFavorite: () => void;
+}
 
 const STATUS_COLOR = {
   입양가능: "primary",
@@ -22,10 +28,9 @@ const COMING_SOON = "곧 제공될 예정이에요.";
 
 /** Sticky application panel with status-branched CTAs (§02). Apply/foster and
  *  inquiry are placeholders until the funnel and inquiry threads land. */
-export const ApplyCard = ({ animal }: { animal: AnimalDetail }) => {
+export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProps) => {
   const navigate = useNavigate();
   const { openWarnToast } = useToast();
-  const [bookmarked, setBookmarked] = useState(false);
 
   const cta = applyCta(animal.status);
   const statusLabel = STATUS_LABEL[animal.status];
@@ -49,12 +54,12 @@ export const ApplyCard = ({ animal }: { animal: AnimalDetail }) => {
         <Hb.Chip label={statusLabel} size="small" variant="soft" color={STATUS_COLOR[statusLabel]} />
         <button
           type="button"
-          aria-label="관심 동물"
-          aria-pressed={bookmarked}
-          {...stylex.props(styles.bookmark, bookmarked && styles.bookmarkOn)}
-          onClick={() => setBookmarked((on) => !on)}
+          aria-label={`${animal.name} 찜하기`}
+          aria-pressed={favorited}
+          {...stylex.props(styles.bookmark, favorited && styles.bookmarkOn)}
+          onClick={onToggleFavorite}
         >
-          {bookmarked ? <Favorite fontSize="small" /> : <FavoriteBorder fontSize="small" />}
+          {favorited ? <Favorite fontSize="small" /> : <FavoriteBorder fontSize="small" />}
         </button>
       </div>
       <p {...stylex.props(styles.meta)}>{meta}</p>

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalGrid.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { AnimalCard, STATUS_LABEL, animalMeta } from "@/entities/animal";
+import { FavoriteButton, useFavoriteToggle } from "@/entities/favorite";
 import { animalDetailPath } from "@/shared/config";
 import { useInfiniteScroll } from "@/shared/model";
 import type { Animal } from "@/entities/animal";
@@ -21,6 +22,7 @@ export const AnimalGrid = ({
   fetchNextPage,
 }: AnimalGridProps) => {
   const sentinelRef = useInfiniteScroll({ hasNextPage, isFetchingNextPage, fetchNextPage });
+  const favorites = useFavoriteToggle("ANIMAL");
 
   if (animals.length === 0) {
     return <p {...stylex.props(styles.empty)}>조건에 맞는 친구가 아직 없어요.</p>;
@@ -37,6 +39,14 @@ export const AnimalGrid = ({
             meta={animalMeta(animal)}
             imageUrl={animal.photoUrl}
             to={animalDetailPath(animal.id)}
+            action={
+              <FavoriteButton
+                favorited={favorites.isFavorited(animal.id)}
+                onToggle={() => favorites.toggle(animal.id)}
+                label={animal.name}
+                overlay
+              />
+            }
           />
         ))}
       </div>

--- a/apps/hobom-angel/src/features/favorites/index.ts
+++ b/apps/hobom-angel/src/features/favorites/index.ts
@@ -1,0 +1,1 @@
+export { Favorites } from "./ui/Favorites";

--- a/apps/hobom-angel/src/features/favorites/model/useFavoriteAnimals.ts
+++ b/apps/hobom-angel/src/features/favorites/model/useFavoriteAnimals.ts
@@ -1,0 +1,18 @@
+import { useSuspenseQueries, useSuspenseQuery } from "hobom-data";
+import { animalQueries } from "@/entities/animal";
+import { favoriteQueries, useFavoriteToggle } from "@/entities/favorite";
+import type { AnimalDetail } from "@/entities/animal";
+
+/** The viewer's favorited animals, hydrated from their refs. The favorite refs
+ *  and each animal's detail load in parallel; toggling unfavorites optimistically
+ *  (which drops the card, since the refs drive the list). */
+export const useFavoriteAnimals = () => {
+  const { data: favorites } = useSuspenseQuery(favoriteQueries.list("ANIMAL"));
+  const results = useSuspenseQueries({
+    queries: favorites.map((favorite) => animalQueries.detail(favorite.targetRef)),
+  });
+  const controls = useFavoriteToggle("ANIMAL");
+  const animals: AnimalDetail[] = results.map((result) => result.data);
+
+  return { animals, controls };
+};

--- a/apps/hobom-angel/src/features/favorites/model/useFavoriteShelters.ts
+++ b/apps/hobom-angel/src/features/favorites/model/useFavoriteShelters.ts
@@ -1,0 +1,20 @@
+import { useSuspenseQueries } from "hobom-data";
+import { favoriteQueries, useFavoriteToggle } from "@/entities/favorite";
+import { shelterQueries } from "@/entities/shelter";
+import type { ShelterMarker } from "@/entities/shelter";
+
+/** The viewer's followed shelters. Favorites store only shelter ids, so we join
+ *  them against the shelter markers (id → name/slug/region) — both load in
+ *  parallel under one suspense boundary. */
+export const useFavoriteShelters = () => {
+  const [{ data: favorites }, { data: markers }] = useSuspenseQueries({
+    queries: [favoriteQueries.list("SHELTER"), shelterQueries.markers()],
+  });
+  const controls = useFavoriteToggle("SHELTER");
+  const byId = new Map(markers.map((marker) => [marker.id, marker]));
+  const shelters = favorites
+    .map((favorite) => byId.get(favorite.targetRef))
+    .filter((marker): marker is ShelterMarker => marker !== undefined);
+
+  return { shelters, controls };
+};

--- a/apps/hobom-angel/src/features/favorites/ui/FavoriteAnimals.tsx
+++ b/apps/hobom-angel/src/features/favorites/ui/FavoriteAnimals.tsx
@@ -1,0 +1,45 @@
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState } from "hobom-design-system";
+import { FavoriteBorder } from "hobom-design-system/icons";
+import { AnimalCard, STATUS_LABEL, animalMeta } from "@/entities/animal";
+import { FavoriteButton } from "@/entities/favorite";
+import { animalDetailPath } from "@/shared/config";
+import { useFavoriteAnimals } from "../model/useFavoriteAnimals";
+import { styles } from "./Favorites.styles";
+
+/** 찜한 동물 grid — unfavoriting drops the card in place (§05·부록). */
+export const FavoriteAnimals = () => {
+  const { animals, controls } = useFavoriteAnimals();
+
+  if (animals.length === 0) {
+    return (
+      <EmptyState
+        icon={<FavoriteBorder style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />}
+        message="아직 찜한 동물이 없어요."
+      />
+    );
+  }
+
+  return (
+    <div {...stylex.props(styles.grid)}>
+      {animals.map((animal) => (
+        <AnimalCard
+          key={animal.id}
+          name={animal.name}
+          status={STATUS_LABEL[animal.status]}
+          meta={animalMeta(animal)}
+          imageUrl={animal.photoUrl}
+          to={animalDetailPath(animal.id)}
+          action={
+            <FavoriteButton
+              favorited={controls.isFavorited(animal.id)}
+              onToggle={() => controls.toggle(animal.id)}
+              label={animal.name}
+              overlay
+            />
+          }
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/favorites/ui/FavoriteShelters.tsx
+++ b/apps/hobom-angel/src/features/favorites/ui/FavoriteShelters.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState, Hb } from "hobom-design-system";
+import { ChevronRight, FavoriteBorder, LocationOnOutlined } from "hobom-design-system/icons";
+import { FavoriteButton } from "@/entities/favorite";
+import { shelterPath } from "@/shared/config";
+import { useFavoriteShelters } from "../model/useFavoriteShelters";
+import { styles } from "./Favorites.styles";
+
+/** 팔로우한 보호소 list — each row links to the microsite with an unfollow heart. */
+export const FavoriteShelters = () => {
+  const { shelters, controls } = useFavoriteShelters();
+
+  if (shelters.length === 0) {
+    return (
+      <EmptyState
+        icon={<FavoriteBorder style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />}
+        message="아직 팔로우한 보호소가 없어요."
+      />
+    );
+  }
+
+  return (
+    <Hb.Stack spacing={1.5}>
+      {shelters.map((shelter) => (
+        <Hb.Card.Root
+          key={shelter.id}
+          variant="outlined"
+          style={{ padding: "12px 16px", borderRadius: "var(--hb-angel-radius-card)" }}
+        >
+          <div {...stylex.props(styles.shelterRow)}>
+            <Link
+              to={shelterPath(shelter.slug)}
+              {...stylex.props(styles.shelterLink)}
+              aria-label={`${shelter.name} 보호소 프로필 보기`}
+            >
+              <span {...stylex.props(styles.shelterName)}>{shelter.name}</span>
+              <span {...stylex.props(styles.shelterRegion)}>
+                <LocationOnOutlined fontSize="small" />
+                {shelter.region}
+              </span>
+              <ChevronRight fontSize="small" {...stylex.props(styles.chevron)} />
+            </Link>
+            <FavoriteButton
+              favorited={controls.isFavorited(shelter.id)}
+              onToggle={() => controls.toggle(shelter.id)}
+              label={shelter.name}
+            />
+          </div>
+        </Hb.Card.Root>
+      ))}
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/features/favorites/ui/Favorites.styles.ts
+++ b/apps/hobom-angel/src/features/favorites/ui/Favorites.styles.ts
@@ -1,0 +1,58 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: 40,
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  header: { display: "flex", flexDirection: "column", gap: 6 },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: { margin: 0, fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
+  panel: { paddingTop: 20 },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(2, 1fr)",
+      [TABLET]: "repeat(3, 1fr)",
+      [DESKTOP]: "repeat(4, 1fr)",
+    },
+    gap: { default: 12, [DESKTOP]: 16 },
+  },
+  shelterRow: { display: "flex", alignItems: "center", gap: 12 },
+  shelterLink: {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    gap: 12,
+    color: "inherit",
+    textDecoration: "none",
+  },
+  shelterName: {
+    fontSize: "0.9375rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+  shelterRegion: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 2,
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  chevron: { marginInlineStart: "auto", color: "var(--hb-color-text-disabled)" },
+});

--- a/apps/hobom-angel/src/features/favorites/ui/Favorites.tsx
+++ b/apps/hobom-angel/src/features/favorites/ui/Favorites.tsx
@@ -1,0 +1,48 @@
+import { Suspense, useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { LoadingState } from "@/shared/ui";
+import { FavoriteAnimals } from "./FavoriteAnimals";
+import { FavoriteShelters } from "./FavoriteShelters";
+import { styles } from "./Favorites.styles";
+
+type FavoriteTab = "animals" | "shelters";
+
+const TABS = [
+  { value: "animals", label: "찜한 동물" },
+  { value: "shelters", label: "팔로우 보호소" },
+] as const;
+
+/** §05·부록 찜: the viewer's favorited animals and followed shelters, each tab
+ *  loading and suspending on its own. */
+export const Favorites = () => {
+  const [tab, setTab] = useState<FavoriteTab>("animals");
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <h1 {...stylex.props(styles.title)}>찜</h1>
+        <p {...stylex.props(styles.subtitle)}>관심 있는 동물과 보호소를 모아봤어요.</p>
+      </header>
+
+      <Hb.Tabs.Provider value={tab} onChange={(_, value) => setTab(value)}>
+        <Hb.Tabs.Root>
+          {TABS.map((item) => (
+            <Hb.Tabs.Item key={item.value} value={item.value} label={item.label} />
+          ))}
+        </Hb.Tabs.Root>
+
+        <Hb.Tabs.Panel value="animals" {...stylex.props(styles.panel)}>
+          <Suspense fallback={<LoadingState />}>
+            <FavoriteAnimals />
+          </Suspense>
+        </Hb.Tabs.Panel>
+        <Hb.Tabs.Panel value="shelters" {...stylex.props(styles.panel)}>
+          <Suspense fallback={<LoadingState />}>
+            <FavoriteShelters />
+          </Suspense>
+        </Hb.Tabs.Panel>
+      </Hb.Tabs.Provider>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/favorite.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/favorite.handlers.ts
@@ -1,0 +1,65 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+type TargetType = "ANIMAL" | "SHELTER";
+
+interface StoredFavorite {
+  targetType: TargetType;
+  targetRef: string;
+  favoritedAt: string;
+}
+
+// Seeded so the /favorites screen and card hearts have state on first load. The
+// mock is single-user, so this array stands in for the viewer's favorites.
+const FAVORITES: StoredFavorite[] = [
+  { targetType: "ANIMAL", targetRef: "animal-1", favoritedAt: "2026-07-14T00:00:00.000Z" },
+  { targetType: "ANIMAL", targetRef: "animal-3", favoritedAt: "2026-07-15T00:00:00.000Z" },
+  { targetType: "SHELTER", targetRef: "shelter-1", favoritedAt: "2026-07-15T00:00:00.000Z" },
+];
+
+const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+const noContent = () => new HttpResponse(null, { status: 204 });
+
+/** §05·부록 favorites mock handlers — viewer's list, idempotent add, remove. */
+export const favoriteHandlers = [
+  http.get(mockUrl("/favorites"), ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const targetType = new URL(request.url).searchParams.get("targetType");
+    const items = targetType
+      ? FAVORITES.filter((favorite) => favorite.targetType === targetType)
+      : FAVORITES;
+
+    return ok(items);
+  }),
+
+  http.post(mockUrl("/favorites"), async ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const body = (await request.json()) as { targetType: TargetType; targetRef: string };
+    const exists = FAVORITES.some(
+      (favorite) => favorite.targetType === body.targetType && favorite.targetRef === body.targetRef,
+    );
+
+    if (!exists) {
+      FAVORITES.unshift({ ...body, favoritedAt: "2026-07-16T00:00:00.000Z" });
+    }
+
+    return noContent();
+  }),
+
+  http.delete(mockUrl("/favorites/:targetType/:targetRef"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const index = FAVORITES.findIndex(
+      (favorite) =>
+        favorite.targetType === params.targetType && favorite.targetRef === params.targetRef,
+    );
+
+    if (index >= 0) FAVORITES.splice(index, 1);
+
+    return noContent();
+  }),
+];

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import { userHandlers } from "./user.handlers";
 import { animalHandlers } from "./animal.handlers";
 import { shelterHandlers } from "./shelter.handlers";
 import { volunteerHandlers } from "./volunteer.handlers";
+import { favoriteHandlers } from "./favorite.handlers";
 import { questionnaireHandlers } from "./questionnaire.handlers";
 import { adoptionHandlers } from "./adoption.handlers";
 
@@ -13,6 +14,7 @@ export const handlers = [
   ...animalHandlers,
   ...shelterHandlers,
   ...volunteerHandlers,
+  ...favoriteHandlers,
   ...questionnaireHandlers,
   ...adoptionHandlers,
 ];

--- a/apps/hobom-angel/src/pages/favorites/index.ts
+++ b/apps/hobom-angel/src/pages/favorites/index.ts
@@ -1,0 +1,1 @@
+export { FavoritesPage } from "./ui/FavoritesPage";

--- a/apps/hobom-angel/src/pages/favorites/ui/FavoritesPage.tsx
+++ b/apps/hobom-angel/src/pages/favorites/ui/FavoritesPage.tsx
@@ -1,0 +1,3 @@
+import { Favorites } from "@/features/favorites";
+
+export const FavoritesPage = () => <Favorites />;


### PR DESCRIPTION
Builds the 찜/팔로우 screen (§05·부록) and wires favoriting across the app.

## What's here
- **/favorites** with two tabs — 찜한 동물 and 팔로우 보호소. Favorited animals hydrate from their refs; followed shelters join against the map markers (id → name/slug/region). Each tab loads in parallel under its own suspense boundary.
- **Heart toggle** on the browse-grid animal cards and the detail panel, driven by a shared `useFavoriteToggle`. It reads the viewer's favorites and toggles them **optimistically**: `onMutate` patches the cache so the heart flips instantly, rolls back on error, and reconciles with the server on settle — no client-side mirror of server state.
- **favorite entity** — list/add/remove over `GET/POST/DELETE /favorites`, with the optimistic list patch extracted as a pure, unit-tested reducer.
- `ApplyCard` is now presentational (`favorited`/`onToggleFavorite` props) with the toggle owned by its container, matching the grid.

## Backend contract
`GET /favorites?targetType=` returns only refs (`{targetType, targetRef, favoritedAt}`), so the screen hydrates animals via their detail query and shelters via the map markers. Add is idempotent; both add and remove return 204.

## Tests
- Unit: pure optimistic reducer (`applyFavoriteToggle` / `isFavorited`).
- e2e: lists seeded favorites and unfavorites optimistically (card drops in place), follows-tab, and favoriting from the browse grid then finding it under 찜. Full suite green (28).