### PR TITLE
Wire up the shelter follow button and global search

### DIFF
--- a/apps/hobom-angel/e2e/nav-search.spec.ts
+++ b/apps/hobom-angel/e2e/nav-search.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("global nav search", () => {
+  test("routes to the filtered animal list", async ({ page }) => {
+    await login(page);
+
+    const search = page.getByLabel("검색");
+    await search.fill("초코");
+    await search.press("Enter");
+
+    await expect(page).toHaveURL(/\/animals\?.*q=/);
+    // The keyword filter chip and the matching animal are shown.
+    await expect(page.getByText('"초코"')).toBeVisible();
+    await expect(page.getByText("초코", { exact: true }).first()).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/e2e/shelter-microsite.spec.ts
+++ b/apps/hobom-angel/e2e/shelter-microsite.spec.ts
@@ -27,6 +27,16 @@ test.describe("§04 shelter microsite", () => {
     await page.screenshot({ path: "e2e-artifacts/shelter.png", fullPage: true });
   });
 
+  test("follows and unfollows the shelter", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter");
+
+    // shelter-1 is seeded as followed; unfollowing flips it optimistically.
+    await expect(page.getByRole("button", { name: "행복보호소 팔로잉" })).toBeVisible();
+    await page.getByRole("button", { name: "행복보호소 팔로잉" }).click();
+    await expect(page.getByRole("button", { name: "행복보호소 팔로우" })).toBeVisible();
+  });
+
   test("switches tabs and syncs the active tab to the URL", async ({ page }) => {
     await login(page);
     await page.goto("shelters/haengbok-shelter");

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/FollowButton.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/FollowButton.tsx
@@ -1,0 +1,27 @@
+import { Hb } from "hobom-design-system";
+import { Favorite, FavoriteBorder } from "hobom-design-system/icons";
+import { useFavoriteToggle } from "@/entities/favorite";
+
+interface FollowButtonProps {
+  shelterId: string;
+  shelterName: string;
+}
+
+/** Follow / unfollow a shelter (팔로우), toggled optimistically. Populates the
+ *  팔로우 보호소 tab on /favorites. */
+export const FollowButton = ({ shelterId, shelterName }: FollowButtonProps) => {
+  const favorites = useFavoriteToggle("SHELTER");
+  const following = favorites.isFavorited(shelterId);
+
+  return (
+    <Hb.Button
+      variant={following ? "secondary" : "primary"}
+      size="small"
+      startIcon={following ? <Favorite fontSize="small" /> : <FavoriteBorder fontSize="small" />}
+      aria-label={`${shelterName} ${following ? "팔로잉" : "팔로우"}`}
+      onClick={() => favorites.toggle(shelterId)}
+    >
+      {following ? "팔로잉" : "팔로우"}
+    </Hb.Button>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.styles.ts
@@ -6,6 +6,7 @@ export const styles = stylex.create({
     alignItems: "center",
     gap: 16,
   },
+  follow: { marginInlineStart: "auto", flexShrink: 0 },
   avatar: {
     width: 60,
     height: 60,

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterHeader.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { formatShelterAddress, isShelterVerified, TRUST_TIER_LABEL } from "@/entities/shelter";
 import type { AddressVisibility, Shelter } from "@/entities/shelter";
+import { FollowButton } from "./FollowButton";
 import { styles } from "./ShelterHeader.styles";
 
 const VISIBILITY_NOTE: Record<AddressVisibility, string> = {
@@ -48,6 +49,10 @@ export const ShelterHeader = ({ shelter }: { shelter: Shelter }) => {
             {addressLine}
           </Hb.Text>
         </Hb.Stack>
+
+        <span {...stylex.props(styles.follow)}>
+          <FollowButton shelterId={shelter.id} shelterName={shelter.name} />
+        </span>
       </div>
     </Hb.Stack>
   );

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalNav.styles.ts
@@ -62,6 +62,7 @@ export const styles = stylex.create({
     backgroundColor: "var(--hb-angel-green-tint)",
   },
   spacer: { flex: 1 },
+  searchForm: { display: "contents" },
   search: {
     display: { default: "none", [DESKTOP]: "block" },
     width: 200,

--- a/apps/hobom-angel/src/widgets/global-nav/ui/NavSearch.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/NavSearch.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { ROUTES } from "@/shared/config";
+import { styles } from "./GlobalNav.styles";
+
+/** Global search: submitting routes to the animal list filtered by keyword. */
+export const NavSearch = () => {
+  const navigate = useNavigate();
+  const [value, setValue] = useState("");
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+
+    const query = value.trim();
+
+    void navigate(query ? `${ROUTES.ANIMALS}?q=${encodeURIComponent(query)}` : ROUTES.ANIMALS);
+  };
+
+  return (
+    <form {...stylex.props(styles.searchForm)} role="search" onSubmit={submit}>
+      <input
+        {...stylex.props(styles.search)}
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="이름·품종·지역 검색"
+        aria-label="검색"
+      />
+    </form>
+  );
+};

--- a/apps/hobom-angel/src/widgets/global-nav/ui/TopNav.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/TopNav.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from "@/shared/config";
 import type { CurrentUser } from "@/entities/user";
 import { PRIMARY_NAV } from "../model/nav-items";
 import { activeLinkProps } from "./nav-link-props";
+import { NavSearch } from "./NavSearch";
 import { ProfileMenu } from "./ProfileMenu";
 import { styles } from "./GlobalNav.styles";
 
@@ -42,7 +43,7 @@ export const TopNav = ({ user, isAuthenticated }: TopNavProps) => {
 
             <span {...stylex.props(styles.spacer)} />
 
-            <input {...stylex.props(styles.search)} placeholder="이름·품종·지역 검색" aria-label="검색" />
+            <NavSearch />
             <button type="button" {...stylex.props(styles.iconBtn)} aria-label="알림">
               <NotificationsNoneOutlined fontSize="small" />
             </button>


### PR DESCRIPTION
Activates two nav affordances that were previously inert.

## Shelter follow
The favorites feature shipped a 팔로우 보호소 tab on /favorites, but there was no way to actually follow a shelter. Adds a 팔로우/팔로잉 toggle to the microsite header, driven by the same optimistic `useFavoriteToggle("SHELTER")` — following a shelter now populates that tab.

## Global search
The top-nav search box was a placeholder `<input>` with no handler. It now submits to the animal list filtered by keyword (`/animals?q=…`), where the existing URL-backed filter picks it up and shows the active-filter chip.

## Tests
- e2e: follow/unfollow on the microsite (seeded shelter flips optimistically); global search routes to the filtered list. Full suite green (32).