### PR TITLE
Add the shelter console — volunteer schedule management (§07)

### DIFF
--- a/apps/hobom-angel/e2e/console-volunteer.spec.ts
+++ b/apps/hobom-angel/e2e/console-volunteer.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§07 shelter console — volunteer", () => {
+  test("enters from the profile menu, creates an event, and decides an applicant", async ({
+    page,
+  }) => {
+    await login(page);
+
+    // Staff reach the console from the profile menu.
+    await page.getByRole("button", { name: /봄이네님/ }).click();
+    await page.getByRole("link", { name: "보호소 콘솔" }).click();
+    await expect(page).toHaveURL(/\/console\/volunteer$/);
+
+    await expect(page.getByRole("heading", { name: "봉사 일정 관리" })).toBeVisible();
+    await expect(page.getByText("주말 산책 봉사")).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/console.png", fullPage: true });
+
+    // Create a new event.
+    await page.getByPlaceholder("유기견 산책 봉사").fill("야간 순찰 봉사");
+    await page.getByLabel("날짜").fill("2026-08-15");
+    await page.getByRole("button", { name: "일정 게시" }).click();
+    await expect(page.getByText("봉사 일정을 게시했어요.")).toBeVisible();
+    await expect(page.getByText("야간 순찰 봉사")).toBeVisible();
+
+    // Open a seeded event's applicants and approve a pending one.
+    await page
+      .getByRole("article")
+      .filter({ hasText: "주말 산책 봉사" })
+      .getByRole("button", { name: /지원자/ })
+      .click();
+    await page.getByRole("button", { name: "승인" }).first().click();
+    await expect(page.getByText("승인됨")).toHaveCount(2);
+
+    // A clear way back to the consumer service.
+    await page.getByRole("link", { name: "서비스로 나가기" }).click();
+    await expect(page).toHaveURL(/\/hobom-angel\/$/);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -1,10 +1,12 @@
 import { lazy, Suspense, useEffect } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { ROUTES } from "@/shared/config";
 import { onIdle } from "@/shared/lib";
 import { useRouteMeta } from "@/shared/model";
 import { ErrorBoundary, LoadingState, NotFoundState } from "@/shared/ui";
 import { ComingSoonPage } from "@/pages/coming-soon";
+import { ConsoleRoute } from "./ConsoleRoute";
+import { ConsoleShellLayout } from "./ConsoleShellLayout";
 import { ConsumerShellLayout } from "./ConsumerShellLayout";
 import { GuestOnlyRoute } from "./GuestOnlyRoute";
 import { ProtectedRoute } from "./ProtectedRoute";
@@ -47,6 +49,9 @@ const WriteReviewPage = lazy(() =>
   import("@/pages/volunteer-write").then((module) => ({ default: module.WriteReviewPage })),
 );
 const MyPage = lazy(() => import("@/pages/my").then((module) => ({ default: module.MyPage })));
+const ConsoleVolunteerPage = lazy(() =>
+  import("@/pages/console-volunteer").then((module) => ({ default: module.ConsoleVolunteerPage })),
+);
 
 // Warm the common route chunks during idle time so navigating to them shows the
 // screen's own skeleton (data Suspense) rather than the chunk-load spinner.
@@ -91,6 +96,14 @@ export const AppRouter = () => {
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />
               ))}
+            </Route>
+          </Route>
+
+          {/* Shelter staff console — its own chrome, gated on a shelter role. */}
+          <Route element={<ConsoleRoute />}>
+            <Route element={<ConsoleShellLayout />}>
+              <Route path={ROUTES.CONSOLE} element={<Navigate to={ROUTES.CONSOLE_VOLUNTEER} replace />} />
+              <Route path={ROUTES.CONSOLE_VOLUNTEER} element={<ConsoleVolunteerPage />} />
             </Route>
           </Route>
 

--- a/apps/hobom-angel/src/apps/ui/ConsoleRoute.tsx
+++ b/apps/hobom-angel/src/apps/ui/ConsoleRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { ROUTES } from "@/shared/config";
+import { managedShelter, useCurrentUser } from "@/entities/user";
+import { RouteFallback } from "./RouteFallback";
+
+/** Gates the shelter console: a guest goes to login, a member without any
+ *  shelter role goes home; only shelter staff reach the console. */
+export const ConsoleRoute = () => {
+  const { user, isAuthenticated, isLoading } = useCurrentUser();
+
+  if (isLoading) return <RouteFallback />;
+
+  if (!isAuthenticated) return <Navigate to={ROUTES.LOGIN} replace />;
+
+  return managedShelter(user) ? <Outlet /> : <Navigate to={ROUTES.HOME} replace />;
+};

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
@@ -1,0 +1,125 @@
+import * as stylex from "@stylexjs/stylex";
+
+const DESKTOP = "@media (min-width: 900px)";
+
+export const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: { default: "column", [DESKTOP]: "row" },
+    minHeight: "100dvh",
+    backgroundColor: "var(--hb-color-canvas)",
+  },
+  sidebar: {
+    display: "flex",
+    flexDirection: "column",
+    flexShrink: 0,
+    width: { default: "100%", [DESKTOP]: 240 },
+    boxSizing: "border-box",
+    padding: 14,
+    gap: 10,
+    borderInlineEndWidth: { default: 0, [DESKTOP]: 1 },
+    borderInlineEndStyle: "solid",
+    borderInlineEndColor: "var(--hb-color-border)",
+    borderBlockEndWidth: { default: 1, [DESKTOP]: 0 },
+    borderBlockEndStyle: "solid",
+    borderBlockEndColor: "var(--hb-color-border)",
+    // Light-gray console rail so the active (white) item reads as raised.
+    backgroundColor: "var(--hb-color-surface-subtle)",
+  },
+  brand: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    padding: "6px 8px 10px",
+  },
+  logo: {
+    width: 28,
+    height: 28,
+    flexShrink: 0,
+    borderRadius: 8,
+    backgroundColor: "var(--hb-color-accent)",
+  },
+  brandText: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+    minWidth: 0,
+  },
+  brandTitle: {
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  brandRole: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  nav: {
+    display: "flex",
+    flexDirection: { default: "row", [DESKTOP]: "column" },
+    flexWrap: { default: "wrap", [DESKTOP]: "nowrap" },
+    gap: 3,
+    flex: 1,
+  },
+  item: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 1,
+    padding: "9px 12px",
+    borderRadius: 10,
+    textDecoration: "none",
+    color: "var(--hb-color-text-primary)",
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-color-surface)" },
+  },
+  itemDisabled: {
+    cursor: "default",
+    backgroundColor: { default: "transparent", ":hover": "transparent" },
+    opacity: 0.55,
+  },
+  itemLabel: {
+    fontSize: "0.9375rem",
+    fontWeight: 600,
+  },
+  itemHint: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  itemSoon: {
+    fontSize: "0.6875rem",
+    color: "var(--hb-color-text-disabled)",
+  },
+  foot: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    paddingTop: 10,
+    borderTopWidth: { default: 0, [DESKTOP]: 1 },
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-color-border)",
+  },
+  scope: {
+    paddingInline: 4,
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-disabled)",
+  },
+  // A clear, bordered way back to the consumer app.
+  exit: {
+    display: "block",
+    padding: "9px 12px",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    textAlign: "center",
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    textDecoration: "none",
+    color: "var(--hb-color-text-primary)",
+    backgroundColor: { default: "var(--hb-color-surface)", ":hover": "var(--hb-color-canvas)" },
+  },
+  main: {
+    flex: 1,
+    minWidth: 0,
+    padding: "clamp(16px, 4vw, 32px)",
+  },
+});

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
@@ -1,0 +1,75 @@
+import { Link, NavLink, Outlet } from "react-router-dom";
+import * as stylex from "@stylexjs/stylex";
+import { ROUTES } from "@/shared/config";
+import { RouteBoundary } from "@/shared/ui";
+import { RouteFallback } from "./RouteFallback";
+import { styles } from "./ConsoleShellLayout.styles";
+
+/** The §07 console menu. Only 봉사 일정 is wired today; the rest are shown (per
+ *  the design's 7-menu map) but disabled until their screens land. */
+const MENU: { label: string; hint: string; to: string | null }[] = [
+  { label: "동물 관리", hint: "등록·상태", to: null },
+  { label: "신청 처리", hint: "심사·문의", to: null },
+  { label: "봉사 일정", hint: "모집·승인", to: ROUTES.CONSOLE_VOLUNTEER },
+  { label: "콘텐츠", hint: "공지·FAQ", to: null },
+  { label: "설문 빌더", hint: "폼 정의", to: null },
+  { label: "스태프 관리", hint: "승격·역할", to: null },
+  { label: "통계", hint: "KPI", to: null },
+];
+
+/** Shelter console chrome (§07): a shelter-branded sidebar (the menu map) beside
+ *  the active screen, with a clear way back to the consumer service. Separate
+ *  from the consumer nav — this is the staff self-service surface. */
+export const ConsoleShellLayout = () => (
+  <div {...stylex.props(styles.root)}>
+    <aside {...stylex.props(styles.sidebar)}>
+      <div {...stylex.props(styles.brand)}>
+        <span {...stylex.props(styles.logo)} aria-hidden />
+        <span {...stylex.props(styles.brandText)}>
+          <span {...stylex.props(styles.brandTitle)}>보호소 콘솔</span>
+          <span {...stylex.props(styles.brandRole)}>관리자</span>
+        </span>
+      </div>
+
+      <nav {...stylex.props(styles.nav)}>
+        {MENU.map((item) =>
+          item.to ? (
+            <NavLink
+              key={item.label}
+              to={item.to}
+              {...stylex.props(styles.item)}
+              style={({ isActive }) => (isActive ? activeStyle : undefined)}
+            >
+              <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
+              <span {...stylex.props(styles.itemHint)}>{item.hint}</span>
+            </NavLink>
+          ) : (
+            <span key={item.label} {...stylex.props(styles.item, styles.itemDisabled)}>
+              <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
+              <span {...stylex.props(styles.itemSoon)}>준비 중</span>
+            </span>
+          ),
+        )}
+      </nav>
+
+      <div {...stylex.props(styles.foot)}>
+        <span {...stylex.props(styles.scope)}>소속 보호소 스코프</span>
+        <Link to={ROUTES.HOME} {...stylex.props(styles.exit)}>
+          ← 서비스로 나가기
+        </Link>
+      </div>
+    </aside>
+
+    <main {...stylex.props(styles.main)}>
+      <RouteBoundary fallback={<RouteFallback />}>
+        <Outlet />
+      </RouteBoundary>
+    </main>
+  </div>
+);
+
+const activeStyle = {
+  backgroundColor: "var(--hb-color-surface)",
+  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
+  color: "var(--hb-color-accent-dark, var(--hb-color-accent))",
+} as const;

--- a/apps/hobom-angel/src/entities/user/api/user.type.ts
+++ b/apps/hobom-angel/src/entities/user/api/user.type.ts
@@ -11,12 +11,22 @@ export interface RawMyProfile {
   status: string;
 }
 
+/** A shelter the user belongs to, with their role there. */
+export interface ShelterRole {
+  shelterId: string;
+  role: string;
+}
+
 /** The signed-in account the app renders. */
 export interface CurrentUser {
   id: string;
   nickname: string;
   email: string;
   verifiedChannel: VerifiedChannel;
+  /** Platform roles (USER, SHELTER_STAFF, SHELTER_ADMIN, SYSTEM_ADMIN). */
+  roles: string[];
+  /** Per-shelter memberships — non-empty for shelter staff (drives the console). */
+  shelterRoles: ShelterRole[];
 }
 
 /** `GET /users/:userId` — another member's public profile. */

--- a/apps/hobom-angel/src/entities/user/index.ts
+++ b/apps/hobom-angel/src/entities/user/index.ts
@@ -2,6 +2,7 @@ export { userQueries } from "./api/user.queries";
 export { changeNickname, withdrawAccount } from "./api/user.api";
 export { useCurrentUser } from "./model/useCurrentUser";
 export { validateNickname } from "./lib/nickname.lib";
+export { managedShelter } from "./lib/managed-shelter.lib";
 export { VERIFIED_CHANNEL_LABEL } from "./model/user.model";
-export type { CurrentUser, PublicProfile } from "./api/user.type";
+export type { CurrentUser, PublicProfile, ShelterRole } from "./api/user.type";
 export type { VerifiedChannel } from "./model/user.model";

--- a/apps/hobom-angel/src/entities/user/lib/managed-shelter.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/user/lib/managed-shelter.lib.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { managedShelter } from "./managed-shelter.lib";
+import type { CurrentUser } from "../api/user.type";
+
+const user = (shelterRoles: CurrentUser["shelterRoles"]): CurrentUser => ({
+  id: "user-1",
+  nickname: "봄이네",
+  email: "hobom@example.com",
+  verifiedChannel: "EMAIL",
+  roles: [],
+  shelterRoles,
+});
+
+describe("managedShelter", () => {
+  it("returns the first shelter membership", () => {
+    expect(managedShelter(user([{ shelterId: "s1", role: "SHELTER_ADMIN" }]))).toEqual({
+      shelterId: "s1",
+      role: "SHELTER_ADMIN",
+    });
+  });
+
+  it("returns null for a member with no shelter role", () => {
+    expect(managedShelter(user([]))).toBeNull();
+  });
+
+  it("returns null when there is no signed-in user", () => {
+    expect(managedShelter(undefined)).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/entities/user/lib/managed-shelter.lib.ts
+++ b/apps/hobom-angel/src/entities/user/lib/managed-shelter.lib.ts
@@ -1,0 +1,6 @@
+import type { CurrentUser, ShelterRole } from "../api/user.type";
+
+/** The shelter this user manages in the console — their first membership, or
+ *  null for a plain member (which gates access to the console entirely). */
+export const managedShelter = (user: CurrentUser | undefined): ShelterRole | null =>
+  user?.shelterRoles[0] ?? null;

--- a/apps/hobom-angel/src/entities/user/lib/to-current-user.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/user/lib/to-current-user.lib.spec.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { toCurrentUser } from "./to-current-user.lib";
 
 describe("toCurrentUser", () => {
-  it("keeps id/nickname/email/verifiedChannel and drops roles and status", () => {
+  it("keeps id/nickname/email/verifiedChannel and the console roles, dropping status", () => {
     const user = toCurrentUser({
       id: "user-1",
       nickname: "봄이네",
       email: "hobom@example.com",
       verifiedChannel: "EMAIL",
-      roles: ["MEMBER"],
-      shelterRoles: [{ shelterId: "s1", role: "STAFF" }],
+      roles: ["SHELTER_ADMIN"],
+      shelterRoles: [{ shelterId: "s1", role: "SHELTER_ADMIN" }],
       status: "ACTIVE",
     });
 
@@ -18,6 +18,8 @@ describe("toCurrentUser", () => {
       nickname: "봄이네",
       email: "hobom@example.com",
       verifiedChannel: "EMAIL",
+      roles: ["SHELTER_ADMIN"],
+      shelterRoles: [{ shelterId: "s1", role: "SHELTER_ADMIN" }],
     });
   });
 });

--- a/apps/hobom-angel/src/entities/user/lib/to-current-user.lib.ts
+++ b/apps/hobom-angel/src/entities/user/lib/to-current-user.lib.ts
@@ -1,10 +1,13 @@
 import type { CurrentUser, RawMyProfile } from "../api/user.type";
 import type { VerifiedChannel } from "../model/user.model";
 
-/** Anti-corruption: expose only what the UI renders (drop roles/status). */
+/** Anti-corruption: expose what the UI renders, including the roles that gate
+ *  the shelter console (status is dropped). */
 export const toCurrentUser = (raw: RawMyProfile): CurrentUser => ({
   id: raw.id,
   nickname: raw.nickname,
   email: raw.email,
   verifiedChannel: raw.verifiedChannel as VerifiedChannel,
+  roles: raw.roles,
+  shelterRoles: raw.shelterRoles,
 });

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
@@ -1,12 +1,15 @@
 import { httpClient, parseResponse } from "@/shared/api";
 import { toVolunteerEvent } from "../lib/to-volunteer-event.lib";
 import {
+  createVolunteerEventSchema,
+  volunteerApplicantsSchema,
   volunteerEventPageSchema,
   volunteerEventSchema,
   volunteerEventsSchema,
   volunteerSignupSchema,
 } from "./volunteer-event.schema";
-import type { VolunteerEvent } from "../model/volunteer-event.model";
+import type { VolunteerApplicant, VolunteerEvent } from "../model/volunteer-event.model";
+import type { CreateVolunteerEventInput } from "./volunteer-event.type";
 
 const parseVolunteerEvents = parseResponse(
   volunteerEventsSchema,
@@ -57,3 +60,34 @@ export const signUpForVolunteerEvent = (id: string): Promise<{ signupId: string 
 /** Withdraw a signup (by its id, from the signup response). */
 export const withdrawVolunteerSignup = (signupId: string): Promise<void> =>
   httpClient.post(`/volunteer-signups/${signupId}/withdrawal`, {}).then(() => undefined);
+
+/** Create a volunteer event for a shelter (§07 console, staff). */
+export const createVolunteerEvent = (
+  shelterId: string,
+  input: CreateVolunteerEventInput,
+): Promise<{ eventId: string }> =>
+  httpClient
+    .post(`/shelters/${shelterId}/volunteer-events`, input)
+    .then(parseResponse(createVolunteerEventSchema, "POST /shelters/:id/volunteer-events"));
+
+/** Cancel a volunteer event (staff, no body). */
+export const cancelVolunteerEvent = (eventId: string): Promise<void> =>
+  httpClient.post(`/volunteer-events/${eventId}/cancellation`, {}).then(() => undefined);
+
+/** List an event's applicants (§07 console, staff). */
+export const getVolunteerApplicants = (
+  eventId: string,
+  signal?: AbortSignal,
+): Promise<VolunteerApplicant[]> =>
+  httpClient
+    .get(`/volunteer-events/${eventId}/signups`, { signal })
+    .then(parseResponse(volunteerApplicantsSchema, "GET /volunteer-events/:id/signups"));
+
+/** Approve or reject an applicant's signup (staff). */
+export const decideVolunteerSignup = (
+  signupId: string,
+  decision: "APPROVE" | "REJECT",
+): Promise<void> =>
+  httpClient
+    .post(`/volunteer-signups/${signupId}/decision`, { decision })
+    .then(() => undefined);

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.mutations.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.mutations.ts
@@ -1,9 +1,31 @@
 import { mutationOptions } from "hobom-data";
-import { signUpForVolunteerEvent } from "./volunteer-event.api";
+import {
+  cancelVolunteerEvent,
+  createVolunteerEvent,
+  decideVolunteerSignup,
+  signUpForVolunteerEvent,
+} from "./volunteer-event.api";
+import type { CreateVolunteerEventInput } from "./volunteer-event.type";
 
 export const volunteerEventMutations = {
   signup: (eventId: string) =>
     mutationOptions({
       mutationFn: () => signUpForVolunteerEvent(eventId),
+    }),
+
+  create: (shelterId: string) =>
+    mutationOptions({
+      mutationFn: (input: CreateVolunteerEventInput) => createVolunteerEvent(shelterId, input),
+    }),
+
+  cancel: () =>
+    mutationOptions({
+      mutationFn: (eventId: string) => cancelVolunteerEvent(eventId),
+    }),
+
+  decideSignup: () =>
+    mutationOptions({
+      mutationFn: (vars: { signupId: string; decision: "APPROVE" | "REJECT" }) =>
+        decideVolunteerSignup(vars.signupId, vars.decision),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.queries.ts
@@ -3,6 +3,7 @@ import {
   getMyVolunteerSignups,
   getShelterVolunteerEvents,
   getUpcomingVolunteerEvents,
+  getVolunteerApplicants,
   getVolunteerEvent,
 } from "./volunteer-event.api";
 
@@ -31,5 +32,11 @@ export const volunteerEventQueries = {
     queryOptions({
       queryKey: [...volunteerEventQueries.all(), "detail", id] as const,
       queryFn: ({ signal }) => getVolunteerEvent(id, signal),
+    }),
+
+  applicants: (eventId: string) =>
+    queryOptions({
+      queryKey: [...volunteerEventQueries.all(), "applicants", eventId] as const,
+      queryFn: ({ signal }) => getVolunteerApplicants(eventId, signal),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.schema.ts
@@ -1,6 +1,11 @@
 import { HoBomSchema } from "hobom-schema";
 import type { Schema } from "hobom-schema";
-import type { RawVolunteerEvent, RawVolunteerSignup } from "./volunteer-event.type";
+import type {
+  RawCreateVolunteerEventResult,
+  RawVolunteerApplicant,
+  RawVolunteerEvent,
+  RawVolunteerSignup,
+} from "./volunteer-event.type";
 
 /** A single volunteer event on the wire — reused for the shelter list, global
  *  list, and single-event reads (all viewer-aware). */
@@ -42,4 +47,18 @@ export const volunteerEventPageSchema = HoBomSchema.object({
 /** `POST /volunteer-events/:eventId/signups` — the created signup's id. */
 export const volunteerSignupSchema: Schema<RawVolunteerSignup> = HoBomSchema.object({
   signupId: HoBomSchema.string(),
+});
+
+/** `GET /volunteer-events/:eventId/signups` — the event's applicants (staff). */
+export const volunteerApplicantsSchema: Schema<RawVolunteerApplicant[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    signupId: HoBomSchema.string(),
+    volunteerId: HoBomSchema.string(),
+    status: HoBomSchema.enum(["PENDING", "APPROVED", "REJECTED", "WITHDRAWN"]),
+  }),
+);
+
+/** `POST /shelters/:shelterId/volunteer-events` — the created event's id. */
+export const createVolunteerEventSchema: Schema<RawCreateVolunteerEventResult> = HoBomSchema.object({
+  eventId: HoBomSchema.string(),
 });

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.type.ts
@@ -1,4 +1,5 @@
 import type {
+  VolunteerApplicantStatus,
   VolunteerEventStatus,
   VolunteerSignupStatus,
   VolunteerType,
@@ -36,4 +37,27 @@ export interface RawVolunteerEvent {
 /** `POST /volunteer-events/:eventId/signups` response. */
 export interface RawVolunteerSignup {
   signupId: string;
+}
+
+/** `GET /volunteer-events/:eventId/signups` item (console applicant list). */
+export interface RawVolunteerApplicant {
+  signupId: string;
+  volunteerId: string;
+  status: VolunteerApplicantStatus;
+}
+
+/** `POST /shelters/:shelterId/volunteer-events` request (staff). Transport is
+ *  only sent for OVERSEAS events (not built yet — GENERAL only for now). */
+export interface CreateVolunteerEventInput {
+  title: string;
+  description?: string;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+  type?: VolunteerType;
+}
+
+/** `POST /shelters/:shelterId/volunteer-events` response. */
+export interface RawCreateVolunteerEventResult {
+  eventId: string;
 }

--- a/apps/hobom-angel/src/entities/volunteer-event/index.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/index.ts
@@ -5,6 +5,7 @@ export {
   VOLUNTEER_STATUS_LABEL,
   VOLUNTEER_TYPE_LABEL,
   VOLUNTEER_SIGNUP_STATUS_LABEL,
+  VOLUNTEER_APPLICANT_STATUS_LABEL,
   spotsLeft,
   isSignUpOpen,
 } from "./model/volunteer-event.model";
@@ -14,4 +15,7 @@ export type {
   VolunteerType,
   VolunteerTransport,
   VolunteerSignupStatus,
+  VolunteerApplicant,
+  VolunteerApplicantStatus,
 } from "./model/volunteer-event.model";
+export type { CreateVolunteerEventInput } from "./api/volunteer-event.type";

--- a/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/model/volunteer-event.model.ts
@@ -6,6 +6,17 @@ export type VolunteerType = "GENERAL" | "OVERSEAS";
  *  (a rejected/withdrawn signup reads back as null). */
 export type VolunteerSignupStatus = "PENDING" | "APPROVED";
 
+/** An applicant's status as the console shows it — includes the terminal states
+ *  a staff member decides or the volunteer withdraws. */
+export type VolunteerApplicantStatus = "PENDING" | "APPROVED" | "REJECTED" | "WITHDRAWN";
+
+/** One person who signed up for an event (console 지원자 목록). */
+export interface VolunteerApplicant {
+  signupId: string;
+  volunteerId: string;
+  status: VolunteerApplicantStatus;
+}
+
 /** Flight/transport details, present only for OVERSEAS 이동봉사 events. */
 export interface VolunteerTransport {
   departure: string;
@@ -52,6 +63,13 @@ export const VOLUNTEER_TYPE_LABEL: Record<VolunteerType, string> = {
 export const VOLUNTEER_SIGNUP_STATUS_LABEL: Record<VolunteerSignupStatus, string> = {
   PENDING: "승인 대기",
   APPROVED: "참여 확정",
+};
+
+export const VOLUNTEER_APPLICANT_STATUS_LABEL: Record<VolunteerApplicantStatus, string> = {
+  PENDING: "승인 대기",
+  APPROVED: "승인됨",
+  REJECTED: "거절됨",
+  WITHDRAWN: "철회됨",
 };
 
 /** Remaining open spots, floored at 0. */

--- a/apps/hobom-angel/src/features/console-volunteer/index.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleVolunteer } from "./ui/ConsoleVolunteer";

--- a/apps/hobom-angel/src/features/console-volunteer/lib/event-format.lib.spec.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/lib/event-format.lib.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { formatEventWhen, recruitLabel, recruitPercent, toEventRange } from "./event-format.lib";
+
+const event = (capacity: number, signedUpCount: number): VolunteerEvent => ({
+  id: "e1",
+  shelterId: "s1",
+  title: "산책 봉사",
+  description: "",
+  startAt: "2026-07-04T10:00:00",
+  endAt: "2026-07-04T13:00:00",
+  capacity,
+  signedUpCount,
+  status: "OPEN",
+  type: "GENERAL",
+  transport: null,
+  mySignupId: null,
+  mySignupStatus: null,
+});
+
+describe("toEventRange", () => {
+  it("stitches a date and start/end times into ISO wall-clock", () => {
+    expect(toEventRange("2026-07-04", "10:00", "13:00")).toEqual({
+      startAt: "2026-07-04T10:00:00",
+      endAt: "2026-07-04T13:00:00",
+    });
+  });
+});
+
+describe("formatEventWhen", () => {
+  it("formats a dotted date with the time range", () => {
+    expect(formatEventWhen("2026-07-04T10:00:00", "2026-07-04T13:00:00")).toBe(
+      "2026.07.04 · 10:00–13:00",
+    );
+  });
+});
+
+describe("recruitPercent", () => {
+  it("is the filled percentage of capacity, capped at 100", () => {
+    expect(recruitPercent(event(12, 8))).toBe(67);
+    expect(recruitPercent(event(12, 20))).toBe(100);
+    expect(recruitPercent(event(0, 0))).toBe(0);
+  });
+});
+
+describe("recruitLabel", () => {
+  it("summarizes filled / capacity with remaining spots", () => {
+    expect(recruitLabel(event(12, 8))).toBe("모집 8 / 12명 · 4자리 남음");
+  });
+});

--- a/apps/hobom-angel/src/features/console-volunteer/lib/event-format.lib.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/lib/event-format.lib.ts
@@ -1,0 +1,27 @@
+import { spotsLeft } from "@/entities/volunteer-event";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+
+/** Build the ISO start/end range for a create request from a date + times.
+ *  The wall-clock values are kept as-is (no timezone shift). */
+export const toEventRange = (date: string, startTime: string, endTime: string) => ({
+  startAt: `${date}T${startTime}:00`,
+  endAt: `${date}T${endTime}:00`,
+});
+
+/** "2026.07.04 · 10:00–13:00" from an event's ISO start/end (wall-clock). */
+export const formatEventWhen = (startAt: string, endAt: string): string => {
+  const date = startAt.slice(0, 10).replaceAll("-", ".");
+
+  return `${date} · ${startAt.slice(11, 16)}–${endAt.slice(11, 16)}`;
+};
+
+/** Recruitment progress as a 0–100 percentage of capacity (capped). */
+export const recruitPercent = (event: VolunteerEvent): number => {
+  if (event.capacity <= 0) return 0;
+
+  return Math.min(100, Math.round((event.signedUpCount / event.capacity) * 100));
+};
+
+/** "모집 8 / 12명" summary. */
+export const recruitLabel = (event: VolunteerEvent): string =>
+  `모집 ${event.signedUpCount} / ${event.capacity}명 · ${spotsLeft(event)}자리 남음`;

--- a/apps/hobom-angel/src/features/console-volunteer/model/useConsoleVolunteer.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/model/useConsoleVolunteer.ts
@@ -1,0 +1,41 @@
+import { useDataLot, useMutation, useSuspenseQuery } from "hobom-data";
+import { volunteerEventMutations, volunteerEventQueries } from "@/entities/volunteer-event";
+import { useToast } from "@/shared/model";
+import type { CreateVolunteerEventInput } from "@/entities/volunteer-event";
+
+/** The console's volunteer schedule for a shelter: the event list plus create /
+ *  cancel, invalidating the list so counts and status stay fresh. */
+export const useConsoleVolunteer = (shelterId: string) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+  const listOptions = volunteerEventQueries.byShelter(shelterId);
+
+  const { data: events } = useSuspenseQuery(listOptions);
+
+  const refresh = () => void dataLot.invalidateQueries(listOptions);
+
+  const create = useMutation({
+    ...volunteerEventMutations.create(shelterId),
+    onSuccess: () => {
+      openSuccessToast({ message: "봉사 일정을 게시했어요." });
+      refresh();
+    },
+    onError: (error: Error) => openErrorToast({ message: error.message || "게시에 실패했어요." }),
+  });
+
+  const cancel = useMutation({
+    ...volunteerEventMutations.cancel(),
+    onSuccess: () => {
+      openSuccessToast({ message: "봉사 일정을 취소했어요." });
+      refresh();
+    },
+    onError: (error: Error) => openErrorToast({ message: error.message || "취소에 실패했어요." }),
+  });
+
+  return {
+    events,
+    createEvent: (input: CreateVolunteerEventInput) => create.mutate(input),
+    creating: create.isPending,
+    cancelEvent: (eventId: string) => cancel.mutate(eventId),
+  };
+};

--- a/apps/hobom-angel/src/features/console-volunteer/model/useEventApplicants.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/model/useEventApplicants.ts
@@ -1,0 +1,26 @@
+import { useDataLot, useMutation, useQuery } from "hobom-data";
+import { volunteerEventMutations, volunteerEventQueries } from "@/entities/volunteer-event";
+import { useToast } from "@/shared/model";
+
+/** An event's applicants plus approve / reject. A decision invalidates the whole
+ *  volunteer-event cache so the applicant list and the event's counts refresh. */
+export const useEventApplicants = (eventId: string) => {
+  const dataLot = useDataLot();
+  const { openErrorToast } = useToast();
+
+  const { data: applicants, status } = useQuery(volunteerEventQueries.applicants(eventId));
+
+  const decide = useMutation({
+    ...volunteerEventMutations.decideSignup(),
+    onSuccess: () => void dataLot.invalidateQueries({ queryKey: volunteerEventQueries.all() }),
+    onError: (error: Error) => openErrorToast({ message: error.message || "처리에 실패했어요." }),
+  });
+
+  return {
+    applicants: applicants ?? [],
+    loading: status === "pending",
+    approve: (signupId: string) => decide.mutate({ signupId, decision: "APPROVE" }),
+    reject: (signupId: string) => decide.mutate({ signupId, decision: "REJECT" }),
+    deciding: decide.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ApplicantList.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ApplicantList.tsx
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+import { useEventApplicants } from "../model/useEventApplicants";
+import { ApplicantRow } from "./ApplicantRow";
+import { styles } from "./EventList.styles";
+
+/** An event's applicants with approve / reject — loaded when the row expands. */
+export const ApplicantList = ({ eventId }: { eventId: string }) => {
+  const { applicants, loading, approve, reject, deciding } = useEventApplicants(eventId);
+
+  if (loading) return <p {...stylex.props(styles.muted)}>지원자 불러오는 중…</p>;
+
+  if (applicants.length === 0) {
+    return <p {...stylex.props(styles.muted)}>아직 지원자가 없어요.</p>;
+  }
+
+  return (
+    <>
+      {applicants.map((applicant) => (
+        <ApplicantRow
+          key={applicant.signupId}
+          applicant={applicant}
+          disabled={deciding}
+          onApprove={() => approve(applicant.signupId)}
+          onReject={() => reject(applicant.signupId)}
+        />
+      ))}
+    </>
+  );
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ApplicantRow.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ApplicantRow.tsx
@@ -1,0 +1,41 @@
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "hobom-data";
+import { Hb } from "hobom-design-system";
+import { userQueries } from "@/entities/user";
+import { VOLUNTEER_APPLICANT_STATUS_LABEL } from "@/entities/volunteer-event";
+import type { VolunteerApplicant } from "@/entities/volunteer-event";
+import { styles } from "./EventList.styles";
+
+interface ApplicantRowProps {
+  applicant: VolunteerApplicant;
+  disabled: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+/** One applicant — nickname (hydrated) with approve / reject for pending signups,
+ *  or the decided status otherwise. */
+export const ApplicantRow = ({ applicant, disabled, onApprove, onReject }: ApplicantRowProps) => {
+  const { data: profile } = useQuery(userQueries.publicProfile(applicant.volunteerId));
+
+  return (
+    <div {...stylex.props(styles.applicantRow)}>
+      <span {...stylex.props(styles.applicantName)}>{profile?.nickname ?? "봉사자"}</span>
+      <span {...stylex.props(styles.spacer)} />
+      {applicant.status === "PENDING" ? (
+        <>
+          <Hb.Button variant="primary" size="small" disabled={disabled} onClick={onApprove}>
+            승인
+          </Hb.Button>
+          <Hb.Button variant="ghost" size="small" disabled={disabled} onClick={onReject}>
+            거절
+          </Hb.Button>
+        </>
+      ) : (
+        <span {...stylex.props(styles.applicantStatus)}>
+          {VOLUNTEER_APPLICANT_STATUS_LABEL[applicant.status]}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+
+const WIDE = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1080,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: {
+    margin: "4px 0 0",
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  layout: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [WIDE]: "360px 1fr" },
+    alignItems: "start",
+    gap: 20,
+  },
+});

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.tsx
@@ -1,0 +1,25 @@
+import * as stylex from "@stylexjs/stylex";
+import { useConsoleVolunteer } from "../model/useConsoleVolunteer";
+import { EventForm } from "./EventForm";
+import { EventList } from "./EventList";
+import { styles } from "./ConsoleVolunteer.styles";
+
+/** §07 봉사 일정 관리: create events on the left, manage the schedule and its
+ *  applicants (approve / reject) on the right. Scoped to the staff's shelter. */
+export const ConsoleVolunteer = ({ shelterId }: { shelterId: string }) => {
+  const { events, createEvent, creating, cancelEvent } = useConsoleVolunteer(shelterId);
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <h1 {...stylex.props(styles.title)}>봉사 일정 관리</h1>
+        <p {...stylex.props(styles.subtitle)}>일정 생성 · 정원/모집 · 지원자 승인</p>
+      </header>
+
+      <div {...stylex.props(styles.layout)}>
+        <EventForm onCreate={createEvent} submitting={creating} />
+        <EventList events={events} onCancel={cancelEvent} />
+      </div>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/EventForm.styles.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/EventForm.styles.ts
@@ -1,0 +1,53 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+    padding: 20,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  heading: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  label: {
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+  },
+  input: {
+    width: "100%",
+    boxSizing: "border-box",
+    padding: "9px 12px",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 10,
+    fontSize: "0.9375rem",
+    fontFamily: "inherit",
+    color: "var(--hb-color-text-primary)",
+    backgroundColor: "var(--hb-color-surface)",
+    outline: "none",
+  },
+  row: {
+    display: "flex",
+    gap: 10,
+  },
+  rowItem: {
+    flex: 1,
+    minWidth: 0,
+  },
+});

--- a/apps/hobom-angel/src/features/console-volunteer/ui/EventForm.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/EventForm.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { CreateVolunteerEventInput } from "@/entities/volunteer-event";
+import { toEventRange } from "../lib/event-format.lib";
+import { styles } from "./EventForm.styles";
+
+interface EventFormProps {
+  onCreate: (input: CreateVolunteerEventInput) => void;
+  submitting: boolean;
+}
+
+/** The 봉사 일정 만들기 form — GENERAL events for now (제목·정원·날짜·시간).
+ *  해외 이동봉사(출발/도착·항공편·동반 동물) follows in a later PR. */
+export const EventForm = ({ onCreate, submitting }: EventFormProps) => {
+  const [title, setTitle] = useState("");
+  const [capacity, setCapacity] = useState("12");
+  const [date, setDate] = useState("");
+  const [startTime, setStartTime] = useState("10:00");
+  const [endTime, setEndTime] = useState("13:00");
+
+  const spots = Number(capacity);
+  const canSubmit =
+    title.trim().length > 0 && spots >= 1 && date !== "" && startTime < endTime && !submitting;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    const range = toEventRange(date, startTime, endTime);
+
+    onCreate({ title: title.trim(), capacity: spots, ...range });
+    setTitle("");
+  };
+
+  return (
+    <section {...stylex.props(styles.card)}>
+      <h2 {...stylex.props(styles.heading)}>봉사 일정 만들기</h2>
+
+      <label {...stylex.props(styles.field)}>
+        <span {...stylex.props(styles.label)}>제목</span>
+        <input
+          {...stylex.props(styles.input)}
+          value={title}
+          placeholder="유기견 산책 봉사"
+          onChange={(event) => setTitle(event.target.value)}
+        />
+      </label>
+
+      <div {...stylex.props(styles.row)}>
+        <label {...stylex.props(styles.field, styles.rowItem)}>
+          <span {...stylex.props(styles.label)}>정원</span>
+          <input
+            {...stylex.props(styles.input)}
+            type="number"
+            min={1}
+            value={capacity}
+            onChange={(event) => setCapacity(event.target.value)}
+          />
+        </label>
+        <label {...stylex.props(styles.field, styles.rowItem)}>
+          <span {...stylex.props(styles.label)}>날짜</span>
+          <input
+            {...stylex.props(styles.input)}
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div {...stylex.props(styles.row)}>
+        <label {...stylex.props(styles.field, styles.rowItem)}>
+          <span {...stylex.props(styles.label)}>시작 시간</span>
+          <input
+            {...stylex.props(styles.input)}
+            type="time"
+            value={startTime}
+            onChange={(event) => setStartTime(event.target.value)}
+          />
+        </label>
+        <label {...stylex.props(styles.field, styles.rowItem)}>
+          <span {...stylex.props(styles.label)}>종료 시간</span>
+          <input
+            {...stylex.props(styles.input)}
+            type="time"
+            value={endTime}
+            onChange={(event) => setEndTime(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <Hb.Button variant="primary" fullWidth disabled={!canSubmit} loading={submitting} onClick={submit}>
+        일정 게시
+      </Hb.Button>
+    </section>
+  );
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/EventList.styles.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/EventList.styles.ts
@@ -1,0 +1,96 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  empty: {
+    padding: "40px 16px",
+    textAlign: "center",
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.9375rem",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: "var(--hb-color-border)",
+  },
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+    padding: 18,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  head: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  title: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  when: {
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  gauge: {
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-color-surface-subtle)",
+    overflow: "hidden",
+  },
+  gaugeFill: {
+    height: "100%",
+    borderRadius: 999,
+    backgroundColor: "var(--hb-color-accent)",
+  },
+  recruit: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  actions: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  spacer: {
+    flex: 1,
+  },
+  applicants: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-color-border)",
+  },
+  applicantRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  applicantName: {
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+  applicantStatus: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  muted: {
+    padding: "8px 0",
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+});

--- a/apps/hobom-angel/src/features/console-volunteer/ui/EventList.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/EventList.tsx
@@ -1,0 +1,25 @@
+import * as stylex from "@stylexjs/stylex";
+import type { VolunteerEvent } from "@/entities/volunteer-event";
+import { EventRow } from "./EventRow";
+import { styles } from "./EventList.styles";
+
+interface EventListProps {
+  events: VolunteerEvent[];
+  onCancel: (eventId: string) => void;
+}
+
+/** The shelter's volunteer schedule — each row shows recruitment and expands to
+ *  its applicants. */
+export const EventList = ({ events, onCancel }: EventListProps) => {
+  if (events.length === 0) {
+    return <p {...stylex.props(styles.empty)}>아직 등록한 봉사 일정이 없어요.</p>;
+  }
+
+  return (
+    <div {...stylex.props(styles.list)}>
+      {events.map((event) => (
+        <EventRow key={event.id} event={event} onCancel={onCancel} />
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-volunteer/ui/EventRow.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/EventRow.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { VOLUNTEER_STATUS_LABEL } from "@/entities/volunteer-event";
+import type { VolunteerEvent, VolunteerEventStatus } from "@/entities/volunteer-event";
+import { formatEventWhen, recruitLabel, recruitPercent } from "../lib/event-format.lib";
+import { ApplicantList } from "./ApplicantList";
+import { styles } from "./EventList.styles";
+
+const STATUS_COLOR: Record<VolunteerEventStatus, "primary" | "default"> = {
+  OPEN: "primary",
+  CLOSED: "default",
+  CANCELLED: "default",
+};
+
+interface EventRowProps {
+  event: VolunteerEvent;
+  onCancel: (eventId: string) => void;
+}
+
+/** One schedule row: recruitment gauge + status, a cancel action, and an
+ *  expandable applicant list. */
+export const EventRow = ({ event, onCancel }: EventRowProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <article {...stylex.props(styles.card)}>
+      <div {...stylex.props(styles.head)}>
+        <h3 {...stylex.props(styles.title)}>{event.title}</h3>
+        <Hb.Chip
+          label={VOLUNTEER_STATUS_LABEL[event.status]}
+          size="small"
+          variant="soft"
+          color={STATUS_COLOR[event.status]}
+        />
+      </div>
+
+      <span {...stylex.props(styles.when)}>{formatEventWhen(event.startAt, event.endAt)}</span>
+
+      <div {...stylex.props(styles.gauge)}>
+        <div {...stylex.props(styles.gaugeFill)} style={{ width: `${recruitPercent(event)}%` }} />
+      </div>
+      <span {...stylex.props(styles.recruit)}>{recruitLabel(event)}</span>
+
+      <div {...stylex.props(styles.actions)}>
+        <Hb.Button variant="ghost" size="small" onClick={() => setOpen((value) => !value)}>
+          지원자 {event.signedUpCount}명 {open ? "접기" : "보기"}
+        </Hb.Button>
+        <span {...stylex.props(styles.spacer)} />
+        {event.status === "OPEN" && (
+          <Hb.Button variant="ghost" size="small" onClick={() => onCancel(event.id)}>
+            일정 취소
+          </Hb.Button>
+        )}
+      </div>
+
+      {open && (
+        <div {...stylex.props(styles.applicants)}>
+          <ApplicantList eventId={event.id} />
+        </div>
+      )}
+    </article>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -33,7 +33,23 @@ const SHELTER = {
   coverImageKey: "https://picsum.photos/seed/shelter1-cover/1200/375",
 };
 
-const VOLUNTEER_EVENTS = [
+interface VolunteerEventRow {
+  id: string;
+  shelterId: string;
+  title: string;
+  description: string;
+  startAt: string;
+  endAt: string;
+  capacity: number;
+  signedUpCount: number;
+  status: string;
+  type: string;
+  transport: null;
+  mySignupId: string | null;
+  mySignupStatus: string | null;
+}
+
+const VOLUNTEER_EVENTS: VolunteerEventRow[] = [
   {
     id: "vol-1",
     shelterId: "shelter-1",
@@ -44,6 +60,8 @@ const VOLUNTEER_EVENTS = [
     capacity: 10,
     signedUpCount: 6,
     status: "OPEN",
+    type: "GENERAL",
+    transport: null,
     mySignupId: null,
     mySignupStatus: null,
   },
@@ -57,10 +75,29 @@ const VOLUNTEER_EVENTS = [
     capacity: 8,
     signedUpCount: 8,
     status: "CLOSED",
+    type: "GENERAL",
+    transport: null,
     mySignupId: null,
     mySignupStatus: null,
   },
 ];
+
+// Applicants per event for the console (§07 봉사 일정 → 지원자 승인/거절).
+const VOLUNTEER_APPLICANTS = new Map<
+  string,
+  { signupId: string; volunteerId: string; status: string }[]
+>([
+  [
+    "vol-1",
+    [
+      { signupId: "vsg-1", volunteerId: "user-2", status: "APPROVED" },
+      { signupId: "vsg-2", volunteerId: "user-3", status: "PENDING" },
+      { signupId: "vsg-3", volunteerId: "mock-user-1", status: "PENDING" },
+    ],
+  ],
+]);
+
+let nextVolunteerEvent = VOLUNTEER_EVENTS.length + 1;
 
 const ANNOUNCEMENTS = [
   {
@@ -226,5 +263,72 @@ export const shelterHandlers = [
     if (!mockSession.isActive()) return unauthorized();
 
     return ok(VOLUNTEER_EVENTS);
+  }),
+
+  // §07 console — create / cancel events and decide applicants.
+  http.post(mockUrl("/shelters/:shelterId/volunteer-events"), async ({ params, request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const input = (await request.json()) as {
+      title: string;
+      description?: string;
+      startAt: string;
+      endAt: string;
+      capacity: number;
+    };
+    const id = `vol-${nextVolunteerEvent}`;
+
+    nextVolunteerEvent += 1;
+
+    VOLUNTEER_EVENTS.unshift({
+      id,
+      shelterId: String(params.shelterId),
+      title: input.title,
+      description: input.description ?? "",
+      startAt: input.startAt,
+      endAt: input.endAt,
+      capacity: input.capacity,
+      signedUpCount: 0,
+      status: "OPEN",
+      type: "GENERAL",
+      transport: null,
+      mySignupId: null,
+      mySignupStatus: null,
+    });
+
+    return ok({ eventId: id });
+  }),
+
+  http.post(mockUrl("/volunteer-events/:eventId/cancellation"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const event = VOLUNTEER_EVENTS.find((candidate) => candidate.id === params.eventId);
+
+    if (event) event.status = "CANCELLED";
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.get(mockUrl("/volunteer-events/:eventId/signups"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(VOLUNTEER_APPLICANTS.get(String(params.eventId)) ?? []);
+  }),
+
+  http.post(mockUrl("/volunteer-signups/:signupId/decision"), async ({ params, request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const { decision } = (await request.json()) as { decision: "APPROVE" | "REJECT" };
+
+    for (const list of VOLUNTEER_APPLICANTS.values()) {
+      const applicant = list.find((candidate) => candidate.signupId === params.signupId);
+
+      if (applicant) {
+        applicant.status = decision === "APPROVE" ? "APPROVED" : "REJECTED";
+        break;
+      }
+    }
+
+    return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/apps/hobom-angel/src/mocks/handlers/user.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/user.handlers.ts
@@ -10,8 +10,11 @@ const profile = {
   nickname: "봄이네",
   email: "hobom@example.com",
   verifiedChannel: "EMAIL",
-  roles: ["MEMBER"],
-  shelterRoles: [] as { shelterId: string; role: string }[],
+  roles: ["SHELTER_ADMIN"],
+  shelterRoles: [{ shelterId: "shelter-1", role: "SHELTER_ADMIN" }] as {
+    shelterId: string;
+    role: string;
+  }[],
   status: "ACTIVE",
 };
 

--- a/apps/hobom-angel/src/pages/console-volunteer/index.ts
+++ b/apps/hobom-angel/src/pages/console-volunteer/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleVolunteerPage } from "./ui/ConsoleVolunteerPage";

--- a/apps/hobom-angel/src/pages/console-volunteer/ui/ConsoleVolunteerPage.tsx
+++ b/apps/hobom-angel/src/pages/console-volunteer/ui/ConsoleVolunteerPage.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { managedShelter, useCurrentUser } from "@/entities/user";
+import { ConsoleVolunteer } from "@/features/console-volunteer";
+import { LoadingState, NotFoundState } from "@/shared/ui";
+
+export const ConsoleVolunteerPage = () => {
+  const { user } = useCurrentUser();
+  const shelter = managedShelter(user);
+
+  if (!shelter) return <NotFoundState />;
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <ConsoleVolunteer shelterId={shelter.shelterId} />
+    </Suspense>
+  );
+};

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -16,6 +16,10 @@ export const ROUTES = {
   APPLICATIONS: "/applications",
   MY: "/my",
 
+  // Shelter staff console.
+  CONSOLE: "/console",
+  CONSOLE_VOLUNTEER: "/console/volunteer",
+
   // Auth.
   LOGIN: "/login",
   SIGNUP: "/signup",

--- a/apps/hobom-angel/src/widgets/global-nav/ui/ProfileMenu.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/ProfileMenu.tsx
@@ -2,11 +2,19 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { useLogout } from "@/features/session";
+import { ROUTES } from "@/shared/config";
 import { PROFILE_MENU } from "../model/nav-items";
 import { styles } from "./GlobalNav.styles";
 
-/** Profile dropdown for a signed-in user: nav shortcuts + logout. */
-export const ProfileMenu = ({ nickname }: { nickname: string }) => {
+interface ProfileMenuProps {
+  nickname: string;
+  /** Show the console shortcut — only for shelter staff. */
+  staff?: boolean;
+}
+
+/** Profile dropdown for a signed-in user: nav shortcuts + logout (plus the
+ *  console shortcut for shelter staff). */
+export const ProfileMenu = ({ nickname, staff = false }: ProfileMenuProps) => {
   const [open, setOpen] = useState(false);
   const { mutate: logout } = useLogout();
 
@@ -20,6 +28,18 @@ export const ProfileMenu = ({ nickname }: { nickname: string }) => {
         <>
           <div {...stylex.props(styles.backdrop)} onClick={() => setOpen(false)} />
           <div {...stylex.props(styles.menu)} role="menu">
+            {staff && (
+              <>
+                <Link
+                  to={ROUTES.CONSOLE}
+                  {...stylex.props(styles.menuItem)}
+                  onClick={() => setOpen(false)}
+                >
+                  보호소 콘솔
+                </Link>
+                <div {...stylex.props(styles.menuDivider)} />
+              </>
+            )}
             {PROFILE_MENU.map((item) => (
               <Link
                 key={item.to}

--- a/apps/hobom-angel/src/widgets/global-nav/ui/TopNav.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/TopNav.tsx
@@ -3,6 +3,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { NotificationsNoneOutlined } from "hobom-design-system/icons";
 import { ROUTES } from "@/shared/config";
+import { managedShelter } from "@/entities/user";
 import type { CurrentUser } from "@/entities/user";
 import { PRIMARY_NAV } from "../model/nav-items";
 import { activeLinkProps } from "./nav-link-props";
@@ -47,7 +48,7 @@ export const TopNav = ({ user, isAuthenticated }: TopNavProps) => {
             <button type="button" {...stylex.props(styles.iconBtn)} aria-label="알림">
               <NotificationsNoneOutlined fontSize="small" />
             </button>
-            <ProfileMenu nickname={user.nickname} />
+            <ProfileMenu nickname={user.nickname} staff={managedShelter(user) !== null} />
           </>
         ) : (
           <>


### PR DESCRIPTION
## What

Stands up the **shelter staff console** (§07) at `/console`, and its first screen: **봉사 일정 관리**.

## Foundation

- `CurrentUser` now carries `roles` + `shelterRoles` (previously dropped), so the app knows who manages which shelter.
- A `/console` route section with its own chrome (`ConsoleShellLayout`), gated by `ConsoleRoute` — a member without a shelter role is sent home.
- The sidebar follows the design's seven-menu map (동물 관리 · 신청 처리 · 봉사 일정 · 콘텐츠 · 설문 빌더 · 스태프 관리 · 통계); only **봉사 일정** is wired, the rest are shown but disabled. A clear **← 서비스로 나가기** returns to the consumer app.
- A **보호소 콘솔** entry appears in the profile menu, only for staff.

## 봉사 일정 관리 (§7.3)

- Create GENERAL events (제목 · 정원 · 날짜 · 시간).
- The shelter's schedule as cards with a recruitment gauge, status, and cancel.
- Expand an event to its applicants and **approve / reject** each — backed by the new volunteer-event staff endpoints (`create` / `cancel` / `GET signups` / `decide`).

## Notes

- Application review (심사 큐) is deliberately not here: the backend has no list endpoint for adoption/foster applications, only counts + a decision endpoint.
- OVERSEAS 이동봉사 fields and the other six console menus follow in later PRs.
- Mocks scope the signed-in user to a shelter (SHELTER_ADMIN of shelter-1) and seed applicants.

## Verification

- typecheck / lint clean
- 100 unit tests pass (incl. new managed-shelter + event-format specs)
- 39 e2e pass, incl. a new console flow: profile menu → create event → approve an applicant → exit