### PR TITLE
Match the animal console to the §7.1 design + photo previews

### DIFF
--- a/apps/hobom-angel/src/features/console-animals/lib/animal-form.lib.spec.ts
+++ b/apps/hobom-angel/src/features/console-animals/lib/animal-form.lib.spec.ts
@@ -12,6 +12,7 @@ const values: AnimalFormValues = {
   ageMonths: "24",
   neutered: true,
   vaccinated: false,
+  microchip: " 410123 ",
   description: "  온순해요 ",
 };
 
@@ -22,16 +23,23 @@ describe("toUpdateInput", () => {
       species: "DOG",
       description: "온순해요",
       traits: { sex: "FEMALE", size: "SMALL", breed: "푸들", ageMonths: 24 },
-      health: { neutered: true, vaccinated: false },
+      health: { neutered: true, vaccinated: false, microchipId: "410123" },
     });
   });
 
-  it("omits blank description, breed, and age", () => {
-    const bare = toUpdateInput({ ...values, breed: "  ", ageMonths: "", description: "" });
+  it("omits blank description, breed, age, and microchip", () => {
+    const bare = toUpdateInput({
+      ...values,
+      breed: "  ",
+      ageMonths: "",
+      description: "",
+      microchip: "  ",
+    });
 
     expect(bare.description).toBeUndefined();
     expect(bare.traits.breed).toBeUndefined();
     expect(bare.traits.ageMonths).toBeUndefined();
+    expect(bare.health.microchipId).toBeUndefined();
   });
 });
 
@@ -58,7 +66,7 @@ describe("animalFormFromDetail", () => {
       breed: null,
       ageMonths: null,
       description: "장난꾸러기",
-      health: { neutered: false, vaccinated: true },
+      health: { neutered: false, vaccinated: true, microchipId: "410999" },
     } as AnimalDetail;
 
     expect(animalFormFromDetail(detail)).toEqual({
@@ -70,6 +78,7 @@ describe("animalFormFromDetail", () => {
       ageMonths: "",
       neutered: false,
       vaccinated: true,
+      microchip: "410999",
       description: "장난꾸러기",
     });
   });

--- a/apps/hobom-angel/src/features/console-animals/lib/animal-form.lib.ts
+++ b/apps/hobom-angel/src/features/console-animals/lib/animal-form.lib.ts
@@ -18,6 +18,7 @@ export interface AnimalFormValues {
   ageMonths: string;
   neutered: boolean;
   vaccinated: boolean;
+  microchip: string;
   description: string;
 }
 
@@ -30,6 +31,7 @@ export const EMPTY_ANIMAL_FORM: AnimalFormValues = {
   ageMonths: "",
   neutered: false,
   vaccinated: false,
+  microchip: "",
   description: "",
 };
 
@@ -43,6 +45,7 @@ export const animalFormFromDetail = (animal: AnimalDetail): AnimalFormValues => 
   ageMonths: animal.ageMonths != null ? String(animal.ageMonths) : "",
   neutered: animal.health.neutered,
   vaccinated: animal.health.vaccinated,
+  microchip: animal.health.microchipId ?? "",
   description: animal.description,
 });
 
@@ -59,7 +62,11 @@ export const toUpdateInput = (values: AnimalFormValues): UpdateAnimalInput => ({
   species: values.species,
   description: values.description.trim() || undefined,
   traits: toTraits(values),
-  health: { neutered: values.neutered, vaccinated: values.vaccinated },
+  health: {
+    neutered: values.neutered,
+    vaccinated: values.vaccinated,
+    microchipId: values.microchip.trim() || undefined,
+  },
 });
 
 /** Build the register body, adding the intake date and any uploaded photos. */

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalFields.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalFields.tsx
@@ -115,6 +115,16 @@ export const AnimalFields = ({ values, onChange }: AnimalFieldsProps) => (
     </div>
 
     <label {...stylex.props(styles.field)}>
+      <span {...stylex.props(styles.label)}>마이크로칩</span>
+      <input
+        {...stylex.props(styles.input)}
+        value={values.microchip}
+        placeholder="칩 번호 (선택)"
+        onChange={(event) => onChange({ ...values, microchip: event.target.value })}
+      />
+    </label>
+
+    <label {...stylex.props(styles.field)}>
       <span {...stylex.props(styles.label)}>소개</span>
       <textarea
         {...stylex.props(styles.input, styles.textarea)}

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalForm.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalForm.styles.ts
@@ -87,6 +87,14 @@ export const styles = stylex.create({
   hiddenInput: {
     display: "none",
   },
+  emptyPhotos: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  note: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-disabled)",
+  },
   actions: {
     display: "flex",
     gap: 8,

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.styles.ts
@@ -1,49 +1,87 @@
 import * as stylex from "@stylexjs/stylex";
 
+const COLUMNS = "44px 1.3fr 1fr 64px";
+
 export const styles = stylex.create({
-  list: {
+  table: {
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 14,
+    overflow: "hidden",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  head: {
+    display: "grid",
+    gridTemplateColumns: COLUMNS,
+    alignItems: "center",
+    gap: 10,
+    padding: "10px 14px",
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+    fontSize: "0.75rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: "var(--hb-color-surface-subtle)",
+  },
+  row: {
+    display: "grid",
+    gridTemplateColumns: COLUMNS,
+    alignItems: "center",
+    gap: 10,
+    width: "100%",
+    padding: "10px 14px",
+    borderWidth: 0,
+    borderBottomWidth: 1,
+    borderBottomStyle: "solid",
+    borderBottomColor: "var(--hb-color-border)",
+    textAlign: "start",
+    cursor: "pointer",
+    backgroundColor: { default: "var(--hb-color-surface)", ":hover": "var(--hb-color-surface-subtle)" },
+  },
+  rowActive: {
+    backgroundColor: "var(--hb-color-accent-subtle, oklch(0.95 0.03 155))",
+  },
+  thumb: {
+    width: 40,
+    height: 40,
+    borderRadius: 8,
+    objectFit: "cover",
+    backgroundColor: "var(--hb-color-surface-subtle)",
+  },
+  thumbEmpty: {
+    width: 40,
+    height: 40,
+    borderRadius: 8,
+    backgroundColor: "var(--hb-color-surface-subtle)",
+  },
+  nameCell: {
     display: "flex",
     flexDirection: "column",
-    gap: 8,
+    minWidth: 0,
+  },
+  name: {
+    fontSize: "0.9375rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  breed: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  count: {
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-secondary)",
+    textAlign: "end",
   },
   empty: {
     padding: "40px 16px",
     textAlign: "center",
     color: "var(--hb-color-text-secondary)",
     fontSize: "0.9375rem",
-    borderRadius: 14,
-    borderWidth: 1,
-    borderStyle: "dashed",
-    borderColor: "var(--hb-color-border)",
-  },
-  row: {
-    display: "flex",
-    alignItems: "center",
-    gap: 10,
-    width: "100%",
-    padding: "12px 14px",
-    borderRadius: 12,
-    borderWidth: 1,
-    borderStyle: "solid",
-    borderColor: "var(--hb-color-border)",
-    backgroundColor: { default: "var(--hb-color-surface)", ":hover": "var(--hb-color-surface-subtle)" },
-    textAlign: "start",
-    cursor: "pointer",
-  },
-  rowActive: {
-    borderColor: "var(--hb-color-accent)",
-    boxShadow: "0 0 0 1px var(--hb-color-accent)",
-  },
-  name: {
-    fontSize: "0.9375rem",
-    fontWeight: 700,
-    color: "var(--hb-color-text-primary)",
-  },
-  meta: {
-    fontSize: "0.8125rem",
-    color: "var(--hb-color-text-secondary)",
-  },
-  spacer: {
-    flex: 1,
   },
 });

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
@@ -9,14 +9,25 @@ interface AnimalRosterProps {
   onEdit: (animalId: string) => void;
 }
 
-/** The shelter's animals — selecting one opens it in the edit form. */
+/** The shelter's animals as a table (§7.1) — thumbnail · 이름·품종 · 상태 · 신청.
+ *  Selecting a row opens it in the edit form. */
 export const AnimalRoster = ({ animals, editingId, onEdit }: AnimalRosterProps) => {
   if (animals.length === 0) {
-    return <p {...stylex.props(styles.empty)}>아직 등록한 동물이 없어요.</p>;
+    return (
+      <div {...stylex.props(styles.table)}>
+        <p {...stylex.props(styles.empty)}>아직 등록한 동물이 없어요.</p>
+      </div>
+    );
   }
 
   return (
-    <div {...stylex.props(styles.list)}>
+    <div {...stylex.props(styles.table)}>
+      <div {...stylex.props(styles.head)}>
+        <span />
+        <span>이름·품종</span>
+        <span>상태</span>
+        <span {...stylex.props(styles.count)}>신청</span>
+      </div>
       {animals.map((animal) => (
         <AnimalRosterRow
           key={animal.id}

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
@@ -1,17 +1,20 @@
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { SPECIES_LABEL, STATUS_LABEL } from "@/entities/animal";
+import { mediaUrl } from "@/shared/lib";
 import type { Animal, AnimalStatusLabel } from "@/entities/animal";
 import { styles } from "./AnimalRoster.styles";
 
-const STATUS_COLOR: Record<AnimalStatusLabel, "primary" | "warning" | "secondary" | "success" | "default"> =
-  {
-    입양가능: "primary",
-    예약중: "warning",
-    임보중: "secondary",
-    입양완료: "success",
-    반환: "default",
-  };
+const STATUS_COLOR: Record<
+  AnimalStatusLabel,
+  "primary" | "warning" | "secondary" | "success" | "default"
+> = {
+  입양가능: "primary",
+  예약중: "warning",
+  임보중: "secondary",
+  입양완료: "success",
+  반환: "default",
+};
 
 interface AnimalRosterRowProps {
   animal: Animal;
@@ -19,20 +22,29 @@ interface AnimalRosterRowProps {
   onEdit: () => void;
 }
 
-/** One roster row — name, species/breed, status — that selects the animal for
- *  editing. */
+/** A table row — thumbnail, name·breed, status, and a signup-count slot (shown
+ *  as — until the backend exposes counts). Selects the animal for editing. */
 export const AnimalRosterRow = ({ animal, active, onEdit }: AnimalRosterRowProps) => {
   const statusLabel = STATUS_LABEL[animal.status];
 
   return (
     <button type="button" {...stylex.props(styles.row, active && styles.rowActive)} onClick={onEdit}>
-      <span {...stylex.props(styles.name)}>{animal.name}</span>
-      <span {...stylex.props(styles.meta)}>
-        {SPECIES_LABEL[animal.species]}
-        {animal.breed ? ` · ${animal.breed}` : ""}
+      {animal.photoUrl ? (
+        <img src={mediaUrl(animal.photoUrl)} alt="" {...stylex.props(styles.thumb)} />
+      ) : (
+        <span {...stylex.props(styles.thumbEmpty)} />
+      )}
+      <span {...stylex.props(styles.nameCell)}>
+        <span {...stylex.props(styles.name)}>{animal.name}</span>
+        <span {...stylex.props(styles.breed)}>
+          {SPECIES_LABEL[animal.species]}
+          {animal.breed ? ` · ${animal.breed}` : ""}
+        </span>
       </span>
-      <span {...stylex.props(styles.spacer)} />
-      <Hb.Chip label={statusLabel} size="small" variant="soft" color={STATUS_COLOR[statusLabel]} />
+      <span>
+        <Hb.Chip label={statusLabel} size="small" variant="soft" color={STATUS_COLOR[statusLabel]} />
+      </span>
+      <span {...stylex.props(styles.count)}>—</span>
     </button>
   );
 };

--- a/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
@@ -6,9 +6,6 @@ export const styles = stylex.create({
   root: {
     maxWidth: 1080,
   },
-  header: {
-    marginBottom: 20,
-  },
   title: {
     margin: 0,
     fontSize: "1.5rem",
@@ -20,9 +17,27 @@ export const styles = stylex.create({
     fontSize: "0.9375rem",
     color: "var(--hb-color-text-secondary)",
   },
+  toolbar: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    marginBlock: 18,
+  },
+  count: {
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  countNum: {
+    color: "var(--hb-color-accent-dark, var(--hb-color-accent))",
+  },
+  spacer: {
+    flex: 1,
+  },
+  // Table on the left, register/edit form on the right (§7.1).
   layout: {
     display: "grid",
-    gridTemplateColumns: { default: "1fr", [WIDE]: "380px 1fr" },
+    gridTemplateColumns: { default: "1fr", [WIDE]: "1.1fr 1fr" },
     alignItems: "start",
     gap: 20,
   },

--- a/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
 import { LoadingState } from "@/shared/ui";
 import { useConsoleAnimals } from "../model/useConsoleAnimals";
 import { AnimalRoster } from "./AnimalRoster";
@@ -7,20 +8,30 @@ import { EditForm } from "./EditForm";
 import { RegisterForm } from "./RegisterForm";
 import { styles } from "./ConsoleAnimals.styles";
 
-/** §07 동물 관리: register on the left, the shelter's roster on the right;
- *  selecting an animal swaps the form into edit mode. Scoped to the shelter. */
+/** §7.1 동물 관리: the shelter's roster as a table on the left, a register/edit
+ *  form on the right. Selecting a row edits it; "+ 동물 등록" returns to register. */
 export const ConsoleAnimals = ({ shelterId }: { shelterId: string }) => {
   const { animals, editingId, edit, clearEdit, registerAnimal, updateAnimal, saving } =
     useConsoleAnimals(shelterId);
 
   return (
     <div {...stylex.props(styles.root)}>
-      <header {...stylex.props(styles.header)}>
-        <h1 {...stylex.props(styles.title)}>동물 관리</h1>
-        <p {...stylex.props(styles.subtitle)}>우리 보호소 동물 {animals.length}마리 · 등록·수정</p>
-      </header>
+      <h1 {...stylex.props(styles.title)}>동물 관리</h1>
+      <p {...stylex.props(styles.subtitle)}>등록·수정 · 이미지 · 상태</p>
+
+      <div {...stylex.props(styles.toolbar)}>
+        <span {...stylex.props(styles.count)}>
+          우리 보호소 동물 <span {...stylex.props(styles.countNum)}>{animals.length}</span>
+        </span>
+        <span {...stylex.props(styles.spacer)} />
+        <Hb.Button variant="primary" size="small" disabled={!editingId} onClick={clearEdit}>
+          + 동물 등록
+        </Hb.Button>
+      </div>
 
       <div {...stylex.props(styles.layout)}>
+        <AnimalRoster animals={animals} editingId={editingId} onEdit={edit} />
+
         {editingId ? (
           <Suspense fallback={<LoadingState />}>
             <EditForm
@@ -34,8 +45,6 @@ export const ConsoleAnimals = ({ shelterId }: { shelterId: string }) => {
         ) : (
           <RegisterForm onRegister={registerAnimal} saving={saving} />
         )}
-
-        <AnimalRoster animals={animals} editingId={editingId} onEdit={edit} />
       </div>
     </div>
   );

--- a/apps/hobom-angel/src/features/console-animals/ui/EditForm.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/EditForm.tsx
@@ -3,10 +3,13 @@ import { useSuspenseQuery } from "hobom-data";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { animalQueries } from "@/entities/animal";
+import { mediaUrl } from "@/shared/lib";
 import type { UpdateAnimalInput } from "@/entities/animal";
 import { AnimalFields } from "./AnimalFields";
+import { PhotoStrip } from "./PhotoStrip";
 import { animalFormFromDetail, toUpdateInput } from "../lib/animal-form.lib";
 import { styles } from "./AnimalForm.styles";
+import { styles as fieldStyles } from "./AnimalFields.styles";
 
 interface EditFormProps {
   animalId: string;
@@ -33,6 +36,15 @@ export const EditForm = ({ animalId, onUpdate, onCancel, saving }: EditFormProps
       </div>
 
       <AnimalFields values={values} onChange={setValues} />
+
+      <div {...stylex.props(fieldStyles.field)}>
+        <span {...stylex.props(fieldStyles.label)}>사진</span>
+        <PhotoStrip
+          photos={detail.photos.map((key) => ({ key, url: mediaUrl(key) }))}
+          emptyText="등록된 사진이 없어요."
+        />
+        <span {...stylex.props(styles.note)}>사진은 동물 등록 시에만 추가할 수 있어요.</span>
+      </div>
 
       <div {...stylex.props(styles.actions)}>
         <Hb.Button variant="ghost" onClick={onCancel}>

--- a/apps/hobom-angel/src/features/console-animals/ui/PhotoStrip.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/PhotoStrip.tsx
@@ -1,0 +1,63 @@
+import * as stylex from "@stylexjs/stylex";
+import { styles } from "./AnimalForm.styles";
+
+export interface StripPhoto {
+  key: string;
+  url: string;
+}
+
+interface PhotoStripProps {
+  photos: StripPhoto[];
+  /** Provided → an add tile appears (register mode). */
+  onAdd?: (files: FileList | null) => void;
+  /** Provided → each photo shows a remove button. */
+  onRemove?: (key: string) => void;
+  uploading?: boolean;
+  emptyText?: string;
+}
+
+/** A row of photo thumbnails, editable (upload / remove) or read-only. Shared by
+ *  the register form (uploads) and the edit form (existing photos preview). */
+export const PhotoStrip = ({ photos, onAdd, onRemove, uploading, emptyText }: PhotoStripProps) => {
+  if (photos.length === 0 && !onAdd) {
+    return <span {...stylex.props(styles.emptyPhotos)}>{emptyText ?? "등록된 사진이 없어요."}</span>;
+  }
+
+  return (
+    <div {...stylex.props(styles.attach)}>
+      {photos.map((photo) => (
+        <div key={photo.key} {...stylex.props(styles.thumb)}>
+          <img src={photo.url} alt="" {...stylex.props(styles.thumbImg)} />
+          {onRemove && (
+            <button
+              type="button"
+              aria-label="사진 삭제"
+              {...stylex.props(styles.thumbRemove)}
+              onClick={() => onRemove(photo.key)}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+
+      {onAdd && (
+        <label {...stylex.props(styles.attachBtn)}>
+          {uploading ? "업로드 중…" : "＋ 사진"}
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            multiple
+            {...stylex.props(styles.hiddenInput)}
+            onChange={(event) => {
+              const input = event.currentTarget;
+
+              onAdd(input.files);
+              input.value = "";
+            }}
+          />
+        </label>
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-animals/ui/RegisterForm.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/RegisterForm.tsx
@@ -3,6 +3,7 @@ import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import type { RegisterAnimalInput } from "@/entities/animal";
 import { AnimalFields } from "./AnimalFields";
+import { PhotoStrip } from "./PhotoStrip";
 import { useAnimalPhotos } from "../model/useAnimalPhotos";
 import { EMPTY_ANIMAL_FORM, toRegisterInput } from "../lib/animal-form.lib";
 import { styles } from "./AnimalForm.styles";
@@ -49,36 +50,12 @@ export const RegisterForm = ({ onRegister, saving }: RegisterFormProps) => {
 
       <div {...stylex.props(fieldStyles.field)}>
         <span {...stylex.props(fieldStyles.label)}>사진</span>
-        <div {...stylex.props(styles.attach)}>
-          {photos.images.map((image) => (
-            <div key={image.objectKey} {...stylex.props(styles.thumb)}>
-              <img src={image.publicUrl} alt="" {...stylex.props(styles.thumbImg)} />
-              <button
-                type="button"
-                aria-label="사진 삭제"
-                {...stylex.props(styles.thumbRemove)}
-                onClick={() => photos.remove(image.objectKey)}
-              >
-                ×
-              </button>
-            </div>
-          ))}
-          <label {...stylex.props(styles.attachBtn)}>
-            {photos.uploading ? "업로드 중…" : "＋ 사진"}
-            <input
-              type="file"
-              accept="image/jpeg,image/png,image/webp"
-              multiple
-              {...stylex.props(styles.hiddenInput)}
-              onChange={(event) => {
-                const input = event.currentTarget;
-
-                void photos.add(input.files);
-                input.value = "";
-              }}
-            />
-          </label>
-        </div>
+        <PhotoStrip
+          photos={photos.images.map((image) => ({ key: image.objectKey, url: image.publicUrl }))}
+          uploading={photos.uploading}
+          onAdd={(files) => void photos.add(files)}
+          onRemove={photos.remove}
+        />
       </div>
 
       <Hb.Button

--- a/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
@@ -257,7 +257,7 @@ export const animalHandlers = [
       species: string;
       description?: string;
       traits: { sex: string; size: string; ageMonths?: number; breed?: string };
-      health: { neutered: boolean; vaccinated: boolean };
+      health: { neutered: boolean; vaccinated: boolean; microchipId?: string };
     };
     const animal = ANIMALS.find((candidate) => candidate.id === params.animalId) as
       | AnimalRow
@@ -273,6 +273,7 @@ export const animalHandlers = [
       animal.traits.breed = input.traits.breed ?? null;
       animal.health.neutered = input.health.neutered;
       animal.health.vaccinated = input.health.vaccinated;
+      animal.health.microchipId = input.health.microchipId ?? null;
     }
 
     return new HttpResponse(null, { status: 204 });


### PR DESCRIPTION
## Why

Feedback: the 동물 관리 screen was too far from the §7.1 design, and images couldn't be previewed (and edit had no photo UI at all).

## Layout — now matches §7.1

- A **count + `+ 동물 등록` toolbar** ("우리 보호소 동물 N") above the body.
- **Two columns**: the roster is a **table** (thumbnail · 이름·품종 · 상태 · 신청) on the **left**, the register/edit form on the **right** — previously these were swapped and the list was cards.
- Added the **마이크로칩** field the design's health section shows.

## Photos

- Extracted a shared **`PhotoStrip`**: the register form previews uploaded photos (add/remove), and the **edit form now previews the animal's existing photos**.
- Editing photos isn't offered because the backend `PATCH /animals/:id` (`UpdateAnimalProfileDto`) has no `photos` field and there's no photo endpoint — the edit form notes this instead of silently discarding changes. Register (`POST`) does accept photos, and that upload/preview works.

## Verification

- typecheck / lint clean
- 105 unit tests pass (mapper specs updated for microchip)
- 40 e2e pass (console register + edit flow); register photo upload/preview verified