### PR TITLE
Fix animal photos not loading (resolve object keys to media URLs)

### DIFF
--- a/apps/hobom-angel/src/entities/animal/ui/AnimalPhoto.tsx
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalPhoto.tsx
@@ -1,8 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
+import { mediaUrl } from "@/shared/lib";
 import { styles } from "./AnimalPhoto.styles";
 
 interface AnimalPhotoProps {
+  /** A media object key or a full URL — resolved to a URL via `mediaUrl`. */
   src?: string;
   alt: string;
   /** CSS aspect-ratio for the frame (e.g. "1 / 1"). Defaults to "4 / 3". */
@@ -11,10 +13,11 @@ interface AnimalPhotoProps {
   priority?: boolean;
 }
 
-/** Animal image — the design-system `Image` with the brand's paw fallback. */
+/** Animal image — the design-system `Image` with the brand's paw fallback. The
+ *  backend returns R2 object keys, so resolve them to URLs before rendering. */
 export const AnimalPhoto = ({ src, alt, ratio = "4 / 3", priority = false }: AnimalPhotoProps) => (
   <Hb.Image
-    src={src}
+    src={src ? mediaUrl(src) : undefined}
     alt={alt}
     ratio={ratio}
     priority={priority}

--- a/apps/hobom-angel/src/features/animal-detail/ui/AnimalGallery.spec.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/AnimalGallery.spec.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { mediaUrl } from "@/shared/lib";
 import { AnimalGallery } from "./AnimalGallery";
 
 const PHOTOS = ["one.jpg", "two.jpg", "three.jpg"];
@@ -8,10 +9,10 @@ const PHOTOS = ["one.jpg", "two.jpg", "three.jpg"];
 const heroSrc = () => screen.getByAltText("콩이 사진").getAttribute("src");
 
 describe("AnimalGallery", () => {
-  it("shows the first photo as the hero", () => {
+  it("shows the first photo (resolved to a media URL) as the hero", () => {
     render(<AnimalGallery photos={PHOTOS} name="콩이" />);
 
-    expect(heroSrc()).toBe("one.jpg");
+    expect(heroSrc()).toBe(mediaUrl("one.jpg"));
     expect(screen.getAllByRole("button")).toHaveLength(PHOTOS.length);
   });
 
@@ -20,7 +21,7 @@ describe("AnimalGallery", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "콩이 사진 3" }));
 
-    expect(heroSrc()).toBe("three.jpg");
+    expect(heroSrc()).toBe(mediaUrl("three.jpg"));
     expect(screen.getByRole("button", { name: "콩이 사진 3" }).getAttribute("aria-pressed")).toBe("true");
   });
 


### PR DESCRIPTION
## Bug

On the browse and detail pages, real animal photos didn't load. The backend returns R2 **object keys** like `{"objectKey": "animals/0a4a…png"}`, but `AnimalPhoto` used `src` verbatim — so the browser requested a relative path that 404s. It only worked in the mock because those photos are full picsum URLs.

## Fix

Resolve `AnimalPhoto`'s `src` through `mediaUrl` — a single, central point every animal image already flows through (browse cards + detail gallery). `mediaUrl` passes full URLs through unchanged and prefixes bare keys with the CDN base, so both the mock and real data work.

## Verification

- typecheck / lint clean
- 105 unit tests pass (gallery spec updated to assert the resolved URL)
- browse + detail e2e green