### PR TITLE
Console content (공지 CMS) + shell polish (white bg, green menu, 1:1)

### DIFF
--- a/apps/hobom-angel/e2e/console-animals.spec.ts
+++ b/apps/hobom-angel/e2e/console-animals.spec.ts
@@ -18,7 +18,7 @@ test.describe("§07 shelter console — animals", () => {
     // The console lands on 동물 관리.
     await expect(page).toHaveURL(/\/console\/animals$/);
     await expect(page.getByRole("heading", { name: "동물 관리" })).toBeVisible();
-    await expect(page.getByRole("button", { name: /콩이/ })).toBeVisible();
+    await expect(page.getByRole("row", { name: /콩이/ })).toBeVisible();
 
     await page.screenshot({ path: "e2e-artifacts/console-animals.png", fullPage: true });
 
@@ -27,14 +27,14 @@ test.describe("§07 shelter console — animals", () => {
     await page.getByLabel("구조일").fill("2026-08-20");
     await page.getByRole("button", { name: "등록하기" }).click();
     await expect(page.getByText("동물을 등록했어요.")).toBeVisible();
-    await expect(page.getByRole("button", { name: /다롱이/ })).toBeVisible();
+    await expect(page.getByRole("row", { name: /다롱이/ })).toBeVisible();
 
     // Edit an existing animal from the roster.
-    await page.getByRole("button", { name: /콩이/ }).first().click();
+    await page.getByRole("row", { name: /콩이/ }).first().click();
     await expect(page.getByRole("heading", { name: "콩이 수정" })).toBeVisible();
     await page.getByPlaceholder("콩이").fill("콩순이");
     await page.getByRole("button", { name: "저장하기" }).click();
     await expect(page.getByText("동물 정보를 수정했어요.")).toBeVisible();
-    await expect(page.getByRole("button", { name: /콩순이/ })).toBeVisible();
+    await expect(page.getByRole("row", { name: /콩순이/ })).toBeVisible();
   });
 });

--- a/apps/hobom-angel/e2e/console-content.spec.ts
+++ b/apps/hobom-angel/e2e/console-content.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§7.4 shelter console — content", () => {
+  test("creates, edits, and deletes an announcement", async ({ page }) => {
+    await login(page);
+    await page.goto("console/content");
+
+    await expect(page.getByRole("heading", { name: "콘텐츠" })).toBeVisible();
+    await expect(page.getByText("설 연휴 임시보호 봉사자를 찾습니다")).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/console-content.png", fullPage: true });
+
+    // Create.
+    await page.getByPlaceholder("공지 제목").fill("여름 봉사 모집");
+    await page.getByPlaceholder("내용을 입력하세요.").fill("무더위에도 함께해 주실 봉사자를 찾아요.");
+    await page.getByRole("button", { name: "게시" }).click();
+    await expect(page.getByText("공지를 게시했어요.")).toBeVisible();
+
+    const created = page.getByRole("article").filter({ hasText: "여름 봉사 모집" });
+    await expect(created).toBeVisible();
+
+    // Edit.
+    await created.getByRole("button", { name: "수정" }).click();
+    await expect(page.getByRole("heading", { name: "공지 수정" })).toBeVisible();
+    await page.getByPlaceholder("공지 제목").fill("여름 정기 봉사");
+    await page.getByRole("button", { name: "저장" }).click();
+    await expect(page.getByText("공지를 수정했어요.")).toBeVisible();
+    await expect(page.getByRole("article").filter({ hasText: "여름 정기 봉사" })).toBeVisible();
+
+    // Delete.
+    await page
+      .getByRole("article")
+      .filter({ hasText: "여름 정기 봉사" })
+      .getByRole("button", { name: "삭제" })
+      .click();
+    await expect(page.getByText("공지를 삭제했어요.")).toBeVisible();
+    await expect(page.getByText("여름 정기 봉사")).toHaveCount(0);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -55,6 +55,9 @@ const ConsoleAnimalsPage = lazy(() =>
 const ConsoleVolunteerPage = lazy(() =>
   import("@/pages/console-volunteer").then((module) => ({ default: module.ConsoleVolunteerPage })),
 );
+const ConsoleContentPage = lazy(() =>
+  import("@/pages/console-content").then((module) => ({ default: module.ConsoleContentPage })),
+);
 
 // Warm the common route chunks during idle time so navigating to them shows the
 // screen's own skeleton (data Suspense) rather than the chunk-load spinner.
@@ -108,6 +111,7 @@ export const AppRouter = () => {
               <Route path={ROUTES.CONSOLE} element={<Navigate to={ROUTES.CONSOLE_ANIMALS} replace />} />
               <Route path={ROUTES.CONSOLE_ANIMALS} element={<ConsoleAnimalsPage />} />
               <Route path={ROUTES.CONSOLE_VOLUNTEER} element={<ConsoleVolunteerPage />} />
+              <Route path={ROUTES.CONSOLE_CONTENT} element={<ConsoleContentPage />} />
             </Route>
           </Route>
 

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
@@ -7,7 +7,8 @@ export const styles = stylex.create({
     display: "flex",
     flexDirection: { default: "column", [DESKTOP]: "row" },
     minHeight: "100dvh",
-    backgroundColor: "var(--hb-color-canvas)",
+    // White content area; the sidebar keeps its own light-gray rail below.
+    backgroundColor: "var(--hb-color-surface)",
   },
   sidebar: {
     display: "flex",
@@ -61,15 +62,24 @@ export const styles = stylex.create({
     gap: 3,
     flex: 1,
   },
+  itemLink: {
+    display: "block",
+    borderRadius: 10,
+    textDecoration: "none",
+  },
   item: {
     display: "flex",
     flexDirection: "column",
     gap: 1,
     padding: "9px 12px",
     borderRadius: 10,
-    textDecoration: "none",
     color: "var(--hb-color-text-primary)",
     backgroundColor: { default: "transparent", ":hover": "var(--hb-color-surface)" },
+  },
+  // Selected menu — filled with the brand green, label/hint go white.
+  itemActive: {
+    color: "#fff",
+    backgroundColor: { default: "var(--hb-color-accent)", ":hover": "var(--hb-color-accent)" },
   },
   itemDisabled: {
     cursor: "default",
@@ -79,14 +89,17 @@ export const styles = stylex.create({
   itemLabel: {
     fontSize: "0.9375rem",
     fontWeight: 600,
+    color: "inherit",
   },
   itemHint: {
     fontSize: "0.75rem",
-    color: "var(--hb-color-text-secondary)",
+    color: "inherit",
+    opacity: 0.65,
   },
   itemSoon: {
     fontSize: "0.6875rem",
-    color: "var(--hb-color-text-disabled)",
+    color: "inherit",
+    opacity: 0.5,
   },
   foot: {
     display: "flex",

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
@@ -7,6 +7,10 @@ export const styles = stylex.create({
     display: "flex",
     flexDirection: { default: "column", [DESKTOP]: "row" },
     minHeight: "100dvh",
+    // On desktop the shell is a fixed viewport: the sidebar stays put and only
+    // the main content scrolls. On phones it falls back to normal page scroll.
+    height: { [DESKTOP]: "100dvh" },
+    overflow: { [DESKTOP]: "hidden" },
     // White content area; the sidebar keeps its own light-gray rail below.
     backgroundColor: "var(--hb-color-surface)",
   },
@@ -18,6 +22,7 @@ export const styles = stylex.create({
     boxSizing: "border-box",
     padding: 14,
     gap: 10,
+    overflowY: { [DESKTOP]: "auto" },
     borderInlineEndWidth: { default: 0, [DESKTOP]: 1 },
     borderInlineEndStyle: "solid",
     borderInlineEndColor: "var(--hb-color-border)",
@@ -133,6 +138,12 @@ export const styles = stylex.create({
   main: {
     flex: 1,
     minWidth: 0,
+    minHeight: 0,
+    // A fixed pane on desktop so each screen manages its own scroll regions;
+    // normal page scroll on phones.
+    display: "flex",
+    flexDirection: "column",
+    overflowY: { default: "visible", [DESKTOP]: "hidden" },
     padding: "clamp(16px, 4vw, 32px)",
   },
 });

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
@@ -11,7 +11,7 @@ const MENU: { label: string; hint: string; to: string | null }[] = [
   { label: "동물 관리", hint: "등록·상태", to: ROUTES.CONSOLE_ANIMALS },
   { label: "신청 처리", hint: "심사·문의", to: null },
   { label: "봉사 일정", hint: "모집·승인", to: ROUTES.CONSOLE_VOLUNTEER },
-  { label: "콘텐츠", hint: "공지·FAQ", to: null },
+  { label: "콘텐츠", hint: "공지·FAQ", to: ROUTES.CONSOLE_CONTENT },
   { label: "설문 빌더", hint: "폼 정의", to: null },
   { label: "스태프 관리", hint: "승격·역할", to: null },
   { label: "통계", hint: "KPI", to: null },
@@ -34,26 +34,27 @@ export const ConsoleShellLayout = () => (
       <nav {...stylex.props(styles.nav)}>
         {MENU.map((item) =>
           item.to ? (
-            <NavLink
-              key={item.label}
-              to={item.to}
-              {...stylex.props(styles.item)}
-              style={({ isActive }) => (isActive ? activeStyle : undefined)}
-            >
-              <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
-              <span {...stylex.props(styles.itemHint)}>{item.hint}</span>
+            <NavLink key={item.label} to={item.to} {...stylex.props(styles.itemLink)}>
+              {({ isActive }) => (
+                <span {...stylex.props(styles.item, isActive && styles.itemActive)}>
+                  <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
+                  <span {...stylex.props(styles.itemHint)}>{item.hint}</span>
+                </span>
+              )}
             </NavLink>
           ) : (
-            <span key={item.label} {...stylex.props(styles.item, styles.itemDisabled)}>
-              <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
-              <span {...stylex.props(styles.itemSoon)}>준비 중</span>
+            <span key={item.label} {...stylex.props(styles.itemLink)}>
+              <span {...stylex.props(styles.item, styles.itemDisabled)}>
+                <span {...stylex.props(styles.itemLabel)}>{item.label}</span>
+                <span {...stylex.props(styles.itemSoon)}>준비 중</span>
+              </span>
             </span>
           ),
         )}
       </nav>
 
       <div {...stylex.props(styles.foot)}>
-        <span {...stylex.props(styles.scope)}>소속 보호소 스코프</span>
+        <span {...stylex.props(styles.scope)}>우리 보호소 정보만 관리할 수 있어요</span>
         <Link to={ROUTES.HOME} {...stylex.props(styles.exit)}>
           ← 서비스로 나가기
         </Link>
@@ -67,9 +68,3 @@ export const ConsoleShellLayout = () => (
     </main>
   </div>
 );
-
-const activeStyle = {
-  backgroundColor: "var(--hb-color-surface)",
-  boxShadow: "0 1px 3px rgba(0, 0, 0, 0.1)",
-  color: "var(--hb-color-accent-dark, var(--hb-color-accent))",
-} as const;

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -4,6 +4,7 @@ import { toShelter, toShelterAnnouncement, toShelterFaq } from "../lib/to-shelte
 import { toShelterListItem } from "../lib/to-shelter-list-item.lib";
 import { toShelterMarker } from "../lib/to-shelter-marker.lib";
 import {
+  createdIdSchema,
   shelterAnnouncementsSchema,
   shelterFaqsSchema,
   shelterListPageSchema,
@@ -19,7 +20,7 @@ import type {
   ShelterMarker,
   ShelterStats,
 } from "../model/shelter.model";
-import type { ShelterSearchParams } from "./shelter.type";
+import type { AnnouncementInput, CreatedId, ShelterSearchParams } from "./shelter.type";
 
 /** A converted page of shelters plus the cursor to the next one. */
 export interface ShelterListResult {
@@ -82,6 +83,20 @@ export const getShelterAnnouncements = (
         .map(toShelterAnnouncement)
         .sort((a, b) => Number(b.pinned) - Number(a.pinned)),
     );
+
+/** Post a shelter announcement (§7.4 console, staff). */
+export const postAnnouncement = (shelterId: string, input: AnnouncementInput): Promise<CreatedId> =>
+  httpClient
+    .post(`/shelters/${shelterId}/announcements`, input)
+    .then(parseResponse(createdIdSchema, "POST /shelters/:id/announcements"));
+
+/** Edit an announcement (staff). */
+export const editAnnouncement = (id: string, input: AnnouncementInput): Promise<void> =>
+  httpClient.patch(`/announcements/${id}`, input).then(() => undefined);
+
+/** Delete an announcement (staff). */
+export const deleteAnnouncement = (id: string): Promise<void> =>
+  httpClient.delete(`/announcements/${id}`).then(() => undefined);
 
 /** Fetch a shelter's FAQ entries. */
 export const getShelterFaqs = (

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
@@ -1,0 +1,21 @@
+import { mutationOptions } from "hobom-data";
+import { deleteAnnouncement, editAnnouncement, postAnnouncement } from "./shelter.api";
+import type { AnnouncementInput } from "./shelter.type";
+
+export const shelterMutations = {
+  createAnnouncement: (shelterId: string) =>
+    mutationOptions({
+      mutationFn: (input: AnnouncementInput) => postAnnouncement(shelterId, input),
+    }),
+
+  updateAnnouncement: () =>
+    mutationOptions({
+      mutationFn: (vars: { id: string; input: AnnouncementInput }) =>
+        editAnnouncement(vars.id, vars.input),
+    }),
+
+  removeAnnouncement: () =>
+    mutationOptions({
+      mutationFn: (id: string) => deleteAnnouncement(id),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -1,6 +1,7 @@
 import { HoBomSchema } from "hobom-schema";
 import type { Schema } from "hobom-schema";
 import type {
+  CreatedId,
   RawShelter,
   RawShelterAnnouncement,
   RawShelterFaq,
@@ -93,4 +94,9 @@ export const shelterStatsSchema: Schema<RawShelterStats> = HoBomSchema.object({
   adoptedCount: HoBomSchema.number(),
   shelteredCount: HoBomSchema.number(),
   availableCount: HoBomSchema.number(),
+});
+
+/** Create responses returning just an id (announcement/faq). */
+export const createdIdSchema: Schema<CreatedId> = HoBomSchema.object({
+  id: HoBomSchema.string(),
 });

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -93,3 +93,15 @@ export interface RawShelterStats {
   shelteredCount: number;
   availableCount: number;
 }
+
+/** `POST/PATCH` announcement request (staff). */
+export interface AnnouncementInput {
+  title: string;
+  body: string;
+  pinned: boolean;
+}
+
+/** Create responses that return just an id. */
+export interface CreatedId {
+  id: string;
+}

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -1,5 +1,7 @@
 export { ShelterCard } from "./ui/ShelterCard";
 export { shelterQueries } from "./api/shelter.queries";
+export { shelterMutations } from "./api/shelter.mutations";
+export type { AnnouncementInput } from "./api/shelter.type";
 export { toShelter } from "./lib/to-shelter.lib";
 export { formatShelterAddress } from "./lib/format-shelter-address.lib";
 export { operatingYears } from "./lib/operating-years.lib";

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.styles.ts
@@ -1,49 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 
-const COLUMNS = "44px 1.3fr 1fr 64px";
-
 export const styles = stylex.create({
-  table: {
-    borderWidth: 1,
-    borderStyle: "solid",
-    borderColor: "var(--hb-color-border)",
-    borderRadius: 14,
-    overflow: "hidden",
-    backgroundColor: "var(--hb-color-surface)",
-  },
-  head: {
-    display: "grid",
-    gridTemplateColumns: COLUMNS,
-    alignItems: "center",
-    gap: 10,
-    padding: "10px 14px",
-    borderBottomWidth: 1,
-    borderBottomStyle: "solid",
-    borderBottomColor: "var(--hb-color-border)",
-    fontSize: "0.75rem",
-    fontWeight: 700,
-    color: "var(--hb-color-text-secondary)",
-    backgroundColor: "var(--hb-color-surface-subtle)",
-  },
-  row: {
-    display: "grid",
-    gridTemplateColumns: COLUMNS,
-    alignItems: "center",
-    gap: 10,
-    width: "100%",
-    padding: "10px 14px",
-    borderWidth: 0,
-    borderBottomWidth: 1,
-    borderBottomStyle: "solid",
-    borderBottomColor: "var(--hb-color-border)",
-    textAlign: "start",
-    cursor: "pointer",
-    backgroundColor: { default: "var(--hb-color-surface)", ":hover": "var(--hb-color-surface-subtle)" },
-  },
-  rowActive: {
-    backgroundColor: "var(--hb-color-accent-subtle, oklch(0.95 0.03 155))",
-  },
   thumb: {
+    display: "block",
     width: 40,
     height: 40,
     borderRadius: 8,
@@ -51,6 +10,7 @@ export const styles = stylex.create({
     backgroundColor: "var(--hb-color-surface-subtle)",
   },
   thumbEmpty: {
+    display: "block",
     width: 40,
     height: 40,
     borderRadius: 8,
@@ -65,18 +25,10 @@ export const styles = stylex.create({
     fontSize: "0.9375rem",
     fontWeight: 700,
     color: "var(--hb-color-text-primary)",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
   },
   breed: {
     fontSize: "0.75rem",
     color: "var(--hb-color-text-secondary)",
-  },
-  count: {
-    fontSize: "0.875rem",
-    color: "var(--hb-color-text-secondary)",
-    textAlign: "end",
   },
   empty: {
     padding: "40px 16px",

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
@@ -1,7 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
 import type { Animal } from "@/entities/animal";
 import { AnimalRosterRow } from "./AnimalRosterRow";
 import { styles } from "./AnimalRoster.styles";
+
+/** Green sticky header with white text (overrides the DS default surface bg). */
+const HEADER = { backgroundColor: "var(--hb-color-accent)", color: "#fff" } as const;
 
 interface AnimalRosterProps {
   animals: Animal[];
@@ -9,33 +13,39 @@ interface AnimalRosterProps {
   onEdit: (animalId: string) => void;
 }
 
-/** The shelter's animals as a table (§7.1) — thumbnail · 이름·품종 · 상태 · 신청.
- *  Selecting a row opens it in the edit form. */
+/** The shelter's animals as a DS table with a sticky header (§7.1). Selecting a
+ *  row opens it in the edit form. */
 export const AnimalRoster = ({ animals, editingId, onEdit }: AnimalRosterProps) => {
   if (animals.length === 0) {
-    return (
-      <div {...stylex.props(styles.table)}>
-        <p {...stylex.props(styles.empty)}>아직 등록한 동물이 없어요.</p>
-      </div>
-    );
+    return <p {...stylex.props(styles.empty)}>아직 등록한 동물이 없어요.</p>;
   }
 
   return (
-    <div {...stylex.props(styles.table)}>
-      <div {...stylex.props(styles.head)}>
-        <span />
-        <span>이름·품종</span>
-        <span>상태</span>
-        <span {...stylex.props(styles.count)}>신청</span>
-      </div>
-      {animals.map((animal) => (
-        <AnimalRosterRow
-          key={animal.id}
-          animal={animal}
-          active={animal.id === editingId}
-          onEdit={() => onEdit(animal.id)}
-        />
-      ))}
-    </div>
+    <Hb.Table.Root size="small" stickyHeader style={{ width: "100%" }}>
+      <Hb.Table.Head>
+        <Hb.Table.Row>
+          <Hb.Table.Cell scope="col" width={52} style={HEADER} />
+          <Hb.Table.Cell scope="col" style={HEADER}>
+            이름·품종
+          </Hb.Table.Cell>
+          <Hb.Table.Cell scope="col" style={HEADER}>
+            상태
+          </Hb.Table.Cell>
+          <Hb.Table.Cell scope="col" align="right" style={HEADER}>
+            신청
+          </Hb.Table.Cell>
+        </Hb.Table.Row>
+      </Hb.Table.Head>
+      <Hb.Table.Body>
+        {animals.map((animal) => (
+          <AnimalRosterRow
+            key={animal.id}
+            animal={animal}
+            active={animal.id === editingId}
+            onEdit={() => onEdit(animal.id)}
+          />
+        ))}
+      </Hb.Table.Body>
+    </Hb.Table.Root>
   );
 };

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
@@ -16,35 +16,41 @@ const STATUS_COLOR: Record<
   반환: "default",
 };
 
+const ACTIVE = { backgroundColor: "var(--hb-color-accent-subtle, oklch(0.95 0.03 155))" };
+
 interface AnimalRosterRowProps {
   animal: Animal;
   active: boolean;
   onEdit: () => void;
 }
 
-/** A table row — thumbnail, name·breed, status, and a signup-count slot (shown
- *  as — until the backend exposes counts). Selects the animal for editing. */
+/** A DS-table row — thumbnail, name·breed, status, and a signup-count slot.
+ *  Selecting it opens the animal in the edit form. */
 export const AnimalRosterRow = ({ animal, active, onEdit }: AnimalRosterRowProps) => {
   const statusLabel = STATUS_LABEL[animal.status];
 
   return (
-    <button type="button" {...stylex.props(styles.row, active && styles.rowActive)} onClick={onEdit}>
-      {animal.photoUrl ? (
-        <img src={mediaUrl(animal.photoUrl)} alt="" {...stylex.props(styles.thumb)} />
-      ) : (
-        <span {...stylex.props(styles.thumbEmpty)} />
-      )}
-      <span {...stylex.props(styles.nameCell)}>
-        <span {...stylex.props(styles.name)}>{animal.name}</span>
-        <span {...stylex.props(styles.breed)}>
-          {SPECIES_LABEL[animal.species]}
-          {animal.breed ? ` · ${animal.breed}` : ""}
+    <Hb.Table.Row hover selected={active} onClick={onEdit} style={{ cursor: "pointer", ...(active ? ACTIVE : {}) }}>
+      <Hb.Table.Cell>
+        {animal.photoUrl ? (
+          <img src={mediaUrl(animal.photoUrl)} alt="" {...stylex.props(styles.thumb)} />
+        ) : (
+          <span {...stylex.props(styles.thumbEmpty)} />
+        )}
+      </Hb.Table.Cell>
+      <Hb.Table.Cell>
+        <span {...stylex.props(styles.nameCell)}>
+          <span {...stylex.props(styles.name)}>{animal.name}</span>
+          <span {...stylex.props(styles.breed)}>
+            {SPECIES_LABEL[animal.species]}
+            {animal.breed ? ` · ${animal.breed}` : ""}
+          </span>
         </span>
-      </span>
-      <span>
+      </Hb.Table.Cell>
+      <Hb.Table.Cell>
         <Hb.Chip label={statusLabel} size="small" variant="soft" color={STATUS_COLOR[statusLabel]} />
-      </span>
-      <span {...stylex.props(styles.count)}>—</span>
-    </button>
+      </Hb.Table.Cell>
+      <Hb.Table.Cell align="right">—</Hb.Table.Cell>
+    </Hb.Table.Row>
   );
 };

--- a/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
@@ -4,7 +4,7 @@ const WIDE = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
   root: {
-    maxWidth: 1080,
+    width: "100%",
   },
   title: {
     margin: 0,
@@ -37,7 +37,7 @@ export const styles = stylex.create({
   // Table on the left, register/edit form on the right (§7.1).
   layout: {
     display: "grid",
-    gridTemplateColumns: { default: "1fr", [WIDE]: "1.1fr 1fr" },
+    gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
     alignItems: "start",
     gap: 20,
   },

--- a/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
+++ b/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.styles.ts
@@ -4,7 +4,11 @@ const WIDE = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
   root: {
+    display: "flex",
+    flexDirection: "column",
     width: "100%",
+    height: { [WIDE]: "100%" },
+    minHeight: 0,
   },
   title: {
     margin: 0,
@@ -22,6 +26,7 @@ export const styles = stylex.create({
     alignItems: "center",
     gap: 10,
     marginBlock: 18,
+    flexShrink: 0,
   },
   count: {
     fontSize: "1rem",
@@ -34,11 +39,29 @@ export const styles = stylex.create({
   spacer: {
     flex: 1,
   },
-  // Table on the left, register/edit form on the right (§7.1).
+  // Full-width 1:1 body; each column scrolls on its own (list left, form right).
   layout: {
     display: "grid",
     gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
     alignItems: "start",
     gap: 20,
+    flex: { [WIDE]: 1 },
+    minHeight: 0,
+  },
+  // The list column is a bordered, scrollable table container.
+  listCol: {
+    minHeight: 0,
+    height: { [WIDE]: "100%" },
+    overflowY: { [WIDE]: "auto" },
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 14,
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  formCol: {
+    minHeight: 0,
+    height: { [WIDE]: "100%" },
+    overflowY: { [WIDE]: "auto" },
   },
 });

--- a/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/ConsoleAnimals.tsx
@@ -8,8 +8,8 @@ import { EditForm } from "./EditForm";
 import { RegisterForm } from "./RegisterForm";
 import { styles } from "./ConsoleAnimals.styles";
 
-/** §7.1 동물 관리: the shelter's roster as a table on the left, a register/edit
- *  form on the right. Selecting a row edits it; "+ 동물 등록" returns to register. */
+/** §7.1 동물 관리: the roster (a sticky-header table) scrolls on the left, the
+ *  register/edit form scrolls on the right. Selecting a row edits it. */
 export const ConsoleAnimals = ({ shelterId }: { shelterId: string }) => {
   const { animals, editingId, edit, clearEdit, registerAnimal, updateAnimal, saving } =
     useConsoleAnimals(shelterId);
@@ -17,7 +17,7 @@ export const ConsoleAnimals = ({ shelterId }: { shelterId: string }) => {
   return (
     <div {...stylex.props(styles.root)}>
       <h1 {...stylex.props(styles.title)}>동물 관리</h1>
-      <p {...stylex.props(styles.subtitle)}>등록·수정 · 이미지 · 상태</p>
+      <p {...stylex.props(styles.subtitle)}>우리 보호소 동물 등록·수정</p>
 
       <div {...stylex.props(styles.toolbar)}>
         <span {...stylex.props(styles.count)}>
@@ -30,21 +30,25 @@ export const ConsoleAnimals = ({ shelterId }: { shelterId: string }) => {
       </div>
 
       <div {...stylex.props(styles.layout)}>
-        <AnimalRoster animals={animals} editingId={editingId} onEdit={edit} />
+        <div {...stylex.props(styles.listCol)}>
+          <AnimalRoster animals={animals} editingId={editingId} onEdit={edit} />
+        </div>
 
-        {editingId ? (
-          <Suspense fallback={<LoadingState />}>
-            <EditForm
-              key={editingId}
-              animalId={editingId}
-              onUpdate={updateAnimal}
-              onCancel={clearEdit}
-              saving={saving}
-            />
-          </Suspense>
-        ) : (
-          <RegisterForm onRegister={registerAnimal} saving={saving} />
-        )}
+        <div {...stylex.props(styles.formCol)}>
+          {editingId ? (
+            <Suspense fallback={<LoadingState />}>
+              <EditForm
+                key={editingId}
+                animalId={editingId}
+                onUpdate={updateAnimal}
+                onCancel={clearEdit}
+                saving={saving}
+              />
+            </Suspense>
+          ) : (
+            <RegisterForm onRegister={registerAnimal} saving={saving} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/hobom-angel/src/features/console-content/index.ts
+++ b/apps/hobom-angel/src/features/console-content/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleContent } from "./ui/ConsoleContent";

--- a/apps/hobom-angel/src/features/console-content/model/useConsoleAnnouncements.ts
+++ b/apps/hobom-angel/src/features/console-content/model/useConsoleAnnouncements.ts
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useDataLot, useMutation, useSuspenseQuery } from "hobom-data";
+import { shelterMutations, shelterQueries } from "@/entities/shelter";
+import { useToast } from "@/shared/model";
+import type { AnnouncementInput, ShelterAnnouncement } from "@/entities/shelter";
+
+/** The console's announcement CMS for a shelter (§7.4): the list plus create /
+ *  edit / delete, invalidating the list so a change shows immediately. Tracks
+ *  which announcement is being edited (null = a new post). */
+export const useConsoleAnnouncements = (shelterId: string) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+  const [editing, setEditing] = useState<ShelterAnnouncement | null>(null);
+
+  const listOptions = shelterQueries.announcements(shelterId);
+  const { data: announcements } = useSuspenseQuery(listOptions);
+
+  const settle = (message: string) => {
+    openSuccessToast({ message });
+    void dataLot.invalidateQueries(listOptions);
+    setEditing(null);
+  };
+  const onError = (error: Error) => openErrorToast({ message: error.message || "저장에 실패했어요." });
+
+  const create = useMutation({
+    ...shelterMutations.createAnnouncement(shelterId),
+    onSuccess: () => settle("공지를 게시했어요."),
+    onError,
+  });
+  const update = useMutation({
+    ...shelterMutations.updateAnnouncement(),
+    onSuccess: () => settle("공지를 수정했어요."),
+    onError,
+  });
+  const remove = useMutation({
+    ...shelterMutations.removeAnnouncement(),
+    onSuccess: () => settle("공지를 삭제했어요."),
+    onError,
+  });
+
+  return {
+    announcements,
+    editing,
+    edit: setEditing,
+    clearEdit: () => setEditing(null),
+    createAnnouncement: (input: AnnouncementInput) => create.mutate(input),
+    updateAnnouncement: (input: AnnouncementInput) => {
+      if (editing) update.mutate({ id: editing.id, input });
+    },
+    removeAnnouncement: (id: string) => remove.mutate(id),
+    saving: create.isPending || update.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/console-content/ui/AnnouncementForm.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/AnnouncementForm.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { AnnouncementInput, ShelterAnnouncement } from "@/entities/shelter";
+import { styles } from "./ConsoleContent.styles";
+
+interface AnnouncementFormProps {
+  editing: ShelterAnnouncement | null;
+  onCreate: (input: AnnouncementInput) => void;
+  onUpdate: (input: AnnouncementInput) => void;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+/** Create or edit a shelter announcement (제목 · 내용 · 상단 고정). */
+export const AnnouncementForm = ({
+  editing,
+  onCreate,
+  onUpdate,
+  onCancel,
+  saving,
+}: AnnouncementFormProps) => {
+  const [title, setTitle] = useState(editing?.title ?? "");
+  const [body, setBody] = useState(editing?.body ?? "");
+  const [pinned, setPinned] = useState(editing?.pinned ?? false);
+
+  const canSubmit = title.trim().length > 0 && body.trim().length > 0 && !saving;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    const input = { title: title.trim(), body: body.trim(), pinned };
+
+    if (editing) {
+      onUpdate(input);
+
+      return;
+    }
+
+    onCreate(input);
+    setTitle("");
+    setBody("");
+    setPinned(false);
+  };
+
+  return (
+    <section {...stylex.props(styles.card)}>
+      <h3 {...stylex.props(styles.heading)}>{editing ? "공지 수정" : "새 공지"}</h3>
+
+      <input
+        {...stylex.props(styles.input)}
+        value={title}
+        placeholder="공지 제목"
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <textarea
+        {...stylex.props(styles.input, styles.textarea)}
+        value={body}
+        placeholder="내용을 입력하세요."
+        onChange={(event) => setBody(event.target.value)}
+      />
+      <label {...stylex.props(styles.check)}>
+        <input
+          type="checkbox"
+          checked={pinned}
+          onChange={(event) => setPinned(event.target.checked)}
+        />
+        상단 고정
+      </label>
+
+      <div {...stylex.props(styles.actions)}>
+        {editing && (
+          <Hb.Button variant="ghost" onClick={onCancel}>
+            취소
+          </Hb.Button>
+        )}
+        <Hb.Button variant="primary" onClick={submit} disabled={!canSubmit} loading={saving}>
+          {editing ? "저장" : "게시"}
+        </Hb.Button>
+      </div>
+    </section>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/AnnouncementList.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/AnnouncementList.tsx
@@ -1,0 +1,51 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { ShelterAnnouncement } from "@/entities/shelter";
+import { styles } from "./ConsoleContent.styles";
+
+interface AnnouncementListProps {
+  announcements: ShelterAnnouncement[];
+  editingId: string | null;
+  onEdit: (announcement: ShelterAnnouncement) => void;
+  onDelete: (id: string) => void;
+}
+
+/** The shelter's announcements — pinned first, each with edit / delete. */
+export const AnnouncementList = ({
+  announcements,
+  editingId,
+  onEdit,
+  onDelete,
+}: AnnouncementListProps) => {
+  if (announcements.length === 0) {
+    return <p {...stylex.props(styles.empty)}>아직 등록한 공지가 없어요.</p>;
+  }
+
+  return (
+    <div {...stylex.props(styles.list)}>
+      {announcements.map((announcement) => (
+        <article
+          key={announcement.id}
+          {...stylex.props(styles.row, announcement.id === editingId && styles.rowActive)}
+        >
+          <div {...stylex.props(styles.rowHead)}>
+            <span {...stylex.props(styles.rowTitle)}>{announcement.title}</span>
+            {announcement.pinned && (
+              <Hb.Chip label="고정" size="small" variant="soft" color="primary" />
+            )}
+            <span {...stylex.props(styles.spacer)} />
+            <div {...stylex.props(styles.rowActions)}>
+              <Hb.Button variant="ghost" size="small" onClick={() => onEdit(announcement)}>
+                수정
+              </Hb.Button>
+              <Hb.Button variant="ghost" size="small" onClick={() => onDelete(announcement.id)}>
+                삭제
+              </Hb.Button>
+            </div>
+          </div>
+          <p {...stylex.props(styles.preview)}>{announcement.body}</p>
+        </article>
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/AnnouncementManager.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/AnnouncementManager.tsx
@@ -19,20 +19,24 @@ export const AnnouncementManager = ({ shelterId }: { shelterId: string }) => {
 
   return (
     <div {...stylex.props(styles.layout)}>
-      <AnnouncementForm
-        key={editing?.id ?? "new"}
-        editing={editing}
-        onCreate={createAnnouncement}
-        onUpdate={updateAnnouncement}
-        onCancel={clearEdit}
-        saving={saving}
-      />
-      <AnnouncementList
-        announcements={announcements}
-        editingId={editing?.id ?? null}
-        onEdit={edit}
-        onDelete={removeAnnouncement}
-      />
+      <div {...stylex.props(styles.col)}>
+        <AnnouncementForm
+          key={editing?.id ?? "new"}
+          editing={editing}
+          onCreate={createAnnouncement}
+          onUpdate={updateAnnouncement}
+          onCancel={clearEdit}
+          saving={saving}
+        />
+      </div>
+      <div {...stylex.props(styles.col)}>
+        <AnnouncementList
+          announcements={announcements}
+          editingId={editing?.id ?? null}
+          onEdit={edit}
+          onDelete={removeAnnouncement}
+        />
+      </div>
     </div>
   );
 };

--- a/apps/hobom-angel/src/features/console-content/ui/AnnouncementManager.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/AnnouncementManager.tsx
@@ -1,0 +1,38 @@
+import * as stylex from "@stylexjs/stylex";
+import { useConsoleAnnouncements } from "../model/useConsoleAnnouncements";
+import { AnnouncementForm } from "./AnnouncementForm";
+import { AnnouncementList } from "./AnnouncementList";
+import { styles } from "./ConsoleContent.styles";
+
+/** 공지사항 management — the form on the left, the list on the right (1:1). */
+export const AnnouncementManager = ({ shelterId }: { shelterId: string }) => {
+  const {
+    announcements,
+    editing,
+    edit,
+    clearEdit,
+    createAnnouncement,
+    updateAnnouncement,
+    removeAnnouncement,
+    saving,
+  } = useConsoleAnnouncements(shelterId);
+
+  return (
+    <div {...stylex.props(styles.layout)}>
+      <AnnouncementForm
+        key={editing?.id ?? "new"}
+        editing={editing}
+        onCreate={createAnnouncement}
+        onUpdate={updateAnnouncement}
+        onCancel={clearEdit}
+        saving={saving}
+      />
+      <AnnouncementList
+        announcements={announcements}
+        editingId={editing?.id ?? null}
+        onEdit={edit}
+        onDelete={removeAnnouncement}
+      />
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
@@ -1,0 +1,157 @@
+import * as stylex from "@stylexjs/stylex";
+
+const WIDE = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  root: {
+    width: "100%",
+  },
+  // Full-width body split 1:1 — form on the left, the list on the right.
+  layout: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
+    alignItems: "start",
+    gap: 20,
+  },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: {
+    margin: "4px 0 0",
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  subtabs: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 6,
+    marginBlock: 18,
+  },
+  tab: {
+    padding: "7px 14px",
+    borderRadius: 999,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    fontSize: "0.875rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  tabActive: {
+    color: "#fff",
+    borderColor: "var(--hb-color-accent)",
+    backgroundColor: "var(--hb-color-accent)",
+  },
+  tabSoon: {
+    opacity: 0.5,
+  },
+  // Form + list stacked.
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+    padding: 20,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  heading: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  input: {
+    width: "100%",
+    boxSizing: "border-box",
+    padding: "9px 12px",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: 10,
+    fontSize: "0.9375rem",
+    fontFamily: "inherit",
+    color: "var(--hb-color-text-primary)",
+    backgroundColor: "var(--hb-color-surface)",
+    outline: "none",
+  },
+  textarea: {
+    minHeight: 96,
+    resize: "vertical",
+  },
+  check: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-primary)",
+    cursor: "pointer",
+  },
+  actions: {
+    display: "flex",
+    justifyContent: "flex-end",
+    gap: 8,
+  },
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  empty: {
+    padding: "36px 16px",
+    textAlign: "center",
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.9375rem",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: "var(--hb-color-border)",
+  },
+  row: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  rowActive: {
+    borderColor: "var(--hb-color-accent)",
+    boxShadow: "0 0 0 1px var(--hb-color-accent)",
+  },
+  rowHead: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  rowTitle: {
+    fontSize: "0.9375rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  preview: {
+    margin: 0,
+    fontSize: "0.875rem",
+    color: "var(--hb-color-text-secondary)",
+    overflow: "hidden",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+  },
+  rowActions: {
+    display: "flex",
+    gap: 4,
+  },
+  spacer: {
+    flex: 1,
+  },
+});

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
@@ -4,14 +4,26 @@ const WIDE = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
   root: {
+    display: "flex",
+    flexDirection: "column",
     width: "100%",
+    height: { [WIDE]: "100%" },
+    minHeight: 0,
   },
-  // Full-width body split 1:1 — form on the left, the list on the right.
+  // Full-width body split 1:1 — form on the left, the list on the right; each
+  // column scrolls on its own.
   layout: {
     display: "grid",
     gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
     alignItems: "start",
     gap: 20,
+    flex: { [WIDE]: 1 },
+    minHeight: 0,
+  },
+  col: {
+    minHeight: 0,
+    height: { [WIDE]: "100%" },
+    overflowY: { [WIDE]: "auto" },
   },
   title: {
     margin: 0,

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { LoadingState } from "@/shared/ui";
+import { AnnouncementManager } from "./AnnouncementManager";
+import { styles } from "./ConsoleContent.styles";
+
+/** §7.4 콘텐츠 (셀프서비스 CMS). 공지사항 management is wired; 보호소 소개 / FAQ
+ *  follow in later PRs (shown as upcoming tabs). Scoped to the shelter. */
+const SUBTABS = [
+  { label: "공지사항", ready: true },
+  { label: "보호소 소개", ready: false },
+  { label: "FAQ", ready: false },
+];
+
+export const ConsoleContent = ({ shelterId }: { shelterId: string }) => (
+  <div {...stylex.props(styles.root)}>
+    <h1 {...stylex.props(styles.title)}>콘텐츠</h1>
+    <p {...stylex.props(styles.subtitle)}>공지·소개·FAQ를 직접 관리해요</p>
+
+    <div {...stylex.props(styles.subtabs)}>
+      {SUBTABS.map((tab) => (
+        <span
+          key={tab.label}
+          {...stylex.props(styles.tab, tab.ready ? styles.tabActive : styles.tabSoon)}
+        >
+          {tab.ready ? tab.label : `${tab.label} · 준비 중`}
+        </span>
+      ))}
+    </div>
+
+    <Suspense fallback={<LoadingState />}>
+      <AnnouncementManager shelterId={shelterId} />
+    </Suspense>
+  </div>
+);

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
@@ -4,10 +4,15 @@ const WIDE = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
   root: {
+    display: "flex",
+    flexDirection: "column",
     width: "100%",
+    height: { [WIDE]: "100%" },
+    minHeight: 0,
   },
   header: {
     marginBottom: 20,
+    flexShrink: 0,
   },
   title: {
     margin: 0,
@@ -20,10 +25,18 @@ export const styles = stylex.create({
     fontSize: "0.9375rem",
     color: "var(--hb-color-text-secondary)",
   },
+  // Full-width 1:1 body; each column scrolls on its own.
   layout: {
     display: "grid",
     gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
     alignItems: "start",
     gap: 20,
+    flex: { [WIDE]: 1 },
+    minHeight: 0,
+  },
+  col: {
+    minHeight: 0,
+    height: { [WIDE]: "100%" },
+    overflowY: { [WIDE]: "auto" },
   },
 });

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.styles.ts
@@ -4,7 +4,7 @@ const WIDE = "@media (min-width: 1024px)";
 
 export const styles = stylex.create({
   root: {
-    maxWidth: 1080,
+    width: "100%",
   },
   header: {
     marginBottom: 20,
@@ -22,7 +22,7 @@ export const styles = stylex.create({
   },
   layout: {
     display: "grid",
-    gridTemplateColumns: { default: "1fr", [WIDE]: "360px 1fr" },
+    gridTemplateColumns: { default: "1fr", [WIDE]: "1fr 1fr" },
     alignItems: "start",
     gap: 20,
   },

--- a/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.tsx
+++ b/apps/hobom-angel/src/features/console-volunteer/ui/ConsoleVolunteer.tsx
@@ -5,7 +5,7 @@ import { EventList } from "./EventList";
 import { styles } from "./ConsoleVolunteer.styles";
 
 /** §07 봉사 일정 관리: create events on the left, manage the schedule and its
- *  applicants (approve / reject) on the right. Scoped to the staff's shelter. */
+ *  applicants (approve / reject) on the right. Each column scrolls on its own. */
 export const ConsoleVolunteer = ({ shelterId }: { shelterId: string }) => {
   const { events, createEvent, creating, cancelEvent } = useConsoleVolunteer(shelterId);
 
@@ -17,8 +17,12 @@ export const ConsoleVolunteer = ({ shelterId }: { shelterId: string }) => {
       </header>
 
       <div {...stylex.props(styles.layout)}>
-        <EventForm onCreate={createEvent} submitting={creating} />
-        <EventList events={events} onCancel={cancelEvent} />
+        <div {...stylex.props(styles.col)}>
+          <EventForm onCreate={createEvent} submitting={creating} />
+        </div>
+        <div {...stylex.props(styles.col)}>
+          <EventList events={events} onCancel={cancelEvent} />
+        </div>
       </div>
     </div>
   );

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -116,6 +116,8 @@ const ANNOUNCEMENTS = [
   },
 ];
 
+let nextAnnouncement = ANNOUNCEMENTS.length + 1;
+
 const FAQS = [
   {
     id: "faq-1",
@@ -216,6 +218,50 @@ export const shelterHandlers = [
     if (!mockSession.isActive()) return unauthorized();
 
     return ok(ANNOUNCEMENTS);
+  }),
+
+  // §7.4 console — announcement CRUD.
+  http.post(mockUrl("/shelters/:shelterId/announcements"), async ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const input = (await request.json()) as { title: string; body: string; pinned: boolean };
+    const id = `ann-${nextAnnouncement}`;
+
+    nextAnnouncement += 1;
+    ANNOUNCEMENTS.unshift({
+      id,
+      title: input.title,
+      body: input.body,
+      pinned: input.pinned,
+      createdAt: "2026-07-18T00:00:00.000Z",
+    });
+
+    return ok({ id });
+  }),
+
+  http.patch(mockUrl("/announcements/:id"), async ({ params, request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const input = (await request.json()) as { title: string; body: string; pinned: boolean };
+    const announcement = ANNOUNCEMENTS.find((item) => item.id === params.id);
+
+    if (announcement) {
+      announcement.title = input.title;
+      announcement.body = input.body;
+      announcement.pinned = input.pinned;
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete(mockUrl("/announcements/:id"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const index = ANNOUNCEMENTS.findIndex((item) => item.id === params.id);
+
+    if (index >= 0) ANNOUNCEMENTS.splice(index, 1);
+
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.get(mockUrl("/shelters/:shelterId/faqs"), () => {

--- a/apps/hobom-angel/src/pages/console-content/index.ts
+++ b/apps/hobom-angel/src/pages/console-content/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleContentPage } from "./ui/ConsoleContentPage";

--- a/apps/hobom-angel/src/pages/console-content/ui/ConsoleContentPage.tsx
+++ b/apps/hobom-angel/src/pages/console-content/ui/ConsoleContentPage.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { managedShelter, useCurrentUser } from "@/entities/user";
+import { ConsoleContent } from "@/features/console-content";
+import { LoadingState, NotFoundState } from "@/shared/ui";
+
+export const ConsoleContentPage = () => {
+  const { user } = useCurrentUser();
+  const shelter = managedShelter(user);
+
+  if (!shelter) return <NotFoundState />;
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <ConsoleContent shelterId={shelter.shelterId} />
+    </Suspense>
+  );
+};

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -20,6 +20,7 @@ export const ROUTES = {
   CONSOLE: "/console",
   CONSOLE_ANIMALS: "/console/animals",
   CONSOLE_VOLUNTEER: "/console/volunteer",
+  CONSOLE_CONTENT: "/console/content",
 
   // Auth.
   LOGIN: "/login",


### PR DESCRIPTION
## What

Adds the §7.4 **콘텐츠** console screen and applies the review feedback to the console shell.

### 콘텐츠 (§7.4)
- **공지사항 CRUD** — create / edit / delete / pin, form on the left and the list on the right. Backed by new announcement staff endpoints (`POST /shelters/:id/announcements`, `PATCH` / `DELETE /announcements/:id`).
- Sub-tabs show 공지사항 (wired) with 보호소 소개 / FAQ as upcoming.

### Shell polish (from feedback)
- **White content area** — the sidebar keeps its light-gray rail.
- **Selected menu item fills with the brand green** (white label/hint).
- **Friendlier footer wording**: "소속 보호소 스코프" → "우리 보호소 정보만 관리할 수 있어요".
- The management screens (동물 / 봉사 / 콘텐츠) now run **full-width with a 1:1 two-column split**.

## Verification
- typecheck / lint clean
- 105 unit tests pass
- 41 e2e pass, incl. a new content flow (create → edit → delete an announcement)