### PR TITLE
Soften console green + clarify RESERVED status wording

### DIFF
--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.styles.ts
@@ -81,10 +81,13 @@ export const styles = stylex.create({
     color: "var(--hb-color-text-primary)",
     backgroundColor: { default: "transparent", ":hover": "var(--hb-color-surface)" },
   },
-  // Selected menu — filled with the brand green, label/hint go white.
+  // Selected menu — a soft green tint with dark-green text.
   itemActive: {
-    color: "#fff",
-    backgroundColor: { default: "var(--hb-color-accent)", ":hover": "var(--hb-color-accent)" },
+    color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
+    backgroundColor: {
+      default: "oklch(0.93 0.045 155)",
+      ":hover": "oklch(0.93 0.045 155)",
+    },
   },
   itemDisabled: {
     cursor: "default",

--- a/apps/hobom-angel/src/entities/animal/model/animal.model.ts
+++ b/apps/hobom-angel/src/entities/animal/model/animal.model.ts
@@ -43,11 +43,11 @@ export const SORT_LABEL: Record<AnimalSort, string> = {
 };
 
 /** Display label for a status; matches the AnimalCard chip labels. */
-export type AnimalStatusLabel = "입양가능" | "예약중" | "임보중" | "입양완료" | "반환";
+export type AnimalStatusLabel = "입양가능" | "입양 진행중" | "임보중" | "입양완료" | "반환";
 
 export const STATUS_LABEL: Record<AnimalStatusCode, AnimalStatusLabel> = {
   AVAILABLE: "입양가능",
-  RESERVED: "예약중",
+  RESERVED: "입양 진행중",
   FOSTERED: "임보중",
   ADOPTED: "입양완료",
   RETURNED: "반환",

--- a/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
+++ b/apps/hobom-angel/src/entities/animal/ui/AnimalCard.tsx
@@ -20,7 +20,7 @@ interface AnimalCardProps {
 
 const STATUS_COLOR = {
   입양가능: "primary",
-  예약중: "warning",
+  "입양 진행중": "warning",
   임보중: "secondary",
   입양완료: "success",
   반환: "default",

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
@@ -18,7 +18,7 @@ interface ApplyCardProps {
 
 const STATUS_COLOR = {
   입양가능: "primary",
-  예약중: "warning",
+  "입양 진행중": "warning",
   임보중: "secondary",
   입양완료: "success",
   반환: "default",

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRoster.tsx
@@ -4,8 +4,11 @@ import type { Animal } from "@/entities/animal";
 import { AnimalRosterRow } from "./AnimalRosterRow";
 import { styles } from "./AnimalRoster.styles";
 
-/** Green sticky header with white text (overrides the DS default surface bg). */
-const HEADER = { backgroundColor: "var(--hb-color-accent)", color: "#fff" } as const;
+/** Soft-green sticky header with dark-green text (overrides the DS surface bg). */
+const HEADER = {
+  backgroundColor: "oklch(0.93 0.045 155)",
+  color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
+} as const;
 
 interface AnimalRosterProps {
   animals: Animal[];

--- a/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
+++ b/apps/hobom-angel/src/features/console-animals/ui/AnimalRosterRow.tsx
@@ -10,7 +10,7 @@ const STATUS_COLOR: Record<
   "primary" | "warning" | "secondary" | "success" | "default"
 > = {
   입양가능: "primary",
-  예약중: "warning",
+  "입양 진행중": "warning",
   임보중: "secondary",
   입양완료: "success",
   반환: "default",

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
@@ -54,9 +54,9 @@ export const styles = stylex.create({
     backgroundColor: "var(--hb-color-surface)",
   },
   tabActive: {
-    color: "#fff",
-    borderColor: "var(--hb-color-accent)",
-    backgroundColor: "var(--hb-color-accent)",
+    color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
+    borderColor: "oklch(0.86 0.06 155)",
+    backgroundColor: "oklch(0.93 0.045 155)",
   },
   tabSoon: {
     opacity: 0.5,

--- a/apps/hobom-angel/src/pages/landing/model/landing.fixtures.ts
+++ b/apps/hobom-angel/src/pages/landing/model/landing.fixtures.ts
@@ -22,7 +22,7 @@ export const ANIMAL_FILTERS = ["전체", "강아지", "고양이"];
 export const ANIMALS: { name: string; status: AnimalStatusLabel; meta: string }[] = [
   { name: "콩이", status: "입양가능", meta: "강아지 · 2살 · 서울" },
   { name: "보리", status: "입양가능", meta: "고양이 · 1살 · 경기" },
-  { name: "초코", status: "예약중", meta: "강아지 · 4살 · 부산" },
+  { name: "초코", status: "입양 진행중", meta: "강아지 · 4살 · 부산" },
   { name: "나비", status: "입양가능", meta: "고양이 · 3살 · 인천" },
 ];
 


### PR DESCRIPTION
## Feedback addressed

- **The console green was too dark.** The filled brand green on the selected sidebar menu, the animal table header, and the active content sub-tab now use a **soft green tint with dark-green text** instead of a solid dark-green fill.
- **"예약중" was unclear.** The RESERVED status label is renamed **예약중 → 입양 진행중**, which reads as an adoption in progress on the browse cards, the animal detail, and the console.

## Verification
- typecheck / lint clean
- 105 unit tests pass
- console + landing e2e green