### PR TITLE
Add FAQ management to the shelter console content screen

### DIFF
--- a/apps/hobom-angel/e2e/console-content.spec.ts
+++ b/apps/hobom-angel/e2e/console-content.spec.ts
@@ -45,4 +45,24 @@ test.describe("§7.4 shelter console — content", () => {
     await expect(page.getByText("공지를 삭제했어요.")).toBeVisible();
     await expect(page.getByText("여름 정기 봉사")).toHaveCount(0);
   });
+
+  test("manages FAQ under its tab", async ({ page }) => {
+    await login(page);
+    await page.goto("console/content");
+
+    await page.getByRole("button", { name: "FAQ", exact: true }).click();
+    await expect(page.getByText("입양 절차가 어떻게 되나요?")).toBeVisible();
+
+    await page.getByPlaceholder("질문").fill("주차 공간이 있나요?");
+    await page.getByPlaceholder("답변").fill("보호소 앞에 방문자 주차가 가능해요.");
+    await page.getByRole("button", { name: "추가" }).click();
+    await expect(page.getByText("FAQ를 추가했어요.")).toBeVisible();
+
+    const created = page.getByRole("article").filter({ hasText: "주차 공간이 있나요?" });
+    await expect(created).toBeVisible();
+
+    await created.getByRole("button", { name: "삭제" }).click();
+    await expect(page.getByText("FAQ를 삭제했어요.")).toBeVisible();
+    await expect(page.getByText("주차 공간이 있나요?")).toHaveCount(0);
+  });
 });

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -20,7 +20,7 @@ import type {
   ShelterMarker,
   ShelterStats,
 } from "../model/shelter.model";
-import type { AnnouncementInput, CreatedId, ShelterSearchParams } from "./shelter.type";
+import type { AnnouncementInput, CreatedId, FaqInput, ShelterSearchParams } from "./shelter.type";
 
 /** A converted page of shelters plus the cursor to the next one. */
 export interface ShelterListResult {
@@ -107,6 +107,20 @@ export const getShelterFaqs = (
     .get(`/shelters/${shelterId}/faqs`, { signal })
     .then(parseFaqs)
     .then((items) => items.map(toShelterFaq));
+
+/** Post a shelter FAQ (§7.4 console, staff). */
+export const postFaq = (shelterId: string, input: FaqInput): Promise<CreatedId> =>
+  httpClient
+    .post(`/shelters/${shelterId}/faqs`, input)
+    .then(parseResponse(createdIdSchema, "POST /shelters/:id/faqs"));
+
+/** Edit a FAQ (staff). */
+export const editFaq = (id: string, input: FaqInput): Promise<void> =>
+  httpClient.patch(`/faqs/${id}`, input).then(() => undefined);
+
+/** Delete a FAQ (staff). */
+export const deleteFaq = (id: string): Promise<void> =>
+  httpClient.delete(`/faqs/${id}`).then(() => undefined);
 
 const EMPTY_STATS: ShelterStats = { adoptedCount: 0, shelteredCount: 0, availableCount: 0 };
 

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
@@ -1,6 +1,13 @@
 import { mutationOptions } from "hobom-data";
-import { deleteAnnouncement, editAnnouncement, postAnnouncement } from "./shelter.api";
-import type { AnnouncementInput } from "./shelter.type";
+import {
+  deleteAnnouncement,
+  deleteFaq,
+  editAnnouncement,
+  editFaq,
+  postAnnouncement,
+  postFaq,
+} from "./shelter.api";
+import type { AnnouncementInput, FaqInput } from "./shelter.type";
 
 export const shelterMutations = {
   createAnnouncement: (shelterId: string) =>
@@ -17,5 +24,20 @@ export const shelterMutations = {
   removeAnnouncement: () =>
     mutationOptions({
       mutationFn: (id: string) => deleteAnnouncement(id),
+    }),
+
+  createFaq: (shelterId: string) =>
+    mutationOptions({
+      mutationFn: (input: FaqInput) => postFaq(shelterId, input),
+    }),
+
+  updateFaq: () =>
+    mutationOptions({
+      mutationFn: (vars: { id: string; input: FaqInput }) => editFaq(vars.id, vars.input),
+    }),
+
+  removeFaq: () =>
+    mutationOptions({
+      mutationFn: (id: string) => deleteFaq(id),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -86,6 +86,7 @@ export const shelterFaqsSchema: Schema<RawShelterFaq[]> = HoBomSchema.array(
     id: HoBomSchema.string(),
     question: HoBomSchema.string(),
     answer: HoBomSchema.string(),
+    order: HoBomSchema.number(),
   }),
 );
 

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -85,6 +85,7 @@ export interface RawShelterFaq {
   id: string;
   question: string;
   answer: string;
+  order: number;
 }
 
 /** `GET /shelters/:shelterId/stats` response. */
@@ -104,4 +105,11 @@ export interface AnnouncementInput {
 /** Create responses that return just an id. */
 export interface CreatedId {
   id: string;
+}
+
+/** `POST/PATCH` FAQ request (staff). */
+export interface FaqInput {
+  question: string;
+  answer: string;
+  order: number;
 }

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -1,7 +1,7 @@
 export { ShelterCard } from "./ui/ShelterCard";
 export { shelterQueries } from "./api/shelter.queries";
 export { shelterMutations } from "./api/shelter.mutations";
-export type { AnnouncementInput } from "./api/shelter.type";
+export type { AnnouncementInput, FaqInput } from "./api/shelter.type";
 export { toShelter } from "./lib/to-shelter.lib";
 export { formatShelterAddress } from "./lib/format-shelter-address.lib";
 export { operatingYears } from "./lib/operating-years.lib";

--- a/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.ts
+++ b/apps/hobom-angel/src/entities/shelter/lib/to-shelter.lib.ts
@@ -46,4 +46,5 @@ export const toShelterFaq = (raw: RawShelterFaq): ShelterFaq => ({
   id: raw.id,
   question: raw.question,
   answer: raw.answer,
+  order: raw.order,
 });

--- a/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
+++ b/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
@@ -77,6 +77,7 @@ export interface ShelterFaq {
   id: string;
   question: string;
   answer: string;
+  order: number;
 }
 
 /** Aggregate counts shown on the About tab (§04). */

--- a/apps/hobom-angel/src/features/console-content/model/useConsoleFaqs.ts
+++ b/apps/hobom-angel/src/features/console-content/model/useConsoleFaqs.ts
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useDataLot, useMutation, useSuspenseQuery } from "hobom-data";
+import { shelterMutations, shelterQueries } from "@/entities/shelter";
+import { useToast } from "@/shared/model";
+import type { ShelterFaq } from "@/entities/shelter";
+
+/** FAQ text (order is assigned by the hook, not the form). */
+export interface FaqDraft {
+  question: string;
+  answer: string;
+}
+
+/** The console's FAQ CMS for a shelter (§7.4): the list plus create / edit /
+ *  delete. New entries append to the end; edits keep their order. */
+export const useConsoleFaqs = (shelterId: string) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+  const [editing, setEditing] = useState<ShelterFaq | null>(null);
+
+  const listOptions = shelterQueries.faqs(shelterId);
+  const { data: faqs } = useSuspenseQuery(listOptions);
+
+  const settle = (message: string) => {
+    openSuccessToast({ message });
+    void dataLot.invalidateQueries(listOptions);
+    setEditing(null);
+  };
+  const onError = (error: Error) => openErrorToast({ message: error.message || "저장에 실패했어요." });
+
+  const create = useMutation({
+    ...shelterMutations.createFaq(shelterId),
+    onSuccess: () => settle("FAQ를 추가했어요."),
+    onError,
+  });
+  const update = useMutation({
+    ...shelterMutations.updateFaq(),
+    onSuccess: () => settle("FAQ를 수정했어요."),
+    onError,
+  });
+  const remove = useMutation({
+    ...shelterMutations.removeFaq(),
+    onSuccess: () => settle("FAQ를 삭제했어요."),
+    onError,
+  });
+
+  return {
+    faqs,
+    editing,
+    edit: setEditing,
+    clearEdit: () => setEditing(null),
+    createFaq: (draft: FaqDraft) => create.mutate({ ...draft, order: faqs.length }),
+    updateFaq: (draft: FaqDraft) => {
+      if (editing) update.mutate({ id: editing.id, input: { ...draft, order: editing.order } });
+    },
+    removeFaq: (id: string) => remove.mutate(id),
+    saving: create.isPending || update.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.styles.ts
@@ -50,8 +50,10 @@ export const styles = stylex.create({
     borderColor: "var(--hb-color-border)",
     fontSize: "0.875rem",
     fontWeight: 600,
+    fontFamily: "inherit",
     color: "var(--hb-color-text-secondary)",
     backgroundColor: "var(--hb-color-surface)",
+    cursor: "pointer",
   },
   tabActive: {
     color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
@@ -60,6 +62,7 @@ export const styles = stylex.create({
   },
   tabSoon: {
     opacity: 0.5,
+    cursor: "default",
   },
   // Form + list stacked.
   card: {

--- a/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/ConsoleContent.tsx
@@ -1,35 +1,47 @@
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import * as stylex from "@stylexjs/stylex";
 import { LoadingState } from "@/shared/ui";
 import { AnnouncementManager } from "./AnnouncementManager";
+import { FaqManager } from "./FaqManager";
 import { styles } from "./ConsoleContent.styles";
 
-/** §7.4 콘텐츠 (셀프서비스 CMS). 공지사항 management is wired; 보호소 소개 / FAQ
- *  follow in later PRs (shown as upcoming tabs). Scoped to the shelter. */
-const SUBTABS = [
-  { label: "공지사항", ready: true },
-  { label: "보호소 소개", ready: false },
-  { label: "FAQ", ready: false },
-];
+type Tab = "announcements" | "faq";
 
-export const ConsoleContent = ({ shelterId }: { shelterId: string }) => (
-  <div {...stylex.props(styles.root)}>
-    <h1 {...stylex.props(styles.title)}>콘텐츠</h1>
-    <p {...stylex.props(styles.subtitle)}>공지·소개·FAQ를 직접 관리해요</p>
+/** §7.4 콘텐츠 (셀프서비스 CMS). 공지사항 and FAQ are wired; 보호소 소개 follows.
+ *  Scoped to the shelter. */
+export const ConsoleContent = ({ shelterId }: { shelterId: string }) => {
+  const [tab, setTab] = useState<Tab>("announcements");
 
-    <div {...stylex.props(styles.subtabs)}>
-      {SUBTABS.map((tab) => (
-        <span
-          key={tab.label}
-          {...stylex.props(styles.tab, tab.ready ? styles.tabActive : styles.tabSoon)}
+  return (
+    <div {...stylex.props(styles.root)}>
+      <h1 {...stylex.props(styles.title)}>콘텐츠</h1>
+      <p {...stylex.props(styles.subtitle)}>공지·소개·FAQ를 직접 관리해요</p>
+
+      <div {...stylex.props(styles.subtabs)}>
+        <button
+          type="button"
+          {...stylex.props(styles.tab, tab === "announcements" && styles.tabActive)}
+          onClick={() => setTab("announcements")}
         >
-          {tab.ready ? tab.label : `${tab.label} · 준비 중`}
-        </span>
-      ))}
-    </div>
+          공지사항
+        </button>
+        <button
+          type="button"
+          {...stylex.props(styles.tab, tab === "faq" && styles.tabActive)}
+          onClick={() => setTab("faq")}
+        >
+          FAQ
+        </button>
+        <span {...stylex.props(styles.tab, styles.tabSoon)}>보호소 소개 · 준비 중</span>
+      </div>
 
-    <Suspense fallback={<LoadingState />}>
-      <AnnouncementManager shelterId={shelterId} />
-    </Suspense>
-  </div>
-);
+      <Suspense fallback={<LoadingState />}>
+        {tab === "announcements" ? (
+          <AnnouncementManager shelterId={shelterId} />
+        ) : (
+          <FaqManager shelterId={shelterId} />
+        )}
+      </Suspense>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/FaqForm.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/FaqForm.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { ShelterFaq } from "@/entities/shelter";
+import { styles } from "./ConsoleContent.styles";
+import type { FaqDraft } from "../model/useConsoleFaqs";
+
+interface FaqFormProps {
+  editing: ShelterFaq | null;
+  onCreate: (draft: FaqDraft) => void;
+  onUpdate: (draft: FaqDraft) => void;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+/** Create or edit a shelter FAQ (질문 · 답변). */
+export const FaqForm = ({ editing, onCreate, onUpdate, onCancel, saving }: FaqFormProps) => {
+  const [question, setQuestion] = useState(editing?.question ?? "");
+  const [answer, setAnswer] = useState(editing?.answer ?? "");
+
+  const canSubmit = question.trim().length > 0 && answer.trim().length > 0 && !saving;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    const draft = { question: question.trim(), answer: answer.trim() };
+
+    if (editing) {
+      onUpdate(draft);
+
+      return;
+    }
+
+    onCreate(draft);
+    setQuestion("");
+    setAnswer("");
+  };
+
+  return (
+    <section {...stylex.props(styles.card)}>
+      <h3 {...stylex.props(styles.heading)}>{editing ? "FAQ 수정" : "새 FAQ"}</h3>
+
+      <input
+        {...stylex.props(styles.input)}
+        value={question}
+        placeholder="질문"
+        onChange={(event) => setQuestion(event.target.value)}
+      />
+      <textarea
+        {...stylex.props(styles.input, styles.textarea)}
+        value={answer}
+        placeholder="답변"
+        onChange={(event) => setAnswer(event.target.value)}
+      />
+
+      <div {...stylex.props(styles.actions)}>
+        {editing && (
+          <Hb.Button variant="ghost" onClick={onCancel}>
+            취소
+          </Hb.Button>
+        )}
+        <Hb.Button variant="primary" onClick={submit} disabled={!canSubmit} loading={saving}>
+          {editing ? "저장" : "추가"}
+        </Hb.Button>
+      </div>
+    </section>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/FaqList.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/FaqList.tsx
@@ -1,0 +1,43 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { ShelterFaq } from "@/entities/shelter";
+import { styles } from "./ConsoleContent.styles";
+
+interface FaqListProps {
+  faqs: ShelterFaq[];
+  editingId: string | null;
+  onEdit: (faq: ShelterFaq) => void;
+  onDelete: (id: string) => void;
+}
+
+/** The shelter's FAQ entries, each with edit / delete. */
+export const FaqList = ({ faqs, editingId, onEdit, onDelete }: FaqListProps) => {
+  if (faqs.length === 0) {
+    return <p {...stylex.props(styles.empty)}>아직 등록한 FAQ가 없어요.</p>;
+  }
+
+  return (
+    <div {...stylex.props(styles.list)}>
+      {faqs.map((faq) => (
+        <article
+          key={faq.id}
+          {...stylex.props(styles.row, faq.id === editingId && styles.rowActive)}
+        >
+          <div {...stylex.props(styles.rowHead)}>
+            <span {...stylex.props(styles.rowTitle)}>Q. {faq.question}</span>
+            <span {...stylex.props(styles.spacer)} />
+            <div {...stylex.props(styles.rowActions)}>
+              <Hb.Button variant="ghost" size="small" onClick={() => onEdit(faq)}>
+                수정
+              </Hb.Button>
+              <Hb.Button variant="ghost" size="small" onClick={() => onDelete(faq.id)}>
+                삭제
+              </Hb.Button>
+            </div>
+          </div>
+          <p {...stylex.props(styles.preview)}>{faq.answer}</p>
+        </article>
+      ))}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/console-content/ui/FaqManager.tsx
+++ b/apps/hobom-angel/src/features/console-content/ui/FaqManager.tsx
@@ -1,0 +1,29 @@
+import * as stylex from "@stylexjs/stylex";
+import { useConsoleFaqs } from "../model/useConsoleFaqs";
+import { FaqForm } from "./FaqForm";
+import { FaqList } from "./FaqList";
+import { styles } from "./ConsoleContent.styles";
+
+/** FAQ management — the form on the left, the list on the right (1:1). */
+export const FaqManager = ({ shelterId }: { shelterId: string }) => {
+  const { faqs, editing, edit, clearEdit, createFaq, updateFaq, removeFaq, saving } =
+    useConsoleFaqs(shelterId);
+
+  return (
+    <div {...stylex.props(styles.layout)}>
+      <div {...stylex.props(styles.col)}>
+        <FaqForm
+          key={editing?.id ?? "new"}
+          editing={editing}
+          onCreate={createFaq}
+          onUpdate={updateFaq}
+          onCancel={clearEdit}
+          saving={saving}
+        />
+      </div>
+      <div {...stylex.props(styles.col)}>
+        <FaqList faqs={faqs} editingId={editing?.id ?? null} onEdit={edit} onDelete={removeFaq} />
+      </div>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -133,6 +133,8 @@ const FAQS = [
   },
 ];
 
+let nextFaq = FAQS.length + 1;
+
 // Verified-shelter directory (§3.5). Only VERIFIED shelters are listed.
 const DIRECTORY_NAMES = [
   ["행복보호소", "haengbok-shelter", "서울", "A"],
@@ -268,6 +270,44 @@ export const shelterHandlers = [
     if (!mockSession.isActive()) return unauthorized();
 
     return ok(FAQS);
+  }),
+
+  // §7.4 console — FAQ CRUD.
+  http.post(mockUrl("/shelters/:shelterId/faqs"), async ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const input = (await request.json()) as { question: string; answer: string; order: number };
+    const id = `faq-${nextFaq}`;
+
+    nextFaq += 1;
+    FAQS.push({ id, question: input.question, answer: input.answer, order: input.order });
+
+    return ok({ id });
+  }),
+
+  http.patch(mockUrl("/faqs/:id"), async ({ params, request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const input = (await request.json()) as { question: string; answer: string; order: number };
+    const faq = FAQS.find((item) => item.id === params.id);
+
+    if (faq) {
+      faq.question = input.question;
+      faq.answer = input.answer;
+      faq.order = input.order;
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.delete(mockUrl("/faqs/:id"), ({ params }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const index = FAQS.findIndex((item) => item.id === params.id);
+
+    if (index >= 0) FAQS.splice(index, 1);
+
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.get(mockUrl("/shelters/:shelterId/stats"), () => {


### PR DESCRIPTION
Rounds out the §7.4 content CMS by adding a FAQ tab beside 공지사항 on the console content screen. Shelter staff can now manage the same FAQ list that shows on their public microsite.

## What's included
- **FAQ tab** on the content screen with a 1:1 form/list split, matching the announcement layout
- Add, edit, and remove FAQ entries — new entries append to the end, edits keep their order
- Staff FAQ endpoints and mutations on the shelter entity (`postFaq`/`editFaq`/`deleteFaq`, `createFaq`/`updateFaq`/`removeFaq`), plus an `order` field on the FAQ model
- Mock CRUD handlers so the flow works end to end under MSW
- e2e covering the tab switch, create, and delete

## Verification
- Typecheck, lint (0 warnings), unit tests, and the console-content e2e all pass