### PR TITLE
Add the shelter console statistics screen

### DIFF
--- a/apps/hobom-angel/e2e/console-stats.spec.ts
+++ b/apps/hobom-angel/e2e/console-stats.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§7.7 shelter console — stats", () => {
+  test("shows the KPI cards and the adoption trend chart", async ({ page }) => {
+    await login(page);
+    await page.goto("console/stats");
+
+    await expect(page.getByRole("heading", { name: "통계" })).toBeVisible();
+
+    // KPIs derived from the dashboard payload.
+    await expect(page.getByText("이번 달 입양")).toBeVisible();
+    await expect(page.getByText("▲ 지난달 +5")).toBeVisible();
+    await expect(page.getByText("88%")).toBeVisible();
+    await expect(page.getByText("누적 입양 240")).toBeVisible();
+
+    // The trend chart renders with its accessible label.
+    await expect(page.getByRole("img", { name: "최근 6개월 월별 입양 추이" })).toBeVisible();
+  });
+
+  test("is reachable from the sidebar", async ({ page }) => {
+    await login(page);
+    await page.goto("console/animals");
+
+    await page.getByRole("link", { name: /통계/ }).click();
+
+    await expect(page).toHaveURL(/\/console\/stats$/);
+    await expect(page.getByRole("heading", { name: "통계" })).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -58,6 +58,9 @@ const ConsoleVolunteerPage = lazy(() =>
 const ConsoleContentPage = lazy(() =>
   import("@/pages/console-content").then((module) => ({ default: module.ConsoleContentPage })),
 );
+const ConsoleStatsPage = lazy(() =>
+  import("@/pages/console-stats").then((module) => ({ default: module.ConsoleStatsPage })),
+);
 
 // Warm the common route chunks during idle time so navigating to them shows the
 // screen's own skeleton (data Suspense) rather than the chunk-load spinner.
@@ -112,6 +115,7 @@ export const AppRouter = () => {
               <Route path={ROUTES.CONSOLE_ANIMALS} element={<ConsoleAnimalsPage />} />
               <Route path={ROUTES.CONSOLE_VOLUNTEER} element={<ConsoleVolunteerPage />} />
               <Route path={ROUTES.CONSOLE_CONTENT} element={<ConsoleContentPage />} />
+              <Route path={ROUTES.CONSOLE_STATS} element={<ConsoleStatsPage />} />
             </Route>
           </Route>
 

--- a/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
+++ b/apps/hobom-angel/src/apps/ui/ConsoleShellLayout.tsx
@@ -14,7 +14,7 @@ const MENU: { label: string; hint: string; to: string | null }[] = [
   { label: "콘텐츠", hint: "공지·FAQ", to: ROUTES.CONSOLE_CONTENT },
   { label: "설문 빌더", hint: "폼 정의", to: null },
   { label: "스태프 관리", hint: "승격·역할", to: null },
-  { label: "통계", hint: "KPI", to: null },
+  { label: "통계", hint: "KPI", to: ROUTES.CONSOLE_STATS },
 ];
 
 /** Shelter console chrome (§07): a shelter-branded sidebar (the menu map) beside

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -6,6 +6,7 @@ import { toShelterMarker } from "../lib/to-shelter-marker.lib";
 import {
   createdIdSchema,
   shelterAnnouncementsSchema,
+  shelterDashboardSchema,
   shelterFaqsSchema,
   shelterListPageSchema,
   shelterMarkersSchema,
@@ -15,6 +16,7 @@ import {
 import type {
   Shelter,
   ShelterAnnouncement,
+  ShelterDashboard,
   ShelterFaq,
   ShelterListItem,
   ShelterMarker,
@@ -37,6 +39,7 @@ const parseAnnouncements = parseResponse(
 );
 const parseFaqs = parseResponse(shelterFaqsSchema, "GET /shelters/:id/faqs");
 const parseStats = parseResponse(shelterStatsSchema, "GET /shelters/:id/stats");
+const parseDashboard = parseResponse(shelterDashboardSchema, "GET /shelters/:id/dashboard");
 const parseMarkers = parseResponse(shelterMarkersSchema, "GET /shelters/map");
 
 /** Browse verified shelters (region filter + cursor pagination) (§3.5). */
@@ -132,3 +135,10 @@ export const getShelterStats = (shelterId: string, signal?: AbortSignal): Promis
     .get(`/shelters/${shelterId}/stats`, { signal })
     .then(parseStats)
     .then((raw): ShelterStats => ({ ...EMPTY_STATS, ...raw }));
+
+/** Fetch a shelter's §07 management KPIs (staff-scoped dashboard). */
+export const getShelterDashboard = (
+  shelterId: string,
+  signal?: AbortSignal,
+): Promise<ShelterDashboard> =>
+  httpClient.get(`/shelters/${shelterId}/dashboard`, { signal }).then(parseDashboard);

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.queries.ts
@@ -2,6 +2,7 @@ import { infiniteQueryOptions, queryOptions } from "hobom-data";
 import {
   getShelterAnnouncements,
   getShelterBySlug,
+  getShelterDashboard,
   getShelterFaqs,
   getShelterMarkers,
   getShelterStats,
@@ -47,5 +48,11 @@ export const shelterQueries = {
     queryOptions({
       queryKey: [...shelterQueries.all(), shelterId, "stats"] as const,
       queryFn: ({ signal }) => getShelterStats(shelterId, signal),
+    }),
+
+  dashboard: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...shelterQueries.all(), shelterId, "dashboard"] as const,
+      queryFn: ({ signal }) => getShelterDashboard(shelterId, signal),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -4,6 +4,7 @@ import type {
   CreatedId,
   RawShelter,
   RawShelterAnnouncement,
+  RawShelterDashboard,
   RawShelterFaq,
   RawShelterMarker,
   RawShelterStats,
@@ -95,6 +96,23 @@ export const shelterStatsSchema: Schema<RawShelterStats> = HoBomSchema.object({
   adoptedCount: HoBomSchema.number(),
   shelteredCount: HoBomSchema.number(),
   availableCount: HoBomSchema.number(),
+});
+
+/** `GET /shelters/:shelterId/dashboard` — the §07 staff KPI payload. */
+export const shelterDashboardSchema: Schema<RawShelterDashboard> = HoBomSchema.object({
+  adoptedCount: HoBomSchema.number(),
+  shelteredCount: HoBomSchema.number(),
+  availableCount: HoBomSchema.number(),
+  adoptionRate: HoBomSchema.number(),
+  thisMonthAdoptions: HoBomSchema.number(),
+  lastMonthAdoptions: HoBomSchema.number(),
+  monthlyAdoptions: HoBomSchema.array(
+    HoBomSchema.object({
+      month: HoBomSchema.string(),
+      count: HoBomSchema.number(),
+    }),
+  ),
+  pendingApplications: HoBomSchema.number(),
 });
 
 /** Create responses returning just an id (announcement/faq). */

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -95,6 +95,23 @@ export interface RawShelterStats {
   availableCount: number;
 }
 
+export interface RawMonthlyAdoptionPoint {
+  month: string;
+  count: number;
+}
+
+/** `GET /shelters/:id/dashboard` — the §07 staff KPI payload. */
+export interface RawShelterDashboard {
+  adoptedCount: number;
+  shelteredCount: number;
+  availableCount: number;
+  adoptionRate: number;
+  thisMonthAdoptions: number;
+  lastMonthAdoptions: number;
+  monthlyAdoptions: RawMonthlyAdoptionPoint[];
+  pendingApplications: number;
+}
+
 /** `POST/PATCH` announcement request (staff). */
 export interface AnnouncementInput {
   title: string;

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -14,6 +14,8 @@ export type {
   Shelter,
   ShelterAddress,
   ShelterAnnouncement,
+  ShelterDashboard,
+  MonthlyAdoptionPoint,
   ShelterFaq,
   ShelterListItem,
   ShelterMarker,

--- a/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
+++ b/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
@@ -87,6 +87,26 @@ export interface ShelterStats {
   availableCount: number;
 }
 
+/** One month of the adoption trend (KST `YYYY-MM`). */
+export interface MonthlyAdoptionPoint {
+  month: string;
+  count: number;
+}
+
+/** §07 management KPIs for a single shelter (staff-scoped dashboard). */
+export interface ShelterDashboard {
+  adoptedCount: number;
+  shelteredCount: number;
+  availableCount: number;
+  /** adopted / (adopted + sheltered), 0–1. */
+  adoptionRate: number;
+  thisMonthAdoptions: number;
+  lastMonthAdoptions: number;
+  /** Trailing six months, oldest first. */
+  monthlyAdoptions: MonthlyAdoptionPoint[];
+  pendingApplications: number;
+}
+
 /** Only VERIFIED shelters show the ✓ badge and get PII privileges. */
 export const isShelterVerified = (status: ShelterStatus): boolean => status === "VERIFIED";
 

--- a/apps/hobom-angel/src/features/console-stats/index.ts
+++ b/apps/hobom-angel/src/features/console-stats/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleStats } from "./ui/ConsoleStats";

--- a/apps/hobom-angel/src/features/console-stats/lib/dashboard.lib.spec.ts
+++ b/apps/hobom-angel/src/features/console-stats/lib/dashboard.lib.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { adoptionDelta, formatAdoptionRate, monthLabel, toAdoptionBars } from "./dashboard.lib";
+
+describe("formatAdoptionRate", () => {
+  it("renders a 0–1 rate as a rounded whole percent", () => {
+    expect(formatAdoptionRate(0.634)).toBe("63%");
+    expect(formatAdoptionRate(0)).toBe("0%");
+    expect(formatAdoptionRate(1)).toBe("100%");
+  });
+});
+
+describe("adoptionDelta", () => {
+  it("marks an increase with an up arrow and a signed caption", () => {
+    expect(adoptionDelta(18, 13)).toEqual({ direction: "up", arrow: "▲", caption: "지난달 +5" });
+  });
+
+  it("marks a decrease with a down arrow", () => {
+    expect(adoptionDelta(10, 14)).toEqual({ direction: "down", arrow: "▼", caption: "지난달 -4" });
+  });
+
+  it("treats no change as flat", () => {
+    expect(adoptionDelta(7, 7)).toEqual({
+      direction: "flat",
+      arrow: "—",
+      caption: "지난달과 같음",
+    });
+  });
+});
+
+describe("monthLabel", () => {
+  it("shortens YYYY-MM to a Korean month", () => {
+    expect(monthLabel("2026-07")).toBe("7월");
+    expect(monthLabel("2026-12")).toBe("12월");
+  });
+
+  it("falls back to the raw value when it isn't a month", () => {
+    expect(monthLabel("nope")).toBe("nope");
+  });
+});
+
+describe("toAdoptionBars", () => {
+  it("highlights only the latest month", () => {
+    const bars = toAdoptionBars([
+      { month: "2026-05", count: 8 },
+      { month: "2026-06", count: 12 },
+      { month: "2026-07", count: 18 },
+    ]);
+
+    const fills = bars.map((bar) => bar.fill);
+
+    expect(bars.map((bar) => bar.label)).toEqual(["5월", "6월", "7월"]);
+    expect(fills[0]).toBe(fills[1]);
+    expect(fills[2]).not.toBe(fills[1]);
+    expect(bars.at(-1)?.count).toBe(18);
+  });
+
+  it("returns an empty list for no data", () => {
+    expect(toAdoptionBars([])).toEqual([]);
+  });
+});

--- a/apps/hobom-angel/src/features/console-stats/lib/dashboard.lib.ts
+++ b/apps/hobom-angel/src/features/console-stats/lib/dashboard.lib.ts
@@ -1,0 +1,48 @@
+import type { MonthlyAdoptionPoint } from "@/entities/shelter";
+
+// Bar fills for the adoption-trend chart: the latest month is solid accent, the
+// earlier months a soft tint — matching the §07 dashboard mock.
+const BAR_CURRENT = "oklch(0.56 0.078 155)";
+const BAR_PAST = "oklch(0.95 0.03 155)";
+
+/** Adoption rate (0–1) as a whole-percent string, e.g. 0.634 → "63%". */
+export const formatAdoptionRate = (rate: number): string => `${Math.round(rate * 100)}%`;
+
+export interface AdoptionDelta {
+  direction: "up" | "down" | "flat";
+  arrow: string;
+  caption: string;
+}
+
+/** Month-over-month adoption change, ready to render (arrow + caption). */
+export const adoptionDelta = (thisMonth: number, lastMonth: number): AdoptionDelta => {
+  const diff = thisMonth - lastMonth;
+
+  if (diff > 0) return { direction: "up", arrow: "▲", caption: `지난달 +${diff}` };
+  if (diff < 0) return { direction: "down", arrow: "▼", caption: `지난달 ${diff}` };
+
+  return { direction: "flat", arrow: "—", caption: "지난달과 같음" };
+};
+
+/** `YYYY-MM` → `M월`; falls back to the raw value if it isn't a month. */
+export const monthLabel = (month: string): string => {
+  const parsed = Number(month.slice(5, 7));
+
+  return Number.isNaN(parsed) || parsed < 1 ? month : `${parsed}월`;
+};
+
+export interface AdoptionBar {
+  month: string;
+  label: string;
+  count: number;
+  fill: string;
+}
+
+/** Map the trend to chart rows, highlighting the latest (current) month. */
+export const toAdoptionBars = (points: readonly MonthlyAdoptionPoint[]): AdoptionBar[] =>
+  points.map((point, index) => ({
+    month: point.month,
+    label: monthLabel(point.month),
+    count: point.count,
+    fill: index === points.length - 1 ? BAR_CURRENT : BAR_PAST,
+  }));

--- a/apps/hobom-angel/src/features/console-stats/model/useConsoleStats.ts
+++ b/apps/hobom-angel/src/features/console-stats/model/useConsoleStats.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from "hobom-data";
+import { shelterQueries } from "@/entities/shelter";
+import { adoptionDelta, toAdoptionBars } from "../lib/dashboard.lib";
+
+/** The §07 통계 dashboard for a shelter: KPIs plus the adoption-trend bars. */
+export const useConsoleStats = (shelterId: string) => {
+  const { data: dashboard } = useSuspenseQuery(shelterQueries.dashboard(shelterId));
+
+  return {
+    dashboard,
+    delta: adoptionDelta(dashboard.thisMonthAdoptions, dashboard.lastMonthAdoptions),
+    bars: toAdoptionBars(dashboard.monthlyAdoptions),
+  };
+};

--- a/apps/hobom-angel/src/features/console-stats/ui/ConsoleStats.styles.ts
+++ b/apps/hobom-angel/src/features/console-stats/ui/ConsoleStats.styles.ts
@@ -1,0 +1,87 @@
+import * as stylex from "@stylexjs/stylex";
+
+const WIDE = "@media (min-width: 1024px)";
+const MID = "@media (min-width: 640px)";
+
+export const styles = stylex.create({
+  // The console main is a fixed pane; this screen owns its own vertical scroll.
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+    height: { [WIDE]: "100%" },
+    minHeight: 0,
+    overflowY: { [WIDE]: "auto" },
+  },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: {
+    margin: "4px 0 18px",
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  kpiGrid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "1fr",
+      [MID]: "repeat(2, 1fr)",
+      [WIDE]: "repeat(4, 1fr)",
+    },
+    gap: 12,
+    marginBottom: 16,
+  },
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  cardLabel: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  cardValue: {
+    marginTop: 2,
+    fontSize: "1.75rem",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  cardValueAccent: {
+    color: "var(--hb-color-accent)",
+  },
+  caption: {
+    marginTop: 2,
+    fontSize: "0.6875rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  captionUp: {
+    color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
+  },
+  captionDown: {
+    color: "var(--hb-color-danger, oklch(0.55 0.18 25))",
+  },
+  chartCard: {
+    padding: 18,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  chartTitle: {
+    margin: "0 0 8px",
+    fontSize: "0.8125rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+});

--- a/apps/hobom-angel/src/features/console-stats/ui/ConsoleStats.tsx
+++ b/apps/hobom-angel/src/features/console-stats/ui/ConsoleStats.tsx
@@ -1,0 +1,82 @@
+import * as stylex from "@stylexjs/stylex";
+import { Chart } from "hobom-design-system";
+import { useConsoleStats } from "../model/useConsoleStats";
+import { formatAdoptionRate } from "../lib/dashboard.lib";
+import { styles } from "./ConsoleStats.styles";
+
+interface Kpi {
+  label: string;
+  value: string;
+  caption: string;
+  accent?: boolean;
+  captionTone?: "up" | "down";
+}
+
+/** §7.7 통계 — a shelter's management KPIs plus the adoption trend, scoped to
+ *  the staff member's shelter. */
+export const ConsoleStats = ({ shelterId }: { shelterId: string }) => {
+  const { dashboard, delta, bars } = useConsoleStats(shelterId);
+
+  const kpis: Kpi[] = [
+    {
+      label: "이번 달 입양",
+      value: String(dashboard.thisMonthAdoptions),
+      caption: `${delta.arrow} ${delta.caption}`,
+      accent: true,
+      captionTone: delta.direction === "flat" ? undefined : delta.direction,
+    },
+    {
+      label: "보호 중",
+      value: String(dashboard.shelteredCount),
+      caption: `입양가능 ${dashboard.availableCount}`,
+    },
+    {
+      label: "처리 대기 신청",
+      value: String(dashboard.pendingApplications),
+      caption: "입양·임보 신청 대기",
+    },
+    {
+      label: "입양율",
+      value: formatAdoptionRate(dashboard.adoptionRate),
+      caption: `누적 입양 ${dashboard.adoptedCount}`,
+    },
+  ];
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <h1 {...stylex.props(styles.title)}>통계</h1>
+      <p {...stylex.props(styles.subtitle)}>입양율 · 보호 현황 · 신청 처리</p>
+
+      <div {...stylex.props(styles.kpiGrid)}>
+        {kpis.map((kpi) => (
+          <div key={kpi.label} {...stylex.props(styles.card)}>
+            <span {...stylex.props(styles.cardLabel)}>{kpi.label}</span>
+            <span {...stylex.props(styles.cardValue, kpi.accent && styles.cardValueAccent)}>
+              {kpi.value}
+            </span>
+            <span
+              {...stylex.props(
+                styles.caption,
+                kpi.captionTone === "up" && styles.captionUp,
+                kpi.captionTone === "down" && styles.captionDown,
+              )}
+            >
+              {kpi.caption}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <section {...stylex.props(styles.chartCard)}>
+        <h2 {...stylex.props(styles.chartTitle)}>월별 입양 추이</h2>
+        <Chart
+          type="bar"
+          data={bars}
+          config={{ x: "label", y: "count", colorKey: "fill", legend: false }}
+          height={180}
+          ariaLabel="최근 6개월 월별 입양 추이"
+        />
+      </section>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -316,6 +316,29 @@ export const shelterHandlers = [
     return ok({ adoptedCount: 240, shelteredCount: 32, availableCount: 18 });
   }),
 
+  // §07 console — staff KPI dashboard (input for the 통계 screen).
+  http.get(mockUrl("/shelters/:shelterId/dashboard"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok({
+      adoptedCount: 240,
+      shelteredCount: 32,
+      availableCount: 18,
+      adoptionRate: 240 / (240 + 32),
+      thisMonthAdoptions: 18,
+      lastMonthAdoptions: 13,
+      monthlyAdoptions: [
+        { month: "2026-02", count: 7 },
+        { month: "2026-03", count: 11 },
+        { month: "2026-04", count: 9 },
+        { month: "2026-05", count: 14 },
+        { month: "2026-06", count: 13 },
+        { month: "2026-07", count: 18 },
+      ],
+      pendingApplications: 6,
+    });
+  }),
+
   http.get(mockUrl("/shelters/:shelterId/volunteer-events"), () => {
     if (!mockSession.isActive()) return unauthorized();
 

--- a/apps/hobom-angel/src/pages/console-stats/index.ts
+++ b/apps/hobom-angel/src/pages/console-stats/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleStatsPage } from "./ui/ConsoleStatsPage";

--- a/apps/hobom-angel/src/pages/console-stats/ui/ConsoleStatsPage.tsx
+++ b/apps/hobom-angel/src/pages/console-stats/ui/ConsoleStatsPage.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from "react";
+import { managedShelter, useCurrentUser } from "@/entities/user";
+import { ConsoleStats } from "@/features/console-stats";
+import { LoadingState, NotFoundState } from "@/shared/ui";
+
+export const ConsoleStatsPage = () => {
+  const { user } = useCurrentUser();
+  const shelter = managedShelter(user);
+
+  if (!shelter) return <NotFoundState />;
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <ConsoleStats shelterId={shelter.shelterId} />
+    </Suspense>
+  );
+};

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   CONSOLE_ANIMALS: "/console/animals",
   CONSOLE_VOLUNTEER: "/console/volunteer",
   CONSOLE_CONTENT: "/console/content",
+  CONSOLE_STATS: "/console/stats",
 
   // Auth.
   LOGIN: "/login",

--- a/packages/hobom-design-system/src/index.ts
+++ b/packages/hobom-design-system/src/index.ts
@@ -11,6 +11,9 @@ export { Sortable, arrayMove, useDroppable } from "./patterns/Sortable";
 export type { DragEndEvent, DragStartEvent, DragOverEvent } from "./patterns/Sortable";
 export { SuspenseLoader } from "./patterns/SuspenseLoader";
 
+export { Chart, createChart } from "./charts";
+export type { ChartConfig, ChartProps, ChartSeries, ChartDatum } from "./charts";
+
 import { SkeletonCard } from "./patterns/SkeletonCard";
 import { SkeletonList } from "./patterns/SkeletonList";
 export const HoBomSkeleton = { Card: SkeletonCard, List: SkeletonList };


### PR DESCRIPTION
Adds the §07 통계 screen to the shelter console — the last of the console menu items backed by a real endpoint. It surfaces a shelter's management KPIs and adoption trend, scoped to the signed-in staff member's shelter.

## What's included
- **KPI cards**: 이번 달 입양 (with a month-over-month delta), 보호 중 / 입양가능, 처리 대기 신청, and 입양율
- **월별 입양 추이** — a six-month bar chart, current month highlighted
- Sourced from `GET /shelters/:shelterId/dashboard` (a new `shelterQueries.dashboard` + schema-validated boundary on the shelter entity)
- Promotes the design system's `Chart` to the package's public exports so apps can use the in-house chart factory
- KPI derivations (rate percent, delta arrow/caption, month labels) extracted to a tested lib
- Mock dashboard payload and an e2e covering the KPIs, the chart, and sidebar navigation

The remaining console menu items (신청 처리, 설문 빌더, 스태프 관리) stay disabled — the backend has no list/read endpoints for them yet.

## Verification
Typecheck, lint (0 warnings), unit tests (angel 113, DS charts 36), and the console-stats e2e all pass.