### PR TITLE
Add shelter reviews and reputation to the microsite

### DIFF
--- a/apps/hobom-angel/e2e/shelter-microsite.spec.ts
+++ b/apps/hobom-angel/e2e/shelter-microsite.spec.ts
@@ -58,6 +58,21 @@ test.describe("§04 shelter microsite", () => {
     await expect(page.getByText("입양 절차가 어떻게 되나요?")).toBeVisible();
   });
 
+  test("shows the reputation summary and reviews on the 후기 tab", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter");
+
+    await page.getByRole("tab", { name: "후기" }).click();
+    await expect(page).toHaveURL(/tab=reviews/);
+
+    // Reputation summary + a seeded review with its placement badge.
+    await expect(page.getByText(/후기 \d+개/)).toBeVisible();
+    await expect(page.getByText("입양자").first()).toBeVisible();
+    await expect(
+      page.getByText("상담부터 입양까지 정말 꼼꼼하게 챙겨주셨어요.", { exact: false }),
+    ).toBeVisible();
+  });
+
   test("deep-links straight to a tab from the URL", async ({ page }) => {
     await login(page);
     await page.goto("shelters/haengbok-shelter?tab=faq");

--- a/apps/hobom-angel/src/entities/review/api/review.api.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.api.ts
@@ -1,0 +1,33 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toQueryString } from "@/shared/lib";
+import { reputationSchema, reviewsPageSchema } from "./review.schema";
+import { toReputation, toReview } from "../lib/to-review.lib";
+import type { ReviewPage, ShelterReputation } from "../model/review.model";
+
+const parsePage = parseResponse(reviewsPageSchema, "GET /shelters/:id/reviews");
+const parseReputation = parseResponse(reputationSchema, "GET /shelters/:id/reviews/reputation");
+
+/** A cursor page of a shelter's reviews (newest first). */
+export const getShelterReviews = (
+  shelterId: string,
+  cursor?: string,
+  signal?: AbortSignal,
+): Promise<ReviewPage> =>
+  httpClient
+    .get(`/shelters/${shelterId}/reviews${toQueryString({ cursor, limit: 20 })}`, { signal })
+    .then(parsePage)
+    .then((page) => ({
+      reviews: page.items.map(toReview),
+      nextCursor: page.nextCursor,
+      hasNext: page.hasNext,
+    }));
+
+/** A shelter's aggregate reputation (mean + star histogram). */
+export const getShelterReputation = (
+  shelterId: string,
+  signal?: AbortSignal,
+): Promise<ShelterReputation> =>
+  httpClient
+    .get(`/shelters/${shelterId}/reviews/reputation`, { signal })
+    .then(parseReputation)
+    .then(toReputation);

--- a/apps/hobom-angel/src/entities/review/api/review.queries.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.queries.ts
@@ -1,0 +1,20 @@
+import { infiniteQueryOptions, queryOptions } from "hobom-data";
+import { getShelterReputation, getShelterReviews } from "./review.api";
+
+export const reviewQueries = {
+  all: () => ["reviews"] as const,
+
+  reputation: (shelterId: string) =>
+    queryOptions({
+      queryKey: [...reviewQueries.all(), shelterId, "reputation"] as const,
+      queryFn: ({ signal }) => getShelterReputation(shelterId, signal),
+    }),
+
+  list: (shelterId: string) =>
+    infiniteQueryOptions({
+      queryKey: [...reviewQueries.all(), shelterId, "list"] as const,
+      queryFn: ({ pageParam, signal }) => getShelterReviews(shelterId, pageParam, signal),
+      getNextPageParam: (last) => (last.hasNext ? (last.nextCursor ?? undefined) : undefined),
+      initialPageParam: undefined as string | undefined,
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/review/api/review.schema.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.schema.ts
@@ -1,0 +1,34 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { RawReputation, RawReview, RawReviewsPage } from "./review.type";
+
+const reviewSchema: Schema<RawReview> = HoBomSchema.object({
+  id: HoBomSchema.string(),
+  shelterId: HoBomSchema.string(),
+  authorId: HoBomSchema.string(),
+  placementType: HoBomSchema.enum(["ADOPTION", "FOSTER"]),
+  rating: HoBomSchema.number(),
+  body: HoBomSchema.string(),
+  createdAt: HoBomSchema.string().nullable(),
+});
+
+/** `GET /shelters/:id/reviews` — a cursor page of reviews. */
+export const reviewsPageSchema: Schema<RawReviewsPage> = HoBomSchema.object({
+  items: HoBomSchema.array(reviewSchema),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});
+
+/** `GET /shelters/:id/reviews/reputation` — mean + star histogram. */
+export const reputationSchema: Schema<RawReputation> = HoBomSchema.object({
+  shelterId: HoBomSchema.string(),
+  reviewCount: HoBomSchema.number(),
+  average: HoBomSchema.number(),
+  distribution: HoBomSchema.object({
+    "1": HoBomSchema.number(),
+    "2": HoBomSchema.number(),
+    "3": HoBomSchema.number(),
+    "4": HoBomSchema.number(),
+    "5": HoBomSchema.number(),
+  }),
+});

--- a/apps/hobom-angel/src/entities/review/api/review.type.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.type.ts
@@ -1,0 +1,24 @@
+import type { PlacementType } from "../model/review.model";
+
+export interface RawReview {
+  id: string;
+  shelterId: string;
+  authorId: string;
+  placementType: PlacementType;
+  rating: number;
+  body: string;
+  createdAt: string | null;
+}
+
+export interface RawReviewsPage {
+  items: RawReview[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+export interface RawReputation {
+  shelterId: string;
+  reviewCount: number;
+  average: number;
+  distribution: { "1": number; "2": number; "3": number; "4": number; "5": number };
+}

--- a/apps/hobom-angel/src/entities/review/index.ts
+++ b/apps/hobom-angel/src/entities/review/index.ts
@@ -1,0 +1,9 @@
+export { reviewQueries } from "./api/review.queries";
+export { PLACEMENT_LABEL } from "./model/review.model";
+export type {
+  Review,
+  ReviewPage,
+  ShelterReputation,
+  PlacementType,
+  StarRating,
+} from "./model/review.model";

--- a/apps/hobom-angel/src/entities/review/lib/to-review.lib.ts
+++ b/apps/hobom-angel/src/entities/review/lib/to-review.lib.ts
@@ -1,0 +1,25 @@
+import type { RawReputation, RawReview } from "../api/review.type";
+import type { Review, ShelterReputation } from "../model/review.model";
+
+export const toReview = (raw: RawReview): Review => ({
+  id: raw.id,
+  shelterId: raw.shelterId,
+  authorId: raw.authorId,
+  placementType: raw.placementType,
+  rating: raw.rating,
+  body: raw.body,
+  createdAt: raw.createdAt,
+});
+
+export const toReputation = (raw: RawReputation): ShelterReputation => ({
+  shelterId: raw.shelterId,
+  reviewCount: raw.reviewCount,
+  average: raw.average,
+  distribution: {
+    1: raw.distribution["1"],
+    2: raw.distribution["2"],
+    3: raw.distribution["3"],
+    4: raw.distribution["4"],
+    5: raw.distribution["5"],
+  },
+});

--- a/apps/hobom-angel/src/entities/review/model/review.model.ts
+++ b/apps/hobom-angel/src/entities/review/model/review.model.ts
@@ -1,0 +1,35 @@
+export type PlacementType = "ADOPTION" | "FOSTER";
+export type StarRating = 1 | 2 | 3 | 4 | 5;
+
+/** A shelter review, anchored to one completed placement (the verified
+ *  experience that makes it trustworthy). Author PII is never exposed. */
+export interface Review {
+  id: string;
+  shelterId: string;
+  authorId: string;
+  placementType: PlacementType;
+  rating: number;
+  body: string;
+  createdAt: string | null;
+}
+
+/** A page of reviews (cursor pagination). */
+export interface ReviewPage {
+  reviews: Review[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+/** A shelter's aggregate reputation: count, mean, and the star histogram. */
+export interface ShelterReputation {
+  shelterId: string;
+  reviewCount: number;
+  average: number;
+  distribution: Record<StarRating, number>;
+}
+
+/** The placement that earned a review — shown as a trust badge on each card. */
+export const PLACEMENT_LABEL: Record<PlacementType, string> = {
+  ADOPTION: "입양자",
+  FOSTER: "임보자",
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/lib/reputation.lib.spec.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/lib/reputation.lib.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { ShelterReputation } from "@/entities/review";
+import { distributionBars, filledStars, formatAverage } from "./reputation.lib";
+
+const reputation = (over: Partial<ShelterReputation> = {}): ShelterReputation => ({
+  shelterId: "s1",
+  reviewCount: 10,
+  average: 4.3,
+  distribution: { 1: 0, 2: 1, 3: 1, 4: 3, 5: 5 },
+  ...over,
+});
+
+describe("distributionBars", () => {
+  it("lists 5★ first with each star's percentage of the total", () => {
+    const bars = distributionBars(reputation());
+
+    expect(bars.map((bar) => bar.star)).toEqual([5, 4, 3, 2, 1]);
+    expect(bars[0]).toEqual({ star: 5, count: 5, pct: 50 });
+    expect(bars[1]).toEqual({ star: 4, count: 3, pct: 30 });
+  });
+
+  it("reports 0% for every bar when there are no reviews", () => {
+    const bars = distributionBars(
+      reputation({ reviewCount: 0, distribution: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } }),
+    );
+
+    expect(bars.every((bar) => bar.pct === 0)).toBe(true);
+  });
+});
+
+describe("formatAverage", () => {
+  it("keeps one decimal place", () => {
+    expect(formatAverage(4)).toBe("4.0");
+    expect(formatAverage(4.27)).toBe("4.3");
+  });
+});
+
+describe("filledStars", () => {
+  it("rounds to whole stars and clamps to 0–5", () => {
+    expect(filledStars(4.3)).toBe(4);
+    expect(filledStars(4.6)).toBe(5);
+    expect(filledStars(-1)).toBe(0);
+    expect(filledStars(9)).toBe(5);
+  });
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/lib/reputation.lib.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/lib/reputation.lib.ts
@@ -1,0 +1,28 @@
+import type { ShelterReputation, StarRating } from "@/entities/review";
+
+export interface DistributionBar {
+  star: StarRating;
+  count: number;
+  /** Share of all reviews, 0–100 (rounded). */
+  pct: number;
+}
+
+const STARS_DESC: StarRating[] = [5, 4, 3, 2, 1];
+
+/** The star histogram as rows (5★ first) with each star's share of the total. */
+export const distributionBars = (reputation: ShelterReputation): DistributionBar[] =>
+  STARS_DESC.map((star) => {
+    const count = reputation.distribution[star];
+
+    return {
+      star,
+      count,
+      pct: reputation.reviewCount > 0 ? Math.round((count / reputation.reviewCount) * 100) : 0,
+    };
+  });
+
+/** Average rating to one decimal, e.g. 4 → "4.0". */
+export const formatAverage = (average: number): string => average.toFixed(1);
+
+/** Round a rating to whole filled stars (0–5) for the star row. */
+export const filledStars = (rating: number): number => Math.max(0, Math.min(5, Math.round(rating)));

--- a/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/lib/shelter-tabs.lib.ts
@@ -1,10 +1,11 @@
-export type ShelterTab = "about" | "animals" | "notices" | "volunteer" | "faq";
+export type ShelterTab = "about" | "animals" | "notices" | "volunteer" | "reviews" | "faq";
 
 export const SHELTER_TABS: { value: ShelterTab; label: string }[] = [
   { value: "about", label: "소개" },
   { value: "animals", label: "동물" },
   { value: "notices", label: "공지·소식" },
   { value: "volunteer", label: "봉사" },
+  { value: "reviews", label: "후기" },
   { value: "faq", label: "FAQ" },
 ];
 
@@ -13,4 +14,5 @@ export const isShelterTab = (value: string | null): value is ShelterTab =>
   value === "animals" ||
   value === "notices" ||
   value === "volunteer" ||
+  value === "reviews" ||
   value === "faq";

--- a/apps/hobom-angel/src/features/shelter-microsite/model/useShelterReviews.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/model/useShelterReviews.ts
@@ -1,0 +1,14 @@
+import { useSuspenseInfiniteQuery } from "hobom-data";
+import { reviewQueries } from "@/entities/review";
+import type { Review } from "@/entities/review";
+
+/** Suspense-backed, cursor-paginated reviews for a shelter. */
+export const useShelterReviews = (shelterId: string) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useSuspenseInfiniteQuery(
+    reviewQueries.list(shelterId),
+  );
+
+  const reviews: Review[] = data.pages.flatMap((page) => page.reviews);
+
+  return { reviews, fetchNextPage, hasNextPage, isFetchingNextPage };
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/ShelterMicrosite.tsx
@@ -12,6 +12,7 @@ import { AboutTab } from "./tabs/AboutTab";
 import { AnimalsTab } from "./tabs/AnimalsTab";
 import { FaqTab } from "./tabs/FaqTab";
 import { NoticesTab } from "./tabs/NoticesTab";
+import { ReviewsTab } from "./tabs/ReviewsTab";
 import { VolunteerTab } from "./tabs/VolunteerTab";
 import { styles } from "./ShelterMicrosite.styles";
 
@@ -56,6 +57,11 @@ export const ShelterMicrosite = ({ slug }: { slug: string }) => {
           <Hb.Tabs.Panel value="volunteer" {...stylex.props(styles.panel)}>
             <Suspense fallback={<LoadingState />}>
               <VolunteerTab shelterId={shelter.id} />
+            </Suspense>
+          </Hb.Tabs.Panel>
+          <Hb.Tabs.Panel value="reviews" {...stylex.props(styles.panel)}>
+            <Suspense fallback={<LoadingState />}>
+              <ReviewsTab shelterId={shelter.id} />
             </Suspense>
           </Hb.Tabs.Panel>
           <Hb.Tabs.Panel value="faq" {...stylex.props(styles.panel)}>

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.styles.ts
@@ -1,0 +1,121 @@
+import * as stylex from "@stylexjs/stylex";
+
+const WIDE = "@media (min-width: 768px)";
+
+export const styles = stylex.create({
+  // Reputation summary: the big score beside the star histogram.
+  summary: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [WIDE]: "auto 1fr" },
+    gap: { default: 16, [WIDE]: 28 },
+    alignItems: "center",
+    padding: 20,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface-subtle)",
+  },
+  score: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 4,
+  },
+  average: {
+    fontSize: "2.75rem",
+    fontWeight: 700,
+    lineHeight: 1,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  count: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  bars: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+    minWidth: 0,
+  },
+  barRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+  },
+  barStar: {
+    width: 28,
+    flexShrink: 0,
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  barTrack: {
+    position: "relative",
+    flex: 1,
+    height: 8,
+    borderRadius: 999,
+    overflow: "hidden",
+    backgroundColor: "var(--hb-color-border)",
+  },
+  barFill: {
+    position: "absolute",
+    insetBlock: 0,
+    insetInlineStart: 0,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-color-accent)",
+  },
+  barCount: {
+    width: 24,
+    flexShrink: 0,
+    textAlign: "end",
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  stars: {
+    display: "inline-flex",
+    gap: 1,
+    color: "var(--hb-color-accent)",
+    fontSize: "0.9375rem",
+    letterSpacing: "1px",
+  },
+  starMuted: {
+    color: "var(--hb-color-border)",
+  },
+  // Review card.
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    padding: 16,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  cardHead: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+  },
+  headSpacer: {
+    flex: 1,
+  },
+  date: {
+    fontSize: "0.75rem",
+    color: "var(--hb-color-text-disabled)",
+  },
+  body: {
+    margin: 0,
+    fontSize: "0.9375rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-primary)",
+    whiteSpace: "pre-line",
+  },
+  more: {
+    display: "flex",
+    justifyContent: "center",
+    paddingTop: 4,
+  },
+});

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.tsx
@@ -1,0 +1,93 @@
+import { useSuspenseQuery } from "hobom-data";
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState, Hb } from "hobom-design-system";
+import { PLACEMENT_LABEL, reviewQueries } from "@/entities/review";
+import type { Review, ShelterReputation } from "@/entities/review";
+import { distributionBars, filledStars, formatAverage } from "../../lib/reputation.lib";
+import { useShelterReviews } from "../../model/useShelterReviews";
+import { styles } from "./ReviewsTab.styles";
+
+const formatDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" });
+
+const Stars = ({ rating }: { rating: number }) => {
+  const filled = filledStars(rating);
+
+  return (
+    <span {...stylex.props(styles.stars)} aria-label={`5점 만점에 ${rating}점`}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <span key={n} {...stylex.props(n > filled && styles.starMuted)} aria-hidden>
+          ★
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const ReputationSummary = ({ reputation }: { reputation: ShelterReputation }) => (
+  <div {...stylex.props(styles.summary)}>
+    <div {...stylex.props(styles.score)}>
+      <span {...stylex.props(styles.average)}>{formatAverage(reputation.average)}</span>
+      <Stars rating={reputation.average} />
+      <span {...stylex.props(styles.count)}>후기 {reputation.reviewCount}개</span>
+    </div>
+    <div {...stylex.props(styles.bars)}>
+      {distributionBars(reputation).map((bar) => (
+        <div key={bar.star} {...stylex.props(styles.barRow)}>
+          <span {...stylex.props(styles.barStar)}>{bar.star}점</span>
+          <span {...stylex.props(styles.barTrack)}>
+            <span {...stylex.props(styles.barFill)} style={{ width: `${bar.pct}%` }} />
+          </span>
+          <span {...stylex.props(styles.barCount)}>{bar.count}</span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const ReviewCard = ({ review }: { review: Review }) => (
+  <article {...stylex.props(styles.card)}>
+    <div {...stylex.props(styles.cardHead)}>
+      <Hb.Chip
+        label={PLACEMENT_LABEL[review.placementType]}
+        color="success"
+        variant="soft"
+        size="small"
+      />
+      <Stars rating={review.rating} />
+      <span {...stylex.props(styles.headSpacer)} />
+      {review.createdAt && <span {...stylex.props(styles.date)}>{formatDate(review.createdAt)}</span>}
+    </div>
+    <p {...stylex.props(styles.body)}>{review.body}</p>
+  </article>
+);
+
+/** 후기 tab — the shelter's reputation summary plus its paginated reviews. */
+export const ReviewsTab = ({ shelterId }: { shelterId: string }) => {
+  const { data: reputation } = useSuspenseQuery(reviewQueries.reputation(shelterId));
+  const { reviews, fetchNextPage, hasNextPage, isFetchingNextPage } = useShelterReviews(shelterId);
+
+  return (
+    <Hb.Stack spacing={2}>
+      <ReputationSummary reputation={reputation} />
+
+      {reviews.length === 0 ? (
+        <EmptyState message="아직 등록된 후기가 없어요." />
+      ) : (
+        reviews.map((review) => <ReviewCard key={review.id} review={review} />)
+      )}
+
+      {hasNextPage && (
+        <div {...stylex.props(styles.more)}>
+          <Hb.Button
+            variant="secondary"
+            onClick={() => fetchNextPage()}
+            loading={isFetchingNextPage}
+          >
+            후기 더 보기
+          </Hb.Button>
+        </div>
+      )}
+    </Hb.Stack>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -2,6 +2,7 @@ import { authHandlers } from "./auth.handlers";
 import { userHandlers } from "./user.handlers";
 import { animalHandlers } from "./animal.handlers";
 import { shelterHandlers } from "./shelter.handlers";
+import { reviewHandlers } from "./review.handlers";
 import { volunteerHandlers } from "./volunteer.handlers";
 import { volunteerPostHandlers } from "./volunteer-post.handlers";
 import { favoriteHandlers } from "./favorite.handlers";
@@ -16,6 +17,7 @@ export const handlers = [
   ...userHandlers,
   ...animalHandlers,
   ...shelterHandlers,
+  ...reviewHandlers,
   ...volunteerHandlers,
   ...volunteerPostHandlers,
   ...favoriteHandlers,

--- a/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
@@ -1,0 +1,102 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+interface ReviewRow {
+  id: string;
+  authorId: string;
+  placementType: "ADOPTION" | "FOSTER";
+  rating: number;
+  body: string;
+  createdAt: string;
+}
+
+const REVIEWS: ReviewRow[] = [
+  {
+    id: "review-1",
+    authorId: "user-11",
+    placementType: "ADOPTION",
+    rating: 5,
+    body: "상담부터 입양까지 정말 꼼꼼하게 챙겨주셨어요. 아이 건강 기록도 투명하게 공유해 주셔서 믿음이 갔습니다.",
+    createdAt: "2026-06-28T09:00:00.000Z",
+  },
+  {
+    id: "review-2",
+    authorId: "user-12",
+    placementType: "FOSTER",
+    rating: 5,
+    body: "임시보호 기간 내내 사료와 용품을 지원해 주시고, 궁금한 점은 언제든 친절하게 답해 주셨어요.",
+    createdAt: "2026-06-20T04:30:00.000Z",
+  },
+  {
+    id: "review-3",
+    authorId: "user-13",
+    placementType: "ADOPTION",
+    rating: 4,
+    body: "전반적으로 만족스러웠어요. 방문 예약이 조금 빠듯했지만 스태프분들이 배려해 주셨습니다.",
+    createdAt: "2026-06-11T07:15:00.000Z",
+  },
+  {
+    id: "review-4",
+    authorId: "user-14",
+    placementType: "ADOPTION",
+    rating: 5,
+    body: "입양 후에도 적응은 잘 하는지 먼저 연락 주셔서 감동했어요. 책임감이 느껴지는 보호소예요.",
+    createdAt: "2026-05-30T10:00:00.000Z",
+  },
+  {
+    id: "review-5",
+    authorId: "user-15",
+    placementType: "FOSTER",
+    rating: 4,
+    body: "처음 임보라 걱정이 많았는데 가이드가 자세해서 어렵지 않았어요. 추천합니다.",
+    createdAt: "2026-05-18T02:45:00.000Z",
+  },
+  {
+    id: "review-6",
+    authorId: "user-16",
+    placementType: "ADOPTION",
+    rating: 3,
+    body: "아이는 건강하고 좋아요. 다만 연락이 조금 늦을 때가 있어 별 하나 뺐어요.",
+    createdAt: "2026-05-02T06:20:00.000Z",
+  },
+];
+
+const reputationOf = () => {
+  const reviewCount = REVIEWS.length;
+  const sum = REVIEWS.reduce((total, review) => total + review.rating, 0);
+  const distribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+
+  REVIEWS.forEach((review) => {
+    distribution[review.rating] = (distribution[review.rating] ?? 0) + 1;
+  });
+
+  return {
+    reviewCount,
+    average: reviewCount > 0 ? Math.round((sum / reviewCount) * 10) / 10 : 0,
+    distribution,
+  };
+};
+
+/** Review domain mock — a shelter's reputation and paginated reviews (§04). */
+export const reviewHandlers = [
+  http.get(mockUrl("/shelters/:shelterId/reviews/reputation"), ({ params }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    return ok({ shelterId: String(params.shelterId), ...reputationOf() });
+  }),
+
+  http.get(mockUrl("/shelters/:shelterId/reviews"), ({ params }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    const shelterId = String(params.shelterId);
+    const items = REVIEWS.map((review) => ({ ...review, shelterId }));
+
+    return ok({ items, nextCursor: null, hasNext: false });
+  }),
+];


### PR DESCRIPTION
Adds a **후기** tab to the §04 shelter microsite, backed by the review endpoints.

## What's included
- **Reputation summary** — average rating, star row, and a 5→1 star histogram with per-star share, from `GET /shelters/:id/reviews/reputation`
- **Reviews list** — the shelter's reviews with cursor pagination (더 보기), from `GET /shelters/:id/reviews`
- Each review card shows its **placement badge** (입양자 / 임보자) — the verified-experience signal that makes a review trustworthy
- A new `review` entity (models, schema-validated boundary, reputation + infinite-list queries), a `reputation.lib` with unit tests, mock reputation/review data, and an e2e for the tab

## Scope note
Read-only for now. Writing a review requires a `placementRef` (a completed adoption/foster application id), and the API doesn't expose a way for a user to enumerate their completed placements — so a self-serve compose flow isn't cleanly buildable yet. It should hang off a "후기 남기기" CTA at placement completion once that reference is available. Edit/delete are backed by `reviewId` but unreachable without a create path, so they're deferred too.

## Verification
Typecheck, lint (0 warnings), unit tests (133), and e2e all pass — including the existing console-volunteer e2e (confirming the mock-handler additions didn't regress anything).