### PR TITLE
Read the volunteer-event and favorite lists as cursor pages

### DIFF
--- a/apps/hobom-angel/src/entities/favorite/api/favorite.api.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.api.ts
@@ -1,17 +1,18 @@
 import { httpClient, parseResponse } from "@/shared/api";
 import { toFavorite } from "../lib/to-favorite.lib";
-import { favoritesSchema } from "./favorite.schema";
+import { favoritesPageSchema } from "./favorite.schema";
 import type { Favorite, FavoriteTargetType } from "../model/favorite.model";
 
-/** Fetch the current user's favorites of one type (찜 animals or 팔로우 shelters). */
+/** Fetch the current user's favorites of one type (찜 animals or 팔로우 shelters).
+ *  Cursor-paginated upstream; the list surfaces the first page. */
 export const getFavorites = (
   targetType: FavoriteTargetType,
   signal?: AbortSignal,
 ): Promise<Favorite[]> =>
   httpClient
     .get(`/favorites?targetType=${targetType}`, { signal })
-    .then(parseResponse(favoritesSchema, "GET /favorites"))
-    .then((items) => items.map(toFavorite));
+    .then(parseResponse(favoritesPageSchema, "GET /favorites"))
+    .then((page) => page.items.map(toFavorite));
 
 /** Add a favorite (idempotent — requires auth, no response body). */
 export const addFavorite = (targetType: FavoriteTargetType, targetRef: string): Promise<void> =>

--- a/apps/hobom-angel/src/entities/favorite/api/favorite.schema.ts
+++ b/apps/hobom-angel/src/entities/favorite/api/favorite.schema.ts
@@ -9,5 +9,13 @@ export const favoriteSchema: Schema<RawFavorite> = HoBomSchema.object({
   favoritedAt: HoBomSchema.string().nullable(),
 });
 
-/** `GET /favorites` — a plain array of favorite references. */
-export const favoritesSchema: Schema<RawFavorite[]> = HoBomSchema.array(favoriteSchema);
+/** `GET /favorites` — a cursor page of favorite references. */
+export const favoritesPageSchema: Schema<{
+  items: RawFavorite[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}> = HoBomSchema.object({
+  items: HoBomSchema.array(favoriteSchema),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});

--- a/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-event/api/volunteer-event.api.ts
@@ -11,20 +11,21 @@ import {
 import type { VolunteerApplicant, VolunteerEvent } from "../model/volunteer-event.model";
 import type { CreateVolunteerEventInput } from "./volunteer-event.type";
 
-const parseVolunteerEvents = parseResponse(
-  volunteerEventsSchema,
+const parseShelterVolunteerEvents = parseResponse(
+  volunteerEventPageSchema,
   "GET /shelters/:id/volunteer-events",
 );
 
-/** Fetch a shelter's volunteer events (§04 봉사 tab). */
+/** Fetch a shelter's volunteer events (§04 봉사 tab). Cursor-paginated upstream;
+ *  the tab shows the first page. */
 export const getShelterVolunteerEvents = (
   shelterId: string,
   signal?: AbortSignal,
 ): Promise<VolunteerEvent[]> =>
   httpClient
     .get(`/shelters/${shelterId}/volunteer-events`, { signal })
-    .then(parseVolunteerEvents)
-    .then((items) => items.map(toVolunteerEvent));
+    .then(parseShelterVolunteerEvents)
+    .then((page) => page.items.map(toVolunteerEvent));
 
 /** Fetch upcoming volunteer events across all shelters (§05 봉사활동). */
 export const getUpcomingVolunteerEvents = (

--- a/apps/hobom-angel/src/mocks/handlers/favorite.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/favorite.handlers.ts
@@ -32,7 +32,7 @@ export const favoriteHandlers = [
       ? FAVORITES.filter((favorite) => favorite.targetType === targetType)
       : FAVORITES;
 
-    return ok(items);
+    return ok({ items, nextCursor: null, hasNext: false });
   }),
 
   http.post(mockUrl("/favorites"), async ({ request }) => {

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -342,7 +342,7 @@ export const shelterHandlers = [
   http.get(mockUrl("/shelters/:shelterId/volunteer-events"), () => {
     if (!mockSession.isActive()) return unauthorized();
 
-    return ok(VOLUNTEER_EVENTS);
+    return ok({ items: VOLUNTEER_EVENTS, nextCursor: null, hasNext: false });
   }),
 
   // §07 console — create / cancel events and decide applicants.


### PR DESCRIPTION
The backend cursor-paginated two previously-array list endpoints:
- `GET /shelters/:shelterId/volunteer-events`
- `GET /favorites`

Both now return `{ items, nextCursor, hasNext }`. Our `getShelterVolunteerEvents` and `getFavorites` still treated the response as an array, so against the updated backend the unwrapped envelope was the page object and `items.map is not a function` was thrown (surfaced on the console 봉사 일정 screen and the shelter 봉사 tab).

## Fix
- Read `page.items` in both callers, validated against page schemas
- Update the MSW mocks for those two endpoints to the paginated shape so dev/e2e match the backend

Only the first page is surfaced (these views don't paginate today) — behaviour is unchanged, just aligned to the new envelope.

## Verification
Typecheck, lint (0 warnings), and e2e all pass — console-volunteer, favorites, and shelter-microsite (봉사 + 후기 tabs).