### PR TITLE
Add the my-applications screen (내 신청 내역)

### DIFF
--- a/apps/hobom-angel/e2e/my-applications.spec.ts
+++ b/apps/hobom-angel/e2e/my-applications.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§05 my applications", () => {
+  test("reaches the list from 마이페이지 and shows adoption + foster applications", async ({
+    page,
+  }) => {
+    await login(page);
+
+    await page.goto("my");
+    await page.getByRole("link", { name: "내 신청 내역" }).click();
+
+    await expect(page).toHaveURL(/\/applications$/);
+    await expect(page.getByRole("heading", { name: "내 신청 내역" })).toBeVisible();
+
+    // Cards hydrate the animal name and overlay a kind · status badge.
+    await expect(page.getByText("콩이").first()).toBeVisible();
+    await expect(page.getByText(/입양 · 심사 중/).first()).toBeVisible();
+    await expect(page.getByText(/임시보호 ·/).first()).toBeVisible();
+  });
+
+  test("opens the animal from an application card", async ({ page }) => {
+    await login(page);
+    await page.goto("applications");
+
+    await page.getByRole("link", { name: /콩이/ }).first().click();
+    await expect(page).toHaveURL(/\/animals\/animal-\d+$/);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -49,6 +49,9 @@ const WriteReviewPage = lazy(() =>
   import("@/pages/volunteer-write").then((module) => ({ default: module.WriteReviewPage })),
 );
 const MyPage = lazy(() => import("@/pages/my").then((module) => ({ default: module.MyPage })));
+const ApplicationsPage = lazy(() =>
+  import("@/pages/applications").then((module) => ({ default: module.ApplicationsPage })),
+);
 const ConsoleAnimalsPage = lazy(() =>
   import("@/pages/console-animals").then((module) => ({ default: module.ConsoleAnimalsPage })),
 );
@@ -80,7 +83,7 @@ const prefetchRoutes = () => {
 };
 
 // Sections still on the ComingSoon placeholder until their screens land.
-const SECTION_ROUTES = [ROUTES.FOSTER, ROUTES.APPLICATIONS];
+const SECTION_ROUTES = [ROUTES.FOSTER];
 
 export const AppRouter = () => {
   useRouteMeta();
@@ -109,6 +112,7 @@ export const AppRouter = () => {
             <Route path={ROUTES.VOLUNTEER} element={<VolunteerPage />} />
             <Route path={ROUTES.VOLUNTEER_WRITE} element={<WriteReviewPage />} />
             <Route path={ROUTES.FAVORITES} element={<FavoritesPage />} />
+            <Route path={ROUTES.APPLICATIONS} element={<ApplicationsPage />} />
             <Route path={ROUTES.MY} element={<MyPage />} />
               {SECTION_ROUTES.map((path) => (
                 <Route key={path} path={path} element={<ComingSoonPage />} />

--- a/apps/hobom-angel/src/entities/application/api/application.api.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.api.ts
@@ -30,6 +30,22 @@ export const getShelterApplications = (
       hasNext: page.hasNext,
     }));
 
+/** The signed-in user's own applications of one kind (status filter, cursor). */
+export const getMyApplications = (
+  kind: ApplicationKind,
+  status?: ApplicationStatus,
+  cursor?: string,
+  signal?: AbortSignal,
+): Promise<ApplicationPage> =>
+  httpClient
+    .get(`/me/${pathFor(kind)}${toQueryString({ status, cursor, limit: 20 })}`, { signal })
+    .then(parsePage)
+    .then((page) => ({
+      applications: page.items.map((raw) => toSummary(raw, kind)),
+      nextCursor: page.nextCursor,
+      hasNext: page.hasNext,
+    }));
+
 /** One application with its submitted answers. */
 export const getApplicationDetail = (
   kind: ApplicationKind,

--- a/apps/hobom-angel/src/entities/application/api/application.queries.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.queries.ts
@@ -1,9 +1,19 @@
 import { infiniteQueryOptions, queryOptions } from "hobom-data";
-import { getApplicationDetail, getShelterApplications } from "./application.api";
+import {
+  getApplicationDetail,
+  getMyApplications,
+  getShelterApplications,
+} from "./application.api";
 import type { ApplicationKind, ApplicationStatus } from "../model/application.model";
 
 export const applicationQueries = {
   all: () => ["applications"] as const,
+
+  mine: (kind: ApplicationKind, status?: ApplicationStatus) =>
+    queryOptions({
+      queryKey: [...applicationQueries.all(), "mine", kind, status ?? "ALL"] as const,
+      queryFn: ({ signal }) => getMyApplications(kind, status, undefined, signal),
+    }),
 
   queue: (shelterId: string, kind: ApplicationKind, status?: ApplicationStatus) =>
     infiniteQueryOptions({

--- a/apps/hobom-angel/src/features/account/ui/MyProfile.styles.ts
+++ b/apps/hobom-angel/src/features/account/ui/MyProfile.styles.ts
@@ -64,6 +64,7 @@ export const styles = stylex.create({
     borderBottomColor: "var(--hb-color-border)",
     color: "var(--hb-color-text-primary)",
     backgroundColor: { default: "transparent", ":hover": "var(--hb-color-canvas)" },
+    textDecoration: "none",
   },
   danger: { color: "var(--hb-color-error, #d32f2f)" },
 });

--- a/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
+++ b/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
@@ -1,6 +1,8 @@
+import { Link } from "react-router-dom";
 import * as stylex from "@stylexjs/stylex";
 import { ConfirmDialog, Hb } from "hobom-design-system";
 import { VERIFIED_CHANNEL_LABEL } from "@/entities/user";
+import { ROUTES } from "@/shared/config";
 import { useOverlay } from "@/shared/model";
 import { useMyProfile } from "../model/useMyProfile";
 import { useWithdrawAccount } from "../model/useWithdrawAccount";
@@ -74,6 +76,18 @@ export const MyProfile = ({ onLogout }: MyProfileProps) => {
           </Hb.Button>
         </div>
       </Hb.Card.Root>
+
+      <section {...stylex.props(styles.section)}>
+        <h3 {...stylex.props(styles.sectionTitle)}>내 활동</h3>
+        <div {...stylex.props(styles.actions)}>
+          <Link to={ROUTES.APPLICATIONS} {...stylex.props(styles.actionRow)}>
+            내 신청 내역
+          </Link>
+          <Link to={ROUTES.FAVORITES} {...stylex.props(styles.actionRow)}>
+            찜한 동물·팔로우
+          </Link>
+        </div>
+      </section>
 
       <section {...stylex.props(styles.section)}>
         <h3 {...stylex.props(styles.sectionTitle)}>계정 관리</h3>

--- a/apps/hobom-angel/src/features/my-applications/index.ts
+++ b/apps/hobom-angel/src/features/my-applications/index.ts
@@ -1,0 +1,1 @@
+export { MyApplications } from "./ui/MyApplications";

--- a/apps/hobom-angel/src/features/my-applications/lib/my-applications.lib.spec.ts
+++ b/apps/hobom-angel/src/features/my-applications/lib/my-applications.lib.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { ApplicationSummary } from "@/entities/application";
+import { sortByRecent } from "./my-applications.lib";
+
+const app = (id: string, createdAt: string | null): ApplicationSummary => ({
+  id,
+  kind: "ADOPTION",
+  animalId: "a",
+  shelterId: "s",
+  applicantId: "u",
+  status: "PENDING",
+  questionnaireVersion: 1,
+  plannedEndDate: null,
+  createdAt,
+});
+
+describe("sortByRecent", () => {
+  it("orders newest first", () => {
+    const sorted = sortByRecent([
+      app("old", "2026-06-01T00:00:00.000Z"),
+      app("new", "2026-07-01T00:00:00.000Z"),
+      app("mid", "2026-06-15T00:00:00.000Z"),
+    ]);
+
+    expect(sorted.map((a) => a.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("sorts undated applications last", () => {
+    const sorted = sortByRecent([app("none", null), app("dated", "2026-07-01T00:00:00.000Z")]);
+
+    expect(sorted.map((a) => a.id)).toEqual(["dated", "none"]);
+  });
+
+  it("does not mutate the input", () => {
+    const input = [app("a", "2026-06-01T00:00:00.000Z"), app("b", "2026-07-01T00:00:00.000Z")];
+
+    sortByRecent(input);
+
+    expect(input.map((a) => a.id)).toEqual(["a", "b"]);
+  });
+});

--- a/apps/hobom-angel/src/features/my-applications/lib/my-applications.lib.ts
+++ b/apps/hobom-angel/src/features/my-applications/lib/my-applications.lib.ts
@@ -1,0 +1,11 @@
+import type { ApplicationSummary } from "@/entities/application";
+
+/** Merge the adoption + foster lists into one, newest first (nulls last). */
+export const sortByRecent = (applications: readonly ApplicationSummary[]): ApplicationSummary[] =>
+  [...applications].sort((a, b) => {
+    if (a.createdAt === b.createdAt) return 0;
+    if (a.createdAt === null) return 1;
+    if (b.createdAt === null) return -1;
+
+    return a.createdAt < b.createdAt ? 1 : -1;
+  });

--- a/apps/hobom-angel/src/features/my-applications/model/useMyApplications.ts
+++ b/apps/hobom-angel/src/features/my-applications/model/useMyApplications.ts
@@ -1,0 +1,24 @@
+import { useSuspenseQueries } from "hobom-data";
+import { animalQueries } from "@/entities/animal";
+import { applicationQueries } from "@/entities/application";
+import type { AnimalDetail } from "@/entities/animal";
+import { sortByRecent } from "../lib/my-applications.lib";
+
+/** The viewer's adoption + foster applications, merged newest-first, with each
+ *  application's animal hydrated for its name and photo. */
+export const useMyApplications = () => {
+  const [{ data: adoption }, { data: foster }] = useSuspenseQueries({
+    queries: [applicationQueries.mine("ADOPTION"), applicationQueries.mine("FOSTER")],
+  });
+  const applications = sortByRecent([...adoption.applications, ...foster.applications]);
+
+  const animalIds = [...new Set(applications.map((application) => application.animalId))];
+  const animals = useSuspenseQueries({
+    queries: animalIds.map((id) => animalQueries.detail(id)),
+  });
+  const animalById = new Map<string, AnimalDetail>(
+    animals.map((result) => [result.data.id, result.data]),
+  );
+
+  return { applications, animal: (animalId: string) => animalById.get(animalId) };
+};

--- a/apps/hobom-angel/src/features/my-applications/ui/ApplicationCard.tsx
+++ b/apps/hobom-angel/src/features/my-applications/ui/ApplicationCard.tsx
@@ -1,0 +1,35 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { AnimalCard, STATUS_LABEL as ANIMAL_STATUS_LABEL, animalMeta } from "@/entities/animal";
+import { KIND_LABEL, STATUS_COLOR, STATUS_LABEL } from "@/entities/application";
+import { animalDetailPath } from "@/shared/config";
+import type { AnimalDetail } from "@/entities/animal";
+import type { ApplicationSummary } from "@/entities/application";
+import { styles } from "./MyApplications.styles";
+
+interface ApplicationCardProps {
+  application: ApplicationSummary;
+  animal: AnimalDetail | undefined;
+}
+
+/** An application shown as an animal card (matching 찜한 동물), with the
+ *  application's kind · status overlaid on the photo. */
+export const ApplicationCard = ({ application, animal }: ApplicationCardProps) => (
+  <AnimalCard
+    name={animal?.name ?? "이름 미상"}
+    status={animal ? ANIMAL_STATUS_LABEL[animal.status] : "입양가능"}
+    meta={animal ? animalMeta(animal) : ""}
+    imageUrl={animal?.photoUrl}
+    to={animalDetailPath(application.animalId)}
+    action={
+      <span {...stylex.props(styles.badge)}>
+        <Hb.Chip
+          label={`${KIND_LABEL[application.kind]} · ${STATUS_LABEL[application.status]}`}
+          color={STATUS_COLOR[application.status]}
+          variant="filled"
+          size="small"
+        />
+      </span>
+    }
+  />
+);

--- a/apps/hobom-angel/src/features/my-applications/ui/MyApplications.styles.ts
+++ b/apps/hobom-angel/src/features/my-applications/ui/MyApplications.styles.ts
@@ -1,0 +1,42 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: 40,
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+  },
+  header: { display: "flex", flexDirection: "column", gap: 6 },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: { margin: 0, fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(2, 1fr)",
+      [TABLET]: "repeat(3, 1fr)",
+      [DESKTOP]: "repeat(4, 1fr)",
+    },
+    gap: { default: 12, [DESKTOP]: 16 },
+    paddingTop: 8,
+  },
+  // Application kind · status, overlaid on the card photo (top-left).
+  badge: {
+    position: "absolute",
+    insetBlockStart: 8,
+    insetInlineStart: 8,
+    zIndex: 1,
+  },
+});

--- a/apps/hobom-angel/src/features/my-applications/ui/MyApplications.tsx
+++ b/apps/hobom-angel/src/features/my-applications/ui/MyApplications.tsx
@@ -1,0 +1,38 @@
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState } from "hobom-design-system";
+import { ArticleOutlined } from "hobom-design-system/icons";
+import { useMyApplications } from "../model/useMyApplications";
+import { ApplicationCard } from "./ApplicationCard";
+import { styles } from "./MyApplications.styles";
+
+/** 내 신청 내역 — the viewer's adoption + foster applications, newest first,
+ *  laid out as an animal-card grid (matching 찜한 동물). */
+export const MyApplications = () => {
+  const { applications, animal } = useMyApplications();
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <h1 {...stylex.props(styles.title)}>내 신청 내역</h1>
+        <p {...stylex.props(styles.subtitle)}>입양·임시보호 신청 현황을 확인해요.</p>
+      </header>
+
+      {applications.length === 0 ? (
+        <EmptyState
+          icon={<ArticleOutlined style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }} />}
+          message="아직 신청한 내역이 없어요."
+        />
+      ) : (
+        <div {...stylex.props(styles.grid)}>
+          {applications.map((application) => (
+            <ApplicationCard
+              key={application.id}
+              application={application}
+              animal={animal(application.animalId)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/application.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/application.handlers.ts
@@ -138,6 +138,23 @@ export const applicationHandlers = [
     return queue(FOSTER_APPLICATIONS, new URL(request.url).searchParams.get("status"));
   }),
 
+  // §05 consumer — the viewer's own applications (내 신청 내역).
+  http.get(mockUrl("/me/adoption-applications"), ({ request }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    return queue(ADOPTION_APPLICATIONS, new URL(request.url).searchParams.get("status"));
+  }),
+
+  http.get(mockUrl("/me/foster-applications"), ({ request }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    return queue(FOSTER_APPLICATIONS, new URL(request.url).searchParams.get("status"));
+  }),
+
   http.get(mockUrl("/adoption-applications/:id"), ({ params }) => {
     if (!mockSession.isActive()) {
       return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });

--- a/apps/hobom-angel/src/pages/applications/index.ts
+++ b/apps/hobom-angel/src/pages/applications/index.ts
@@ -1,0 +1,1 @@
+export { ApplicationsPage } from "./ui/ApplicationsPage";

--- a/apps/hobom-angel/src/pages/applications/ui/ApplicationsPage.tsx
+++ b/apps/hobom-angel/src/pages/applications/ui/ApplicationsPage.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from "react";
+import { MyApplications } from "@/features/my-applications";
+import { LoadingState } from "@/shared/ui";
+
+export const ApplicationsPage = () => (
+  <Suspense fallback={<LoadingState />}>
+    <MyApplications />
+  </Suspense>
+);


### PR DESCRIPTION
Turns the `/applications` ComingSoon placeholder into a real 내 신청 내역 screen, backed by the new `GET /me/adoption-applications` + `GET /me/foster-applications` endpoints.

## What's included
- The viewer's adoption + foster applications merged **newest-first**, laid out as an **animal-card grid matching 찜한 동물** (same container, header, and responsive 2/3/4-column grid)
- Each card overlays the application's **kind · status** (e.g. `입양 · 심사 중`) on the photo and links to the animal
- A **내 활동** section on 마이페이지 links to it (and to 찜)
- Extends the `application` entity with a `mine` query, a `sortByRecent` helper with unit tests, mock me-endpoints, and an e2e

## Verification
Typecheck, lint (0 warnings), unit tests (142), and the my-applications e2e all pass.

This also sets up the review-compose flow: an APPROVED application here carries the `placementRef` a 후기 needs — a natural next step.