### PR TITLE
Let adopters write a shelter review from a completed placement

### DIFF
--- a/apps/hobom-angel/e2e/my-applications.spec.ts
+++ b/apps/hobom-angel/e2e/my-applications.spec.ts
@@ -34,4 +34,21 @@ test.describe("§05 my applications", () => {
     await page.getByRole("link", { name: /콩이/ }).first().click();
     await expect(page).toHaveURL(/\/animals\/animal-\d+$/);
   });
+
+  test("writes a review for an approved placement", async ({ page }) => {
+    await login(page);
+    await page.goto("applications");
+
+    // Approved applications expose a review CTA.
+    await page.getByRole("button", { name: "후기 남기기" }).first().click();
+
+    await expect(page.getByRole("heading", { name: "후기 남기기" })).toBeVisible();
+    await page.getByRole("button", { name: "4점" }).click();
+    await page
+      .getByPlaceholder("보호소와의 경험, 아이의 근황을 자유롭게 남겨주세요")
+      .fill("입양 내내 세심하게 챙겨주셔서 감사했어요. 아이도 잘 적응하고 있어요.");
+    await page.getByRole("button", { name: "등록" }).click();
+
+    await expect(page.getByText("후기를 남겼어요. 감사합니다!")).toBeVisible();
+  });
 });

--- a/apps/hobom-angel/src/entities/review/api/review.api.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.api.ts
@@ -1,11 +1,13 @@
 import { httpClient, parseResponse } from "@/shared/api";
 import { toQueryString } from "@/shared/lib";
-import { reputationSchema, reviewsPageSchema } from "./review.schema";
+import { createdReviewSchema, reputationSchema, reviewsPageSchema } from "./review.schema";
 import { toReputation, toReview } from "../lib/to-review.lib";
 import type { ReviewPage, ShelterReputation } from "../model/review.model";
+import type { SubmitReviewInput } from "./review.type";
 
 const parsePage = parseResponse(reviewsPageSchema, "GET /shelters/:id/reviews");
 const parseReputation = parseResponse(reputationSchema, "GET /shelters/:id/reviews/reputation");
+const parseCreated = parseResponse(createdReviewSchema, "POST /shelters/:id/reviews");
 
 /** A cursor page of a shelter's reviews (newest first). */
 export const getShelterReviews = (
@@ -31,3 +33,10 @@ export const getShelterReputation = (
     .get(`/shelters/${shelterId}/reviews/reputation`, { signal })
     .then(parseReputation)
     .then(toReputation);
+
+/** Write a review for a completed placement (완료된 입양/임보자만). */
+export const submitReview = (shelterId: string, input: SubmitReviewInput): Promise<string> =>
+  httpClient
+    .post(`/shelters/${shelterId}/reviews`, input)
+    .then(parseCreated)
+    .then((created) => created.reviewId);

--- a/apps/hobom-angel/src/entities/review/api/review.mutations.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.mutations.ts
@@ -1,0 +1,13 @@
+import { mutationOptions } from "hobom-data";
+import { submitReview } from "./review.api";
+import type { SubmitReviewInput } from "./review.type";
+
+export const reviewMutations = {
+  // shelterId changes with the application under review, so it rides in the
+  // mutate vars rather than being bound at render time.
+  submit: () =>
+    mutationOptions({
+      mutationFn: (vars: { shelterId: string; input: SubmitReviewInput }) =>
+        submitReview(vars.shelterId, vars.input),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/review/api/review.schema.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.schema.ts
@@ -1,6 +1,11 @@
 import { HoBomSchema } from "hobom-schema";
 import type { Schema } from "hobom-schema";
-import type { RawReputation, RawReview, RawReviewsPage } from "./review.type";
+import type {
+  RawCreatedReview,
+  RawReputation,
+  RawReview,
+  RawReviewsPage,
+} from "./review.type";
 
 const reviewSchema: Schema<RawReview> = HoBomSchema.object({
   id: HoBomSchema.string(),
@@ -17,6 +22,11 @@ export const reviewsPageSchema: Schema<RawReviewsPage> = HoBomSchema.object({
   items: HoBomSchema.array(reviewSchema),
   nextCursor: HoBomSchema.string().nullable(),
   hasNext: HoBomSchema.boolean(),
+});
+
+/** `POST /shelters/:id/reviews` — the created review id. */
+export const createdReviewSchema: Schema<RawCreatedReview> = HoBomSchema.object({
+  reviewId: HoBomSchema.string(),
 });
 
 /** `GET /shelters/:id/reviews/reputation` — mean + star histogram. */

--- a/apps/hobom-angel/src/entities/review/api/review.type.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.type.ts
@@ -22,3 +22,16 @@ export interface RawReputation {
   average: number;
   distribution: { "1": number; "2": number; "3": number; "4": number; "5": number };
 }
+
+/** `POST /shelters/:id/reviews` request — anchored to a completed placement. */
+export interface SubmitReviewInput {
+  placementType: PlacementType;
+  /** The completed adoption/foster application id. */
+  placementRef: string;
+  rating: number;
+  body: string;
+}
+
+export interface RawCreatedReview {
+  reviewId: string;
+}

--- a/apps/hobom-angel/src/entities/review/index.ts
+++ b/apps/hobom-angel/src/entities/review/index.ts
@@ -1,4 +1,5 @@
 export { reviewQueries } from "./api/review.queries";
+export { reviewMutations } from "./api/review.mutations";
 export { PLACEMENT_LABEL } from "./model/review.model";
 export type {
   Review,
@@ -7,3 +8,4 @@ export type {
   PlacementType,
   StarRating,
 } from "./model/review.model";
+export type { SubmitReviewInput } from "./api/review.type";

--- a/apps/hobom-angel/src/features/my-applications/model/useSubmitReview.ts
+++ b/apps/hobom-angel/src/features/my-applications/model/useSubmitReview.ts
@@ -1,0 +1,25 @@
+import { useMutation } from "hobom-data";
+import { reviewMutations } from "@/entities/review";
+import { useToast } from "@/shared/model";
+import type { SubmitReviewInput } from "@/entities/review";
+
+/** Submit a shelter review for a completed placement, with toast feedback. */
+export const useSubmitReview = (onDone: () => void) => {
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const mutation = useMutation({
+    ...reviewMutations.submit(),
+    onSuccess: () => {
+      openSuccessToast({ message: "후기를 남겼어요. 감사합니다!" });
+      onDone();
+    },
+    onError: (error: Error) =>
+      openErrorToast({ message: error.message || "후기 등록에 실패했어요." }),
+  });
+
+  return {
+    submit: (shelterId: string, input: SubmitReviewInput) =>
+      mutation.mutate({ shelterId, input }),
+    submitting: mutation.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/my-applications/ui/MyApplications.styles.ts
+++ b/apps/hobom-angel/src/features/my-applications/ui/MyApplications.styles.ts
@@ -39,4 +39,46 @@ export const styles = stylex.create({
     insetInlineStart: 8,
     zIndex: 1,
   },
+  // A grid cell: the card plus an optional "후기 남기기" action beneath it.
+  cell: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+  },
+  reviewCta: {
+    padding: "8px 12px",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "oklch(0.86 0.06 155)",
+    fontFamily: "inherit",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-accent-dark, oklch(0.46 0.08 155))",
+    backgroundColor: { default: "oklch(0.97 0.02 155)", ":hover": "oklch(0.93 0.045 155)" },
+    cursor: "pointer",
+  },
+  // Compose dialog.
+  composeIntro: {
+    margin: "0 0 12px",
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  stars: {
+    display: "flex",
+    gap: 4,
+    marginBottom: 14,
+  },
+  star: {
+    padding: 2,
+    border: "none",
+    background: "none",
+    fontSize: "1.75rem",
+    lineHeight: 1,
+    color: "var(--hb-color-border)",
+    cursor: "pointer",
+  },
+  starOn: {
+    color: "var(--hb-color-accent)",
+  },
 });

--- a/apps/hobom-angel/src/features/my-applications/ui/MyApplications.tsx
+++ b/apps/hobom-angel/src/features/my-applications/ui/MyApplications.tsx
@@ -1,14 +1,28 @@
 import * as stylex from "@stylexjs/stylex";
 import { EmptyState } from "hobom-design-system";
 import { ArticleOutlined } from "hobom-design-system/icons";
+import { useOverlay } from "@/shared/model";
+import type { ApplicationSummary } from "@/entities/application";
 import { useMyApplications } from "../model/useMyApplications";
 import { ApplicationCard } from "./ApplicationCard";
+import { ReviewComposeDialog } from "./ReviewComposeDialog";
 import { styles } from "./MyApplications.styles";
 
 /** 내 신청 내역 — the viewer's adoption + foster applications, newest first,
- *  laid out as an animal-card grid (matching 찜한 동물). */
+ *  laid out as an animal-card grid (matching 찜한 동물). Completed placements
+ *  can leave a review. */
 export const MyApplications = () => {
   const { applications, animal } = useMyApplications();
+  const overlay = useOverlay();
+
+  const compose = (application: ApplicationSummary) =>
+    overlay.open(({ close }) => (
+      <ReviewComposeDialog
+        application={application}
+        animalName={animal(application.animalId)?.name ?? "이 아이"}
+        onClose={close}
+      />
+    ));
 
   return (
     <div {...stylex.props(styles.root)}>
@@ -25,11 +39,18 @@ export const MyApplications = () => {
       ) : (
         <div {...stylex.props(styles.grid)}>
           {applications.map((application) => (
-            <ApplicationCard
-              key={application.id}
-              application={application}
-              animal={animal(application.animalId)}
-            />
+            <div key={application.id} {...stylex.props(styles.cell)}>
+              <ApplicationCard application={application} animal={animal(application.animalId)} />
+              {application.status === "APPROVED" && (
+                <button
+                  type="button"
+                  {...stylex.props(styles.reviewCta)}
+                  onClick={() => compose(application)}
+                >
+                  후기 남기기
+                </button>
+              )}
+            </div>
           ))}
         </div>
       )}

--- a/apps/hobom-angel/src/features/my-applications/ui/ReviewComposeDialog.tsx
+++ b/apps/hobom-angel/src/features/my-applications/ui/ReviewComposeDialog.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { ApplicationSummary } from "@/entities/application";
+import { useSubmitReview } from "../model/useSubmitReview";
+import { styles } from "./MyApplications.styles";
+
+const StarInput = ({ value, onChange }: { value: number; onChange: (rating: number) => void }) => (
+  <div {...stylex.props(styles.stars)} role="radiogroup" aria-label="별점">
+    {[1, 2, 3, 4, 5].map((n) => (
+      <button
+        key={n}
+        type="button"
+        {...stylex.props(styles.star, n <= value && styles.starOn)}
+        onClick={() => onChange(n)}
+        aria-label={`${n}점`}
+        aria-pressed={value === n}
+      >
+        ★
+      </button>
+    ))}
+  </div>
+);
+
+interface ReviewComposeDialogProps {
+  application: ApplicationSummary;
+  animalName: string;
+  onClose: () => void;
+}
+
+/** Write a review for a completed adoption/foster, anchored to that placement. */
+export const ReviewComposeDialog = ({
+  application,
+  animalName,
+  onClose,
+}: ReviewComposeDialogProps) => {
+  const [rating, setRating] = useState(5);
+  const [body, setBody] = useState("");
+  const { submit, submitting } = useSubmitReview(onClose);
+
+  const canSubmit = body.trim().length > 0 && !submitting;
+
+  const onSubmit = () => {
+    if (!canSubmit) return;
+
+    submit(application.shelterId, {
+      placementType: application.kind,
+      placementRef: application.id,
+      rating,
+      body: body.trim(),
+    });
+  };
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="sm">
+      <Hb.Dialog.Title>후기 남기기</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <p {...stylex.props(styles.composeIntro)}>{animalName}와 함께한 경험을 들려주세요.</p>
+        <StarInput value={rating} onChange={setRating} />
+        <Hb.TextField
+          placeholder="보호소와의 경험, 아이의 근황을 자유롭게 남겨주세요"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+          autoFocus
+        />
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          취소
+        </Hb.Button>
+        <Hb.Button variant="primary" onClick={onSubmit} disabled={!canSubmit} loading={submitting}>
+          등록
+        </Hb.Button>
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
@@ -99,4 +99,15 @@ export const reviewHandlers = [
 
     return ok({ items, nextCursor: null, hasNext: false });
   }),
+
+  // §04 — write a review for a completed placement.
+  http.post(mockUrl("/shelters/:shelterId/reviews"), async ({ request }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    await request.json();
+
+    return ok({ reviewId: `review-${REVIEWS.length + 1}` });
+  }),
 ];


### PR DESCRIPTION
Completes the shelter reviews feature. The microsite 후기 tab (#231) was read-only because writing a review needs a completed-placement reference; now that 내 신청 내역 surfaces approved applications, that reference is available.

## What's included
- On **내 신청 내역**, an **APPROVED** application shows a **후기 남기기** action
- It opens a compose dialog — a 1–5 star rating input and a text area — and posts to `POST /shelters/:id/reviews`, anchored to the placement (`placementType` + `placementRef` = the application id) as the verified experience
- Extends the `review` entity with `submitReview` + a `submit` mutation, adds the compose dialog + star input to `my-applications`, a mock write handler, and an e2e

## Notes
No dedicated design mockup exists for shelter-review compose (the design's "후기·홍보글" is the volunteer feed, already built), so the dialog follows the app's existing dialog conventions (Hb.Dialog, like the nickname editor). The CTA is shown only for APPROVED placements; the backend enforces final eligibility.

## Verification
Typecheck, lint (0 warnings), unit tests (148), and the my-applications e2e (incl. the review flow) all pass.