### PR TITLE
Wire the operator approval queue to the pending-request API

### DIFF
--- a/apps/hobom-angel/e2e/operator-approvals.spec.ts
+++ b/apps/hobom-angel/e2e/operator-approvals.spec.ts
@@ -10,7 +10,7 @@ const login = async (page: Page) => {
 };
 
 test.describe("§09 operator — approval queue", () => {
-  test("processes a report and switches tabs", async ({ page }) => {
+  test("reviews the pending queue and moderates a report", async ({ page }) => {
     await login(page);
 
     // Reachable from 마이페이지 for an operator.
@@ -19,21 +19,27 @@ test.describe("§09 operator — approval queue", () => {
     await expect(page).toHaveURL(/\/operator\/approvals$/);
 
     await expect(page.getByRole("heading", { name: "승인 큐" })).toBeVisible();
-    await expect(page.getByRole("tab", { name: "신고 3" })).toBeVisible();
 
-    // A seeded report with its target/reason headline.
+    // Default tab: 보호소 검증 — its real pending queue with approve / reject.
+    await expect(page.getByRole("tab", { name: "보호소 검증 2" })).toBeVisible();
+    await expect(page.getByText("보호소 검증 요청").first()).toBeVisible();
+
+    // Approve one — the queue shrinks and the tab count drops.
+    await page
+      .getByRole("button", { name: "승인" })
+      .first()
+      .click();
+    await expect(page.getByText("승인했어요.")).toBeVisible();
+    await expect(page.getByRole("tab", { name: "보호소 검증 1" })).toBeVisible();
+
+    // The 신고 tab still moderates reports.
+    await page.getByRole("tab", { name: "신고 3" }).click();
     await expect(page.getByText("보호소 신고 · 허위 보호소")).toBeVisible();
-
-    // Dismiss it — the queue shrinks.
     await page
       .getByRole("button", { name: "기각" })
       .first()
       .click();
     await expect(page.getByText("신고를 처리했어요.")).toBeVisible();
     await expect(page.getByRole("tab", { name: "신고 2" })).toBeVisible();
-
-    // Other tabs await their backend endpoint.
-    await page.getByRole("tab", { name: "보호소 검증" }).click();
-    await expect(page.getByText(/대기 목록 엔드포인트/)).toBeVisible();
   });
 });

--- a/apps/hobom-angel/src/entities/approval/api/approval.api.ts
+++ b/apps/hobom-angel/src/entities/approval/api/approval.api.ts
@@ -1,0 +1,48 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { pendingApprovalCountsSchema, pendingApprovalPageSchema } from "./approval.schema";
+import type { ApprovalType, PendingApprovalCounts } from "../model/approval.model";
+import type {
+  DecideApprovalInput,
+  PendingApprovalPage,
+  RawPendingApprovalPage,
+} from "./approval.type";
+
+const PAGE_SIZE = 20;
+
+const parsePage = parseResponse(pendingApprovalPageSchema, "GET /approvals/pending");
+const parseCounts = parseResponse(pendingApprovalCountsSchema, "GET /approvals/pending/counts");
+
+/** One cursor page of the operator's pending queue, optionally filtered by type. */
+export const getPendingApprovals = (
+  type: ApprovalType | undefined,
+  cursor: string | undefined,
+  signal?: AbortSignal,
+): Promise<PendingApprovalPage> => {
+  const query = new URLSearchParams({ limit: String(PAGE_SIZE) });
+
+  if (type) query.set("type", type);
+  if (cursor) query.set("cursor", cursor);
+
+  return httpClient
+    .get<RawPendingApprovalPage>(`/approvals/pending?${query.toString()}`, { signal })
+    .then((page) => {
+      // Advisory scalar check; the raw page is kept so `context` survives.
+      parsePage(page);
+
+      return {
+        approvals: page.items,
+        nextCursor: page.nextCursor,
+        hasNext: page.hasNext,
+      };
+    });
+};
+
+/** Pending counts per type — the queue's tab badges. */
+export const getPendingApprovalCounts = (signal?: AbortSignal): Promise<PendingApprovalCounts> =>
+  httpClient
+    .get<PendingApprovalCounts>("/approvals/pending/counts", { signal })
+    .then(parseCounts);
+
+/** Decide a pending request — approve or reject (reason required on a reject). */
+export const decideApproval = (approvalId: string, input: DecideApprovalInput): Promise<void> =>
+  httpClient.post(`/approvals/${approvalId}/decision`, input).then(() => undefined);

--- a/apps/hobom-angel/src/entities/approval/api/approval.mutations.ts
+++ b/apps/hobom-angel/src/entities/approval/api/approval.mutations.ts
@@ -1,0 +1,11 @@
+import { mutationOptions } from "hobom-data";
+import { decideApproval } from "./approval.api";
+import type { DecideApprovalInput } from "./approval.type";
+
+export const approvalMutations = {
+  decide: () =>
+    mutationOptions({
+      mutationFn: (vars: { approvalId: string; input: DecideApprovalInput }) =>
+        decideApproval(vars.approvalId, vars.input),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/approval/api/approval.queries.ts
+++ b/apps/hobom-angel/src/entities/approval/api/approval.queries.ts
@@ -1,0 +1,22 @@
+import { infiniteQueryOptions, queryOptions } from "hobom-data";
+import { getPendingApprovalCounts, getPendingApprovals } from "./approval.api";
+import type { ApprovalType } from "../model/approval.model";
+
+export const approvalQueries = {
+  all: () => ["approvals"] as const,
+
+  pending: (type: ApprovalType) =>
+    infiniteQueryOptions({
+      queryKey: [...approvalQueries.all(), "pending", type] as const,
+      queryFn: ({ pageParam, signal }) => getPendingApprovals(type, pageParam, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined,
+      initialPageParam: undefined as string | undefined,
+    }),
+
+  counts: () =>
+    queryOptions({
+      queryKey: [...approvalQueries.all(), "counts"] as const,
+      queryFn: ({ signal }) => getPendingApprovalCounts(signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/approval/api/approval.schema.ts
+++ b/apps/hobom-angel/src/entities/approval/api/approval.schema.ts
@@ -1,0 +1,36 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { PendingApprovalCounts } from "../model/approval.model";
+
+const approvalType = HoBomSchema.enum([
+  "SHELTER_VERIFICATION",
+  "STAFF_PROMOTION",
+  "ADOPTION",
+  "FOSTER",
+]);
+
+// `context` is intentionally left out — it's a free-form, type-specific record
+// the object schema can't carry, so the scalars are validated advisorily and
+// `context` is read straight from the raw payload.
+const pendingApprovalSchema = HoBomSchema.object({
+  approvalId: HoBomSchema.string(),
+  type: approvalType,
+  subjectRef: HoBomSchema.string(),
+  requesterId: HoBomSchema.string(),
+  createdAt: HoBomSchema.string().nullable(),
+});
+
+/** `GET /approvals/pending` — one cursor page (scalars only; advisory). */
+export const pendingApprovalPageSchema = HoBomSchema.object({
+  items: HoBomSchema.array(pendingApprovalSchema),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});
+
+/** `GET /approvals/pending/counts` — per-type badges. */
+export const pendingApprovalCountsSchema: Schema<PendingApprovalCounts> = HoBomSchema.object({
+  SHELTER_VERIFICATION: HoBomSchema.number(),
+  STAFF_PROMOTION: HoBomSchema.number(),
+  ADOPTION: HoBomSchema.number(),
+  FOSTER: HoBomSchema.number(),
+});

--- a/apps/hobom-angel/src/entities/approval/api/approval.type.ts
+++ b/apps/hobom-angel/src/entities/approval/api/approval.type.ts
@@ -1,0 +1,31 @@
+import type { ApprovalDecision, ApprovalType, PendingApproval } from "../model/approval.model";
+
+export interface RawPendingApproval {
+  approvalId: string;
+  type: ApprovalType;
+  subjectRef: string;
+  requesterId: string;
+  context: Record<string, unknown> | null;
+  createdAt: string | null;
+}
+
+/** The wire shape of one cursor page (envelope already unwrapped). */
+export interface RawPendingApprovalPage {
+  items: RawPendingApproval[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+/** One cursor page of the pending queue, in domain shape. */
+export interface PendingApprovalPage {
+  approvals: PendingApproval[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+/** `POST /approvals/:id/decision` request. `reason` is required on a reject. */
+export interface DecideApprovalInput {
+  decision: ApprovalDecision;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/apps/hobom-angel/src/entities/approval/index.ts
+++ b/apps/hobom-angel/src/entities/approval/index.ts
@@ -1,0 +1,10 @@
+export { approvalQueries } from "./api/approval.queries";
+export { approvalMutations } from "./api/approval.mutations";
+export { APPROVAL_TYPE_LABEL } from "./model/approval.model";
+export type {
+  ApprovalType,
+  ApprovalDecision,
+  PendingApproval,
+  PendingApprovalCounts,
+} from "./model/approval.model";
+export type { DecideApprovalInput } from "./api/approval.type";

--- a/apps/hobom-angel/src/entities/approval/model/approval.model.ts
+++ b/apps/hobom-angel/src/entities/approval/model/approval.model.ts
@@ -1,0 +1,29 @@
+/** The kinds of decision the operator approval queue handles (§09). */
+export type ApprovalType = "SHELTER_VERIFICATION" | "STAFF_PROMOTION" | "ADOPTION" | "FOSTER";
+
+/** The operator's verdict on a pending request. */
+export type ApprovalDecision = "APPROVE" | "REJECT";
+
+/**
+ * One pending request in the operator queue. Type-agnostic: `subjectRef` is the
+ * target entity id and `context` the submit-time payload, both type-specific.
+ * Feed `approvalId` to the decision endpoint.
+ */
+export interface PendingApproval {
+  approvalId: string;
+  type: ApprovalType;
+  subjectRef: string;
+  requesterId: string;
+  context: Record<string, unknown> | null;
+  createdAt: string | null;
+}
+
+/** Pending counts per type — the queue's tab badges. */
+export type PendingApprovalCounts = Record<ApprovalType, number>;
+
+export const APPROVAL_TYPE_LABEL: Record<ApprovalType, string> = {
+  SHELTER_VERIFICATION: "보호소 검증",
+  STAFF_PROMOTION: "스태프 승격",
+  ADOPTION: "입양",
+  FOSTER: "임보",
+};

--- a/apps/hobom-angel/src/features/operator-approvals/lib/approval-format.lib.spec.ts
+++ b/apps/hobom-angel/src/features/operator-approvals/lib/approval-format.lib.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { PendingApproval } from "@/entities/approval";
+import {
+  approvalContextLine,
+  approvalHeadline,
+  formatApprovalDate,
+  maskRequester,
+  subjectTag,
+} from "./approval-format.lib";
+
+const make = (over: Partial<PendingApproval>): PendingApproval => ({
+  approvalId: "ap-1",
+  type: "ADOPTION",
+  subjectRef: "adoption-abc123",
+  requesterId: "user-xyz789",
+  context: null,
+  createdAt: null,
+  ...over,
+});
+
+describe("approvalHeadline", () => {
+  it("labels each type with a 요청 suffix", () => {
+    expect(approvalHeadline("SHELTER_VERIFICATION")).toBe("보호소 검증 요청");
+    expect(approvalHeadline("STAFF_PROMOTION")).toBe("스태프 승격 요청");
+    expect(approvalHeadline("ADOPTION")).toBe("입양 요청");
+    expect(approvalHeadline("FOSTER")).toBe("임보 요청");
+  });
+});
+
+describe("subjectTag", () => {
+  it("names the subject per type and shortens the id", () => {
+    expect(subjectTag(make({ type: "SHELTER_VERIFICATION", subjectRef: "shelter-9900aa" }))).toBe(
+      "보호소 #9900aa",
+    );
+    expect(subjectTag(make({ type: "STAFF_PROMOTION", subjectRef: "user-4455bb" }))).toBe(
+      "대상 회원 #4455bb",
+    );
+    expect(subjectTag(make({ type: "ADOPTION", subjectRef: "adoption-abc123" }))).toBe(
+      "신청서 #abc123",
+    );
+  });
+});
+
+describe("maskRequester", () => {
+  it("keeps only the id tail", () => {
+    expect(maskRequester("user-xyz789")).toBe("요청자 xyz789");
+  });
+});
+
+describe("approvalContextLine", () => {
+  it("prefers the animal, then the shelter, else null", () => {
+    expect(approvalContextLine(make({ context: { animalId: "animal-770077" } }))).toBe(
+      "대상 동물 #770077",
+    );
+    expect(approvalContextLine(make({ context: { shelterId: "shelter-110022" } }))).toBe(
+      "소속 보호소 #110022",
+    );
+    expect(approvalContextLine(make({ context: null }))).toBeNull();
+    expect(approvalContextLine(make({ context: { note: "x" } }))).toBeNull();
+  });
+});
+
+describe("formatApprovalDate", () => {
+  it("formats an ISO date and passes null through", () => {
+    expect(formatApprovalDate("2026-07-26T01:20:00Z")).toContain("7월");
+    expect(formatApprovalDate(null)).toBeNull();
+  });
+});

--- a/apps/hobom-angel/src/features/operator-approvals/lib/approval-format.lib.ts
+++ b/apps/hobom-angel/src/features/operator-approvals/lib/approval-format.lib.ts
@@ -1,0 +1,36 @@
+import { APPROVAL_TYPE_LABEL } from "@/entities/approval";
+import type { ApprovalType, PendingApproval } from "@/entities/approval";
+
+/** The card heading, e.g. "보호소 검증 요청". */
+export const approvalHeadline = (type: ApprovalType): string => `${APPROVAL_TYPE_LABEL[type]} 요청`;
+
+/** What the subject id refers to, per type. */
+const SUBJECT_LABEL: Record<ApprovalType, string> = {
+  SHELTER_VERIFICATION: "보호소",
+  STAFF_PROMOTION: "대상 회원",
+  ADOPTION: "신청서",
+  FOSTER: "신청서",
+};
+
+/** A short, id-safe reference tag, e.g. "보호소 #a1b2c3". */
+export const subjectTag = (approval: PendingApproval): string =>
+  `${SUBJECT_LABEL[approval.type]} #${approval.subjectRef.slice(-6)}`;
+
+/** A privacy-safe requester handle (no PII is exposed). */
+export const maskRequester = (requesterId: string): string => `요청자 ${requesterId.slice(-6)}`;
+
+/** A one-line hint drawn from the submit-time context (best-effort, id-safe). */
+export const approvalContextLine = (approval: PendingApproval): string | null => {
+  const context = approval.context ?? {};
+  const animalId = typeof context.animalId === "string" ? context.animalId : null;
+  const shelterId = typeof context.shelterId === "string" ? context.shelterId : null;
+
+  if (animalId) return `대상 동물 #${animalId.slice(-6)}`;
+  if (shelterId) return `소속 보호소 #${shelterId.slice(-6)}`;
+
+  return null;
+};
+
+/** "7월 26일" — the request's submitted date, or null when absent. */
+export const formatApprovalDate = (iso: string | null): string | null =>
+  iso ? new Date(iso).toLocaleDateString("ko-KR", { month: "long", day: "numeric" }) : null;

--- a/apps/hobom-angel/src/features/operator-approvals/model/usePendingApprovals.ts
+++ b/apps/hobom-angel/src/features/operator-approvals/model/usePendingApprovals.ts
@@ -1,0 +1,39 @@
+import { useDataLot, useMutation, useSuspenseInfiniteQuery } from "hobom-data";
+import { approvalMutations, approvalQueries } from "@/entities/approval";
+import { useToast } from "@/shared/model";
+import type { ApprovalType, DecideApprovalInput } from "@/entities/approval";
+
+/** §09 승인 큐 — one type's pending list (cursor-paged) plus the approve /
+ *  reject decision, invalidating both the list and the tab-badge counts. */
+export const usePendingApprovals = (type: ApprovalType) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const listOptions = approvalQueries.pending(type);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSuspenseInfiniteQuery(listOptions);
+
+  const approvals = data.pages.flatMap((page) => page.approvals);
+
+  const decide = useMutation({
+    ...approvalMutations.decide(),
+    onSuccess: (_data, vars) => {
+      openSuccessToast({
+        message: vars.input.decision === "APPROVE" ? "승인했어요." : "반려했어요.",
+      });
+      void dataLot.invalidateQueries(listOptions);
+      void dataLot.invalidateQueries(approvalQueries.counts());
+    },
+    onError: (error: Error) => openErrorToast({ message: error.message || "처리에 실패했어요." }),
+  });
+
+  return {
+    approvals,
+    decide: (approvalId: string, input: DecideApprovalInput) =>
+      decide.mutate({ approvalId, input }),
+    deciding: decide.isPending,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage: () => void fetchNextPage(),
+  };
+};

--- a/apps/hobom-angel/src/features/operator-approvals/ui/ApprovalRejectDialog.tsx
+++ b/apps/hobom-angel/src/features/operator-approvals/ui/ApprovalRejectDialog.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Hb } from "hobom-design-system";
+
+interface ApprovalRejectDialogProps {
+  headline: string;
+  onConfirm: (reason: string) => void;
+  onClose: () => void;
+}
+
+/** Collect the required reason before rejecting a pending request. */
+export const ApprovalRejectDialog = ({
+  headline,
+  onConfirm,
+  onClose,
+}: ApprovalRejectDialogProps) => {
+  const [reason, setReason] = useState("");
+  const canSubmit = reason.trim().length > 0;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    onConfirm(reason.trim());
+    onClose();
+  };
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="xs">
+      <Hb.Dialog.Title>{headline} 반려</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <Hb.TextField
+          label="반려 사유"
+          placeholder="반려 사유를 입력하세요"
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          multiline
+          minRows={3}
+          fullWidth
+          autoFocus
+        />
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          취소
+        </Hb.Button>
+        <Hb.Button variant="danger" onClick={submit} disabled={!canSubmit}>
+          반려하기
+        </Hb.Button>
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.styles.ts
+++ b/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.styles.ts
@@ -72,16 +72,4 @@ export const styles = stylex.create({
     borderStyle: "dashed",
     borderColor: "var(--hb-color-border)",
   },
-  // Tabs whose data isn't wired yet (await backend list endpoints).
-  placeholder: {
-    padding: "44px 16px",
-    textAlign: "center",
-    color: "var(--hb-color-text-secondary)",
-    fontSize: "0.9375rem",
-    lineHeight: 1.6,
-    borderRadius: 14,
-    borderWidth: 1,
-    borderStyle: "dashed",
-    borderColor: "var(--hb-color-border)",
-  },
 });

--- a/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.tsx
+++ b/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.tsx
@@ -2,30 +2,28 @@ import { Suspense, useState } from "react";
 import { useSuspenseQuery } from "hobom-data";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
+import { APPROVAL_TYPE_LABEL, approvalQueries } from "@/entities/approval";
 import { reportQueries } from "@/entities/report";
 import { LoadingState } from "@/shared/ui";
+import type { ApprovalType } from "@/entities/approval";
+import { PendingApprovalQueue } from "./PendingApprovalQueue";
 import { ReportQueue } from "./ReportQueue";
 import { styles } from "./OperatorApprovals.styles";
 
-type ApprovalTab = "verification" | "promotion" | "placement" | "report";
+type Tab = ApprovalType | "REPORT";
 
-// Only the report tab is backed today; the rest await GET /approvals/pending.
-const PENDING_TABS: { value: ApprovalTab; label: string }[] = [
-  { value: "verification", label: "보호소 검증" },
-  { value: "promotion", label: "스태프 승격" },
-  { value: "placement", label: "입양·임보" },
+const APPROVAL_TABS: ApprovalType[] = [
+  "SHELTER_VERIFICATION",
+  "STAFF_PROMOTION",
+  "ADOPTION",
+  "FOSTER",
 ];
 
-const Placeholder = () => (
-  <p {...stylex.props(styles.placeholder)}>
-    대기 목록 엔드포인트(GET /approvals/pending)가 연결되면 여기에 표시돼요.
-  </p>
-);
-
-/** §09 운영자 승인 큐 — 보호소 검증 · 스태프 승격 · 입양/임보 · 신고 모더레이션.
- *  The 신고 tab is wired; the others await their backend list endpoint. */
+/** §09 운영자 승인 큐 — 보호소 검증 · 스태프 승격 · 입양 · 임보 · 신고 모더레이션.
+ *  Each tab loads its own pending list on demand; the badges show live counts. */
 export const OperatorApprovals = () => {
-  const [tab, setTab] = useState<ApprovalTab>("report");
+  const [tab, setTab] = useState<Tab>("SHELTER_VERIFICATION");
+  const { data: counts } = useSuspenseQuery(approvalQueries.counts());
   const { data: reports } = useSuspenseQuery(reportQueries.pending());
 
   return (
@@ -39,18 +37,26 @@ export const OperatorApprovals = () => {
 
       <Hb.Tabs.Provider value={tab} onChange={(_, value) => setTab(value)}>
         <Hb.Tabs.Root>
-          {PENDING_TABS.map((item) => (
-            <Hb.Tabs.Item key={item.value} value={item.value} label={item.label} />
+          {APPROVAL_TABS.map((type) => (
+            <Hb.Tabs.Item
+              key={type}
+              value={type}
+              label={`${APPROVAL_TYPE_LABEL[type]} ${counts[type]}`}
+            />
           ))}
-          <Hb.Tabs.Item value="report" label={`신고 ${reports.length}`} />
+          <Hb.Tabs.Item value="REPORT" label={`신고 ${reports.length}`} />
         </Hb.Tabs.Root>
 
-        {PENDING_TABS.map((item) => (
-          <Hb.Tabs.Panel key={item.value} value={item.value} {...stylex.props(styles.panel)}>
-            <Placeholder />
+        {APPROVAL_TABS.map((type) => (
+          <Hb.Tabs.Panel key={type} value={type} {...stylex.props(styles.panel)}>
+            {tab === type && (
+              <Suspense fallback={<LoadingState />}>
+                <PendingApprovalQueue type={type} />
+              </Suspense>
+            )}
           </Hb.Tabs.Panel>
         ))}
-        <Hb.Tabs.Panel value="report" {...stylex.props(styles.panel)}>
+        <Hb.Tabs.Panel value="REPORT" {...stylex.props(styles.panel)}>
           <Suspense fallback={<LoadingState />}>
             <ReportQueue />
           </Suspense>

--- a/apps/hobom-angel/src/features/operator-approvals/ui/PendingApprovalQueue.tsx
+++ b/apps/hobom-angel/src/features/operator-approvals/ui/PendingApprovalQueue.tsx
@@ -1,0 +1,81 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { useInfiniteScroll, useOverlay } from "@/shared/model";
+import type { ApprovalType, PendingApproval } from "@/entities/approval";
+import { usePendingApprovals } from "../model/usePendingApprovals";
+import {
+  approvalContextLine,
+  approvalHeadline,
+  formatApprovalDate,
+  maskRequester,
+  subjectTag,
+} from "../lib/approval-format.lib";
+import { ApprovalRejectDialog } from "./ApprovalRejectDialog";
+import { styles } from "./OperatorApprovals.styles";
+
+/** §09 승인 큐 — one approval type's pending list with approve / reject. */
+export const PendingApprovalQueue = ({ type }: { type: ApprovalType }) => {
+  const { approvals, decide, deciding, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    usePendingApprovals(type);
+  const overlay = useOverlay();
+
+  const sentinelRef = useInfiniteScroll({ hasNextPage, isFetchingNextPage, fetchNextPage });
+
+  const promptReject = (approval: PendingApproval) =>
+    overlay.open(({ close }) => (
+      <ApprovalRejectDialog
+        headline={approvalHeadline(approval.type)}
+        onConfirm={(reason) => {
+          decide(approval.approvalId, { decision: "REJECT", reason });
+        }}
+        onClose={close}
+      />
+    ));
+
+  if (approvals.length === 0) {
+    return <p {...stylex.props(styles.empty)}>대기 중인 요청이 없어요.</p>;
+  }
+
+  return (
+    <div {...stylex.props(styles.list)}>
+      {approvals.map((approval) => {
+        const contextLine = approvalContextLine(approval);
+        const date = formatApprovalDate(approval.createdAt);
+
+        return (
+          <article key={approval.approvalId} {...stylex.props(styles.card)}>
+            <div {...stylex.props(styles.cardHead)}>
+              <span {...stylex.props(styles.headline)}>{approvalHeadline(approval.type)}</span>
+              <span {...stylex.props(styles.spacer)} />
+              <span {...stylex.props(styles.actions)}>
+                <Hb.Button
+                  variant="primary"
+                  size="small"
+                  onClick={() => decide(approval.approvalId, { decision: "APPROVE" })}
+                  disabled={deciding}
+                >
+                  승인
+                </Hb.Button>
+                <Hb.Button
+                  variant="ghost"
+                  size="small"
+                  onClick={() => promptReject(approval)}
+                  disabled={deciding}
+                >
+                  반려
+                </Hb.Button>
+              </span>
+            </div>
+            <div {...stylex.props(styles.meta)}>
+              <span>{subjectTag(approval)}</span>
+              {contextLine && <span>{contextLine}</span>}
+              <span>{maskRequester(approval.requesterId)}</span>
+              {date && <span>{date}</span>}
+            </div>
+          </article>
+        );
+      })}
+      {hasNextPage && <div ref={sentinelRef} aria-hidden />}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/approval.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/approval.handlers.ts
@@ -1,0 +1,90 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { mockSession } from "./mock-session";
+import { ok } from "./ok";
+
+type ApprovalType = "SHELTER_VERIFICATION" | "STAFF_PROMOTION" | "ADOPTION" | "FOSTER";
+
+interface PendingApprovalRow {
+  approvalId: string;
+  type: ApprovalType;
+  subjectRef: string;
+  requesterId: string;
+  context: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+// The operator's global pending queue. Mutable so a decision drops the row and
+// the counts fall on the next read. Shared with the decision handler in
+// shelter.handlers so approving/rejecting here clears the item.
+export const PENDING_APPROVALS: PendingApprovalRow[] = [
+  {
+    approvalId: "ap-verif-1",
+    type: "SHELTER_VERIFICATION",
+    subjectRef: "shelter-9",
+    requesterId: "user-31",
+    context: null,
+    createdAt: "2026-07-24T09:00:00.000Z",
+  },
+  {
+    approvalId: "ap-verif-2",
+    type: "SHELTER_VERIFICATION",
+    subjectRef: "shelter-12",
+    requesterId: "user-44",
+    context: null,
+    createdAt: "2026-07-25T02:30:00.000Z",
+  },
+  {
+    approvalId: "ap-promo-1",
+    type: "STAFF_PROMOTION",
+    subjectRef: "user-58",
+    requesterId: "user-2",
+    context: { shelterId: "shelter-1" },
+    createdAt: "2026-07-25T05:10:00.000Z",
+  },
+  {
+    approvalId: "ap-adopt-1",
+    type: "ADOPTION",
+    subjectRef: "adoption-77",
+    requesterId: "user-63",
+    context: { animalId: "animal-21" },
+    createdAt: "2026-07-25T08:45:00.000Z",
+  },
+  {
+    approvalId: "ap-foster-1",
+    type: "FOSTER",
+    subjectRef: "foster-88",
+    requesterId: "user-70",
+    context: { animalId: "animal-34" },
+    createdAt: "2026-07-26T01:20:00.000Z",
+  },
+];
+
+const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+
+/** Operator approval-queue mock — the pending list and its per-type counts. */
+export const approvalHandlers = [
+  http.get(mockUrl("/approvals/pending/counts"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const counts: Record<ApprovalType, number> = {
+      SHELTER_VERIFICATION: 0,
+      STAFF_PROMOTION: 0,
+      ADOPTION: 0,
+      FOSTER: 0,
+    };
+
+    for (const row of PENDING_APPROVALS) counts[row.type] += 1;
+
+    return ok(counts);
+  }),
+
+  http.get(mockUrl("/approvals/pending"), ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const type = new URL(request.url).searchParams.get("type") as ApprovalType | null;
+    const items = type ? PENDING_APPROVALS.filter((row) => row.type === type) : PENDING_APPROVALS;
+
+    return ok({ items, nextCursor: null, hasNext: false });
+  }),
+];

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -12,6 +12,7 @@ import { questionnaireHandlers } from "./questionnaire.handlers";
 import { adoptionHandlers } from "./adoption.handlers";
 import { fosterHandlers } from "./foster.handlers";
 import { applicationHandlers } from "./application.handlers";
+import { approvalHandlers } from "./approval.handlers";
 
 /** All MSW request handlers, aggregated per domain. Add new domains here. */
 export const handlers = [
@@ -29,4 +30,5 @@ export const handlers = [
   ...adoptionHandlers,
   ...fosterHandlers,
   ...applicationHandlers,
+  ...approvalHandlers,
 ];

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import { mockUrl } from "./mock-url";
 import { ok } from "./ok";
 import { mockSession } from "./mock-session";
+import { PENDING_APPROVALS } from "./approval.handlers";
 
 const SHELTER = {
   id: "shelter-1",
@@ -406,6 +407,13 @@ export const shelterHandlers = [
     const index = PROMOTION_REQUESTS.findIndex((row) => row.approvalId === params.approvalId);
 
     if (index >= 0) PROMOTION_REQUESTS.splice(index, 1);
+
+    // Same decision endpoint backs the operator queue — drop that row too.
+    const pendingIndex = PENDING_APPROVALS.findIndex(
+      (row) => row.approvalId === params.approvalId,
+    );
+
+    if (pendingIndex >= 0) PENDING_APPROVALS.splice(pendingIndex, 1);
 
     return new HttpResponse(null, { status: 204 });
   }),


### PR DESCRIPTION
## What
The §09 operator 승인 큐 had its 신고 tab wired and the other four tabs as placeholders waiting on a backend list endpoint. That endpoint now exists (`GET /approvals/pending` + `/counts`), so this fills in the rest.

- **보호소 검증 / 스태프 승격 / 입양 / 임보** tabs each read their own type from `GET /approvals/pending?type=…` (cursor-paged, infinite scroll).
- Tab badges show live per-type counts from `GET /approvals/pending/counts`.
- Each row can be **승인** (approve outright) or **반려** (reject with a required reason), both via `POST /approvals/:id/decision`. A decision invalidates the affected list and the counts.
- The **신고** tab is untouched.

## Rendering
The pending payload is type-agnostic — an opaque `subjectRef`, a `requesterId`, and a small type-specific `context` (`{shelterId}` / `{animalId}`, or null). No names are exposed, so each card shows an id-safe subject tag (`보호소 #…`), a best-effort context hint (`대상 동물 #…` / `소속 보호소 #…`), a masked requester, and the submitted date.

## Structure
- New `entities/approval` slice (model / api / queries / mutations). `context` is a free-form record the object schema can't carry, so the scalars are validated advisorily and `context` is read from the raw page.
- Feature: `usePendingApprovals` hook, `PendingApprovalQueue`, `ApprovalRejectDialog`, plus pure `approval-format` helpers with unit tests.
- MSW: an `approval.handlers` queue; the existing decision mock now clears the operator row as well.

## Verify
typecheck, lint, tests (155), and the production build all pass.

Note: I spotted a stray `1` accidentally left in `console-survey/ui/SurveyBuilder.tsx` in the working tree (renders a bogus "1" next to 저장). It's unrelated to this change, so I left it out — worth a separate cleanup.