### PR TITLE
Scope the operator approval queue to what the operator decides

### DIFF
--- a/apps/hobom-angel/e2e/console-staff.spec.ts
+++ b/apps/hobom-angel/e2e/console-staff.spec.ts
@@ -22,9 +22,10 @@ test.describe("§7.6 shelter console — staff", () => {
     await expect(page.getByText("대표", { exact: true })).toBeVisible();
     await expect(page.getByText("정지")).toBeVisible();
 
-    // Pending queue with candidate activity.
+    // Pending queue with candidate activity. The membership months are relative
+    // to today, so match the format rather than a fixed count.
     await expect(page.getByText("박자원")).toBeVisible();
-    await expect(page.getByText("봉사 20회 · 가입 8개월")).toBeVisible();
+    await expect(page.getByText(/봉사 20회 · 가입 \d+개월/)).toBeVisible();
 
     // Approve the first request — it leaves the queue.
     await page.getByRole("button", { name: "승인" }).first().click();

--- a/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.tsx
+++ b/apps/hobom-angel/src/features/operator-approvals/ui/OperatorApprovals.tsx
@@ -5,22 +5,15 @@ import { Hb } from "hobom-design-system";
 import { APPROVAL_TYPE_LABEL, approvalQueries } from "@/entities/approval";
 import { reportQueries } from "@/entities/report";
 import { LoadingState } from "@/shared/ui";
-import type { ApprovalType } from "@/entities/approval";
 import { PendingApprovalQueue } from "./PendingApprovalQueue";
 import { ReportQueue } from "./ReportQueue";
 import { styles } from "./OperatorApprovals.styles";
 
-type Tab = ApprovalType | "REPORT";
+type Tab = "SHELTER_VERIFICATION" | "REPORT";
 
-const APPROVAL_TABS: ApprovalType[] = [
-  "SHELTER_VERIFICATION",
-  "STAFF_PROMOTION",
-  "ADOPTION",
-  "FOSTER",
-];
-
-/** §09 운영자 승인 큐 — 보호소 검증 · 스태프 승격 · 입양 · 임보 · 신고 모더레이션.
- *  Each tab loads its own pending list on demand; the badges show live counts. */
+/** §09 운영자 승인 큐 — the platform operator decides 보호소 검증 and moderates
+ *  신고. Staff-promotion / adoption / foster are decided by the owning shelter's
+ *  manager (in the shelter console), not here, so they are not surfaced. */
 export const OperatorApprovals = () => {
   const [tab, setTab] = useState<Tab>("SHELTER_VERIFICATION");
   const { data: counts } = useSuspenseQuery(approvalQueries.counts());
@@ -30,32 +23,25 @@ export const OperatorApprovals = () => {
     <div {...stylex.props(styles.root)}>
       <header {...stylex.props(styles.header)}>
         <h1 {...stylex.props(styles.title)}>승인 큐</h1>
-        <p {...stylex.props(styles.subtitle)}>
-          보호소 검증 · 스태프 승격 · 입양/임보 · 신고를 한곳에서 처리해요.
-        </p>
+        <p {...stylex.props(styles.subtitle)}>보호소 검증과 신고를 처리해요.</p>
       </header>
 
       <Hb.Tabs.Provider value={tab} onChange={(_, value) => setTab(value)}>
         <Hb.Tabs.Root>
-          {APPROVAL_TABS.map((type) => (
-            <Hb.Tabs.Item
-              key={type}
-              value={type}
-              label={`${APPROVAL_TYPE_LABEL[type]} ${counts[type]}`}
-            />
-          ))}
+          <Hb.Tabs.Item
+            value="SHELTER_VERIFICATION"
+            label={`${APPROVAL_TYPE_LABEL.SHELTER_VERIFICATION} ${counts.SHELTER_VERIFICATION}`}
+          />
           <Hb.Tabs.Item value="REPORT" label={`신고 ${reports.length}`} />
         </Hb.Tabs.Root>
 
-        {APPROVAL_TABS.map((type) => (
-          <Hb.Tabs.Panel key={type} value={type} {...stylex.props(styles.panel)}>
-            {tab === type && (
-              <Suspense fallback={<LoadingState />}>
-                <PendingApprovalQueue type={type} />
-              </Suspense>
-            )}
-          </Hb.Tabs.Panel>
-        ))}
+        <Hb.Tabs.Panel value="SHELTER_VERIFICATION" {...stylex.props(styles.panel)}>
+          {tab === "SHELTER_VERIFICATION" && (
+            <Suspense fallback={<LoadingState />}>
+              <PendingApprovalQueue type="SHELTER_VERIFICATION" />
+            </Suspense>
+          )}
+        </Hb.Tabs.Panel>
         <Hb.Tabs.Panel value="REPORT" {...stylex.props(styles.panel)}>
           <Suspense fallback={<LoadingState />}>
             <ReportQueue />


### PR DESCRIPTION
## Why
The backend now enforces per-type authorization on `POST /approvals/:id/decision` (deciders differ by type):

| Type | Decider |
|---|---|
| 보호소 검증 | platform operator |
| 스태프 승격 | owning shelter's manager |
| 입양 / 임보 | owning shelter's manager |

The operator queue was showing approve/reject on **all** types, but a platform operator can only decide **보호소 검증** — acting on the others returns 403. Staff-promotion / adoption / foster are already handled by shelter managers in the shelter console (스태프 관리, 신청 처리).

## Change
The operator queue now surfaces only the two things the operator actually owns: the **보호소 검증** pending queue and the **신고** moderation tab. The other three tabs are removed.

The generic `entities/approval` slice and `PendingApprovalQueue` are unchanged — the page just drives them with a single type.

## Verify
typecheck, lint, unit tests (7), the operator-approvals e2e, and the production build all pass.

Note: still no `GET /approvals/:approvalId` on the backend, so the 상세보기 dialog (most needed for 보호소 검증) waits on that endpoint. The stray `1` in console-survey/ui/SurveyBuilder.tsx is still in the working tree, unrelated — left out again.