### PR TITLE
Wire the landing CTAs to the animal and foster routes

### DIFF
--- a/apps/hobom-angel/e2e/landing.spec.ts
+++ b/apps/hobom-angel/e2e/landing.spec.ts
@@ -16,4 +16,23 @@ test.describe("landing", () => {
     await expect(page.getByRole("button", { name: "로그인" })).toBeVisible();
     await expect(page.getByText("일시적인 오류가 발생했어요")).toHaveCount(0);
   });
+
+  test("hero and cta buttons route to the animal list", async ({ page }) => {
+    await page.goto("./");
+    await page.getByRole("button", { name: "로그인" }).click();
+    await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+    await page.getByPlaceholder("••••••••").fill("secret123");
+    await page.getByRole("button", { name: "로그인" }).click();
+    await expect(page.getByText("봄이네님")).toBeVisible();
+
+    // Back on the landing, the primary CTA follows through to the animal list.
+    await page.goto("./");
+    await page.getByRole("button", { name: "우리 가족 찾기" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    // The closing CTA lands on the same place.
+    await page.goto("./");
+    await page.getByRole("button", { name: "우리 가족 만나러 가기" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+  });
 });

--- a/apps/hobom-angel/src/pages/landing/ui/CtaSection.tsx
+++ b/apps/hobom-angel/src/pages/landing/ui/CtaSection.tsx
@@ -1,16 +1,25 @@
+import { useNavigate } from "react-router";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
+import { ROUTES } from "@/shared/config";
 import { CTA } from "../model/landing.fixtures";
 import { styles } from "./CtaSection.styles";
 
-export const CtaSection = () => (
-  <section {...stylex.props(styles.section)}>
-    <div {...stylex.props(styles.inner)}>
-      <h2 {...stylex.props(styles.title)}>{CTA.title}</h2>
-      <p {...stylex.props(styles.lead)}>{CTA.lead}</p>
-      <Hb.Button style={{ backgroundColor: "#ffffff", color: "var(--hb-color-accent-dark)" }}>
-        {CTA.button}
-      </Hb.Button>
-    </div>
-  </section>
-);
+export const CtaSection = () => {
+  const navigate = useNavigate();
+
+  return (
+    <section {...stylex.props(styles.section)}>
+      <div {...stylex.props(styles.inner)}>
+        <h2 {...stylex.props(styles.title)}>{CTA.title}</h2>
+        <p {...stylex.props(styles.lead)}>{CTA.lead}</p>
+        <Hb.Button
+          style={{ backgroundColor: "#ffffff", color: "var(--hb-color-accent-dark)" }}
+          onClick={() => navigate(ROUTES.ANIMALS)}
+        >
+          {CTA.button}
+        </Hb.Button>
+      </div>
+    </section>
+  );
+};

--- a/apps/hobom-angel/src/pages/landing/ui/HeroSection.tsx
+++ b/apps/hobom-angel/src/pages/landing/ui/HeroSection.tsx
@@ -1,30 +1,36 @@
 import { Fragment } from "react";
+import { useNavigate } from "react-router";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
+import { ROUTES } from "@/shared/config";
 import { HERO } from "../model/landing.fixtures";
 import { styles } from "./HeroSection.styles";
 
-export const HeroSection = () => (
-  <section {...stylex.props(styles.section)} id="top">
-    <div {...stylex.props(styles.inner)}>
-      <span {...stylex.props(styles.badge)}>{HERO.badge}</span>
-      <h1 {...stylex.props(styles.title)}>
-        {HERO.title.map((line, index) => (
-          <Fragment key={line}>
-            {index > 0 && <br />}
-            {line}
-          </Fragment>
-        ))}
-      </h1>
-      <p {...stylex.props(styles.lead)}>{HERO.lead}</p>
-      <div {...stylex.props(styles.cta)}>
-        <Hb.Button variant="primary">
-          {HERO.primary}
-        </Hb.Button>
-        <Hb.Button variant="secondary">
-          {HERO.secondary}
-        </Hb.Button>
+export const HeroSection = () => {
+  const navigate = useNavigate();
+
+  return (
+    <section {...stylex.props(styles.section)} id="top">
+      <div {...stylex.props(styles.inner)}>
+        <span {...stylex.props(styles.badge)}>{HERO.badge}</span>
+        <h1 {...stylex.props(styles.title)}>
+          {HERO.title.map((line, index) => (
+            <Fragment key={line}>
+              {index > 0 && <br />}
+              {line}
+            </Fragment>
+          ))}
+        </h1>
+        <p {...stylex.props(styles.lead)}>{HERO.lead}</p>
+        <div {...stylex.props(styles.cta)}>
+          <Hb.Button variant="primary" onClick={() => navigate(ROUTES.ANIMALS)}>
+            {HERO.primary}
+          </Hb.Button>
+          <Hb.Button variant="secondary" onClick={() => navigate(ROUTES.FOSTER)}>
+            {HERO.secondary}
+          </Hb.Button>
+        </div>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};


### PR DESCRIPTION
## What
The landing page's call-to-action buttons rendered but had no navigation. This wires them:

| Button | Destination |
|---|---|
| 우리 가족 찾기 (hero primary) | `/animals` |
| 임시보호 알아보기 (hero secondary) | `/foster` |
| 우리 가족 만나러 가기 (closing CTA) | `/animals` |

Uses the app's `navigate()` pattern (as in NotFoundState / VolunteerPage). A guest who follows a CTA hits the auth gate and is sent to login, like any other consumer route; an authed visitor lands on the target page.

The animal cards in the '지금 만날 수 있는 친구들' section are static fixtures with no ids, so they aren't individually linkable — left as-is.

## Verify
typecheck, lint, and the production build pass. Adds a landing e2e that logs in and follows the hero + closing CTAs through to `/animals`; the full flow passes locally.