### PR TITLE
Build the 임시보호 explainer page

### DIFF
--- a/apps/hobom-angel/e2e/foster.spec.ts
+++ b/apps/hobom-angel/e2e/foster.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("임시보호 알아보기", () => {
+  test("is public and hands off to the animal list", async ({ page }) => {
+    // Reachable without logging in (the explainer is a public surface).
+    await page.goto("foster");
+    await expect(page.getByRole("heading", { name: /곁을 내어주세요/ })).toBeVisible();
+    await expect(page.getByText("입양과 무엇이 다를까요")).toBeVisible();
+
+    // The CTA sends visitors to the (gated) catalog — a guest hits the login gate.
+    await page.getByRole("button", { name: "임보 가능한 친구 보기" }).click();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -16,6 +16,9 @@ import { ProtectedRoute } from "./ProtectedRoute";
 const LandingPage = lazy(() =>
   import("@/pages/landing").then((module) => ({ default: module.LandingPage })),
 );
+const FosterPage = lazy(() =>
+  import("@/pages/foster").then((module) => ({ default: module.FosterPage })),
+);
 const LoginPage = lazy(() =>
   import("@/pages/login").then((module) => ({ default: module.LoginPage })),
 );
@@ -91,9 +94,6 @@ const prefetchRoutes = () => {
   void import("@/pages/shelters");
 };
 
-// Sections still on the ComingSoon placeholder until their screens land.
-const SECTION_ROUTES = [ROUTES.FOSTER];
-
 export const AppRouter = () => {
   useRouteMeta();
 
@@ -106,6 +106,9 @@ export const AppRouter = () => {
           {/* Consumer screens render inside the global nav chrome. */}
           <Route element={<ConsumerShellLayout />}>
             <Route path={ROUTES.HOME} element={<LandingPage />} />
+            {/* Public 임시보호 explainer — foster is applied per-animal, so this
+                informs and hands off to the (gated) animal list. */}
+            <Route path={ROUTES.FOSTER} element={<FosterPage />} />
             {/* Public info surfaces (footer links). */}
             <Route path={ROUTES.TERMS} element={<ComingSoonPage />} />
             <Route path={ROUTES.PRIVACY} element={<ComingSoonPage />} />
@@ -123,9 +126,6 @@ export const AppRouter = () => {
             <Route path={ROUTES.FAVORITES} element={<FavoritesPage />} />
             <Route path={ROUTES.APPLICATIONS} element={<ApplicationsPage />} />
             <Route path={ROUTES.MY} element={<MyPage />} />
-              {SECTION_ROUTES.map((path) => (
-                <Route key={path} path={path} element={<ComingSoonPage />} />
-              ))}
             </Route>
           </Route>
 

--- a/apps/hobom-angel/src/pages/foster/index.ts
+++ b/apps/hobom-angel/src/pages/foster/index.ts
@@ -1,0 +1,1 @@
+export { FosterPage } from "./ui/FosterPage";

--- a/apps/hobom-angel/src/pages/foster/model/foster.fixtures.ts
+++ b/apps/hobom-angel/src/pages/foster/model/foster.fixtures.ts
@@ -1,0 +1,41 @@
+// Static explainer copy for the 임시보호 알아보기 page. Grounded in the foster
+// lifecycle from the design (기한·무기한·조기종료·만료 통보).
+
+export const FOSTER_HERO = {
+  badge: "임시보호",
+  title: ["평생은 아니어도,", "지금 곁을 내어주세요."],
+  lead: "임시보호는 새 가족을 만나기 전까지 아이가 가정의 온기를 느끼며 지내도록 돕는 일이에요. 정해진 기간 동안 돌보고, 마음이 닿으면 입양으로 이어지기도 해요.",
+};
+
+export const FOSTER_COMPARE = [
+  {
+    tag: "입양",
+    title: "평생 가족이 되어요",
+    desc: "아이의 남은 삶을 끝까지 함께하는 영구적인 약속이에요.",
+  },
+  {
+    tag: "임시보호",
+    title: "정해진 기간 동안 돌봐요",
+    desc: "새 가족을 찾는 동안 사회화와 입양 준비를 곁에서 도와요.",
+  },
+];
+
+export const FOSTER_STEPS = [
+  { n: "1", title: "친구 찾기", desc: "보호소의 아이들 중 마음이 가는 친구를 찾아요." },
+  { n: "2", title: "임보 신청·설문", desc: "보호소가 준비한 설문에 답하며 돌봄 환경을 알려요." },
+  { n: "3", title: "보호소 승인", desc: "보호소가 신청을 검토하고 임시보호를 확정해요." },
+  { n: "4", title: "임보 시작", desc: "정해진 기간 동안 아이와 함께 지내요." },
+];
+
+export const FOSTER_TERMS = [
+  { title: "기간을 정해요", desc: "시작일과 종료일을 정해 그 기간 동안 아이를 돌봐요." },
+  { title: "무기한도 가능해요", desc: "종료일 없이 새 가족을 만날 때까지 함께할 수 있어요." },
+  { title: "일찍 마칠 수 있어요", desc: "사정이 생기면 보호소와 상의해 조기에 종료할 수 있어요." },
+  { title: "만료 전에 알려드려요", desc: "종료일이 다가오면 메일과 문자로 미리 안내해요." },
+];
+
+export const FOSTER_CTA = {
+  title: "임시보호로 첫 봄을 선물하세요",
+  lead: "지금 만날 수 있는 친구들을 둘러보고 임보를 신청해요.",
+  button: "임보 가능한 친구 보기",
+};

--- a/apps/hobom-angel/src/pages/foster/ui/FosterPage.styles.ts
+++ b/apps/hobom-angel/src/pages/foster/ui/FosterPage.styles.ts
@@ -1,0 +1,150 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+const DESKTOP = "@media (min-width: 1024px)";
+
+export const styles = stylex.create({
+  // Hero
+  hero: {
+    paddingBlock: { default: "48px 40px", [DESKTOP]: "72px 56px" },
+    paddingInline: "clamp(16px, 4vw, 40px)",
+    backgroundColor: "var(--hb-color-surface)",
+    textAlign: "center",
+  },
+  heroInner: { maxWidth: 720, marginInline: "auto" },
+  badge: {
+    display: "inline-block",
+    paddingBlock: 8,
+    paddingInline: 16,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-angel-green-tint)",
+    color: "var(--hb-color-accent-dark)",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+  },
+  title: {
+    margin: 0,
+    marginTop: 24,
+    fontSize: { default: "30px", [TABLET]: "40px", [DESKTOP]: "48px" },
+    lineHeight: 1.25,
+    fontWeight: 800,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  lead: {
+    margin: 0,
+    marginTop: 20,
+    marginInline: "auto",
+    maxWidth: 560,
+    fontSize: "1rem",
+    lineHeight: 1.7,
+    color: "var(--hb-color-text-secondary)",
+  },
+
+  // Generic section
+  section: {
+    paddingBlock: { default: 48, [DESKTOP]: 64 },
+    paddingInline: "clamp(16px, 4vw, 40px)",
+  },
+  altSection: { backgroundColor: "var(--hb-angel-surface-alt)" },
+  inner: { maxWidth: 1120, marginInline: "auto" },
+  head: { textAlign: "center", marginBottom: 36 },
+  sectionTitle: {
+    margin: 0,
+    fontSize: { default: "1.375rem", [DESKTOP]: "1.625rem" },
+    fontWeight: 800,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  sectionSub: {
+    margin: 0,
+    marginTop: 10,
+    fontSize: "0.9375rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+
+  // Card grids (compare 2-up, steps/terms responsive)
+  compareGrid: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [TABLET]: "repeat(2, 1fr)" },
+    gap: 16,
+  },
+  grid: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [TABLET]: "repeat(2, 1fr)", [DESKTOP]: "repeat(4, 1fr)" },
+    gap: 16,
+  },
+  card: {
+    backgroundColor: "var(--hb-color-surface)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    borderRadius: "var(--hb-angel-radius-card)",
+    padding: "28px 24px",
+    textAlign: "center",
+  },
+  tag: {
+    display: "inline-block",
+    paddingBlock: 4,
+    paddingInline: 12,
+    borderRadius: 999,
+    backgroundColor: "var(--hb-angel-green-tint)",
+    color: "var(--hb-color-accent-dark)",
+    fontSize: "0.75rem",
+    fontWeight: 700,
+  },
+  num: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 44,
+    height: 44,
+    borderRadius: "50%",
+    backgroundColor: "var(--hb-angel-green-tint)",
+    color: "var(--hb-color-accent-dark)",
+    fontSize: "1.125rem",
+    fontWeight: 800,
+  },
+  cardTitle: {
+    margin: 0,
+    marginTop: 16,
+    fontSize: "1.0625rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  cardDesc: {
+    margin: 0,
+    marginTop: 8,
+    fontSize: "0.9375rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-secondary)",
+  },
+
+  // CTA band
+  ctaInner: {
+    maxWidth: 1120,
+    marginInline: "auto",
+    padding: { default: "40px 24px", [DESKTOP]: "56px 40px" },
+    borderRadius: 24,
+    backgroundImage:
+      "linear-gradient(135deg, var(--hb-color-accent) 0%, var(--hb-angel-green-deep) 100%)",
+    textAlign: "center",
+    color: "#ffffff",
+  },
+  ctaTitle: {
+    margin: 0,
+    fontSize: { default: "1.375rem", [DESKTOP]: "1.75rem" },
+    fontWeight: 800,
+    letterSpacing: "-0.02em",
+  },
+  ctaLead: {
+    margin: 0,
+    marginTop: 10,
+    marginBottom: 24,
+    fontSize: "0.9375rem",
+    color: "rgba(255,255,255,0.85)",
+  },
+});

--- a/apps/hobom-angel/src/pages/foster/ui/FosterPage.tsx
+++ b/apps/hobom-angel/src/pages/foster/ui/FosterPage.tsx
@@ -1,0 +1,109 @@
+import { Fragment } from "react";
+import { useNavigate } from "react-router";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { ROUTES } from "@/shared/config";
+import {
+  FOSTER_COMPARE,
+  FOSTER_CTA,
+  FOSTER_HERO,
+  FOSTER_STEPS,
+  FOSTER_TERMS,
+} from "../model/foster.fixtures";
+import { styles } from "./FosterPage.styles";
+
+/** §임시보호 알아보기 — a public explainer for fostering. There is no separate
+ *  foster catalog (foster is applied per-animal from the animal detail), so this
+ *  informs and then sends visitors to the animal list to apply. */
+export const FosterPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <section {...stylex.props(styles.hero)}>
+        <div {...stylex.props(styles.heroInner)}>
+          <span {...stylex.props(styles.badge)}>{FOSTER_HERO.badge}</span>
+          <h1 {...stylex.props(styles.title)}>
+            {FOSTER_HERO.title.map((line, index) => (
+              <Fragment key={line}>
+                {index > 0 && <br />}
+                {line}
+              </Fragment>
+            ))}
+          </h1>
+          <p {...stylex.props(styles.lead)}>{FOSTER_HERO.lead}</p>
+        </div>
+      </section>
+
+      <section {...stylex.props(styles.section, styles.altSection)}>
+        <div {...stylex.props(styles.inner)}>
+          <header {...stylex.props(styles.head)}>
+            <h2 {...stylex.props(styles.sectionTitle)}>입양과 무엇이 다를까요</h2>
+            <p {...stylex.props(styles.sectionSub)}>
+              임시보호는 짧게 머무는 돌봄, 입양은 평생의 약속이에요.
+            </p>
+          </header>
+          <div {...stylex.props(styles.compareGrid)}>
+            {FOSTER_COMPARE.map((item) => (
+              <div key={item.tag} {...stylex.props(styles.card)}>
+                <span {...stylex.props(styles.tag)}>{item.tag}</span>
+                <h3 {...stylex.props(styles.cardTitle)}>{item.title}</h3>
+                <p {...stylex.props(styles.cardDesc)}>{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.inner)}>
+          <header {...stylex.props(styles.head)}>
+            <h2 {...stylex.props(styles.sectionTitle)}>이렇게 진행돼요</h2>
+            <p {...stylex.props(styles.sectionSub)}>신청부터 임보 시작까지, 한 걸음씩 안내할게요.</p>
+          </header>
+          <ol {...stylex.props(styles.grid)}>
+            {FOSTER_STEPS.map((step) => (
+              <li key={step.n} {...stylex.props(styles.card)}>
+                <span {...stylex.props(styles.num)}>{step.n}</span>
+                <h3 {...stylex.props(styles.cardTitle)}>{step.title}</h3>
+                <p {...stylex.props(styles.cardDesc)}>{step.desc}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+
+      <section {...stylex.props(styles.section, styles.altSection)}>
+        <div {...stylex.props(styles.inner)}>
+          <header {...stylex.props(styles.head)}>
+            <h2 {...stylex.props(styles.sectionTitle)}>기간은 어떻게 정하나요</h2>
+            <p {...stylex.props(styles.sectionSub)}>
+              상황에 맞게 유연하게, 종료 전에는 미리 알려드려요.
+            </p>
+          </header>
+          <ul {...stylex.props(styles.grid)}>
+            {FOSTER_TERMS.map((term) => (
+              <li key={term.title} {...stylex.props(styles.card)}>
+                <h3 {...stylex.props(styles.cardTitle)}>{term.title}</h3>
+                <p {...stylex.props(styles.cardDesc)}>{term.desc}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.ctaInner)}>
+          <h2 {...stylex.props(styles.ctaTitle)}>{FOSTER_CTA.title}</h2>
+          <p {...stylex.props(styles.ctaLead)}>{FOSTER_CTA.lead}</p>
+          <Hb.Button
+            style={{ backgroundColor: "#ffffff", color: "var(--hb-color-accent-dark)" }}
+            onClick={() => navigate(ROUTES.ANIMALS)}
+          >
+            {FOSTER_CTA.button}
+          </Hb.Button>
+        </div>
+      </section>
+    </>
+  );
+};


### PR DESCRIPTION
## What
`/foster` was a ComingSoon placeholder. Fostering has no separate catalog in the design — it's applied per-animal from the animal detail (the `ApplyCard` already offers 임보 신청) — so a second animal list would just clone `/animals`. Instead this fills `/foster` with a **public explainer**, matching the landing's '임시보호 **알아보기**' intent:

- **Hero** — what fostering is
- **입양과의 차이** — temporary care vs the lifelong commitment
- **진행 단계** — 친구 찾기 → 임보 신청·설문 → 보호소 승인 → 임보 시작
- **기간 안내** — 기한 설정 · 무기한 · 조기 종료 · 만료 자동 알림 (from the design's foster lifecycle)
- **CTA** — '임보 가능한 친구 보기' → the animal list

## Routing
The explainer is made **public** (alongside the landing), so the '임시보호 알아보기' link informs before the login gate; the CTA hands off to the gated `/animals` catalog where foster is actually applied. Removes the now-empty `SECTION_ROUTES` placeholder wiring.

No backend needed — reuses the existing catalog and per-animal foster-apply flow.

## Verify
typecheck, lint, build, unit (155), and the full e2e suite (55) pass. Adds a foster e2e: a guest opens the public explainer and the CTA routes to the login gate.