### PR TITLE
Distinguish 입양/임보 in the animal catalog by placement eligibility

### DIFF
--- a/apps/hobom-angel/e2e/browse-animals.spec.ts
+++ b/apps/hobom-angel/e2e/browse-animals.spec.ts
@@ -53,6 +53,16 @@ test.describe("§01 browse animals", () => {
     await page.screenshot({ path: "e2e-artifacts/browse-cat.png", fullPage: true });
   });
 
+  test("filters by placement (입양/임보) and reflects it in the URL", async ({ page }) => {
+    await login(page);
+    await page.getByRole("banner").getByRole("link", { name: "입양" }).click();
+    await expect(page).toHaveURL(/\/animals$/);
+
+    await page.getByRole("button", { name: "임보", exact: true }).click();
+    await expect(page).toHaveURL(/placement=FOSTER/);
+    await expect(page.getByText(/\d+마리/)).toBeVisible();
+  });
+
   test("sorts by oldest and reflects it in the URL", async ({ page }) => {
     await login(page);
     await page.getByRole("banner").getByRole("link", { name: "입양" }).click();

--- a/apps/hobom-angel/e2e/foster.spec.ts
+++ b/apps/hobom-angel/e2e/foster.spec.ts
@@ -1,4 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
 
 test.describe("임시보호 알아보기", () => {
   test("is public and hands off to the animal list", async ({ page }) => {
@@ -10,5 +19,15 @@ test.describe("임시보호 알아보기", () => {
     // The CTA sends visitors to the (gated) catalog — a guest hits the login gate.
     await page.getByRole("button", { name: "임보 가능한 친구 보기" }).click();
     await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test("the CTA lands a signed-in visitor on the foster-filtered catalog", async ({ page }) => {
+    await login(page);
+
+    await page.goto("foster");
+    await page.getByRole("button", { name: "임보 가능한 친구 보기" }).click();
+
+    await expect(page).toHaveURL(/\/animals\?placement=FOSTER$/);
+    await expect(page.getByRole("button", { name: "임보", exact: true })).toBeVisible();
   });
 });

--- a/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.schema.ts
@@ -14,6 +14,7 @@ const animalFields = {
   species: HoBomSchema.enum(["DOG", "CAT", "OTHER"]),
   description: HoBomSchema.string(),
   status: HoBomSchema.enum(["AVAILABLE", "RESERVED", "FOSTERED", "ADOPTED", "RETURNED"]),
+  eligiblePlacements: HoBomSchema.array(HoBomSchema.enum(["ADOPTION", "FOSTER"])),
   traits: HoBomSchema.object({
     sex: HoBomSchema.enum(["MALE", "FEMALE", "UNKNOWN"]),
     size: HoBomSchema.enum(["SMALL", "MEDIUM", "LARGE"]),

--- a/apps/hobom-angel/src/entities/animal/api/animal.type.ts
+++ b/apps/hobom-angel/src/entities/animal/api/animal.type.ts
@@ -4,6 +4,7 @@ import type {
   AnimalSort,
   AnimalSpecies,
   AnimalStatusCode,
+  PlacementType,
 } from "../model/animal.model";
 
 interface RawAnimalTraits {
@@ -24,6 +25,7 @@ export interface RawAnimal {
   species: AnimalSpecies;
   description: string;
   status: AnimalStatusCode;
+  eligiblePlacements: PlacementType[];
   traits: RawAnimalTraits;
   photos: { objectKey: string; caption?: string }[];
 }
@@ -68,6 +70,7 @@ export interface AnimalSearchParams {
   size?: AnimalSize;
   sex?: AnimalSex;
   status?: AnimalStatusCode;
+  placement?: PlacementType;
   keyword?: string;
   sort?: AnimalSort;
   cursor?: string;

--- a/apps/hobom-angel/src/entities/animal/index.ts
+++ b/apps/hobom-angel/src/entities/animal/index.ts
@@ -15,6 +15,7 @@ export {
   SEX_LABEL,
   STATUS_LABEL,
   SORT_LABEL,
+  PLACEMENT_LABEL,
   formatAge,
   animalMeta,
 } from "./model/animal.model";
@@ -30,4 +31,5 @@ export type {
   AnimalSort,
   AnimalStatusCode,
   AnimalStatusLabel,
+  PlacementType,
 } from "./model/animal.model";

--- a/apps/hobom-angel/src/entities/animal/lib/to-animal-detail.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/animal/lib/to-animal-detail.lib.spec.ts
@@ -9,6 +9,7 @@ const raw: RawAnimalDetail = {
   species: "DOG",
   description: "순한 아이",
   status: "AVAILABLE",
+  eligiblePlacements: ["ADOPTION", "FOSTER"],
   traits: {
     sex: "FEMALE",
     size: "SMALL",

--- a/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.spec.ts
+++ b/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.spec.ts
@@ -10,6 +10,7 @@ describe("toAnimal", () => {
       species: "DOG",
       description: "사람을 좋아해요",
       status: "AVAILABLE",
+      eligiblePlacements: ["ADOPTION", "FOSTER"],
       traits: {
         sex: "MALE",
         size: "MEDIUM",
@@ -28,6 +29,7 @@ describe("toAnimal", () => {
       name: "콩이",
       species: "DOG",
       status: "AVAILABLE",
+      eligiblePlacements: ["ADOPTION", "FOSTER"],
       sex: "MALE",
       size: "MEDIUM",
       ageMonths: 24,
@@ -45,6 +47,7 @@ describe("toAnimal", () => {
       species: "CAT",
       description: "",
       status: "RESERVED",
+      eligiblePlacements: ["ADOPTION"],
       traits: {
         sex: "FEMALE",
         size: "SMALL",

--- a/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.ts
+++ b/apps/hobom-angel/src/entities/animal/lib/to-animal.lib.ts
@@ -8,6 +8,7 @@ export const toAnimal = (raw: RawAnimal): Animal => ({
   name: raw.name,
   species: raw.species,
   status: raw.status,
+  eligiblePlacements: raw.eligiblePlacements,
   sex: raw.traits.sex,
   size: raw.traits.size,
   ageMonths: raw.traits.ageMonths,

--- a/apps/hobom-angel/src/entities/animal/model/animal.model.ts
+++ b/apps/hobom-angel/src/entities/animal/model/animal.model.ts
@@ -3,6 +3,8 @@ export type AnimalSex = "MALE" | "FEMALE" | "UNKNOWN";
 export type AnimalSize = "SMALL" | "MEDIUM" | "LARGE";
 export type AnimalStatusCode = "AVAILABLE" | "RESERVED" | "FOSTERED" | "ADOPTED" | "RETURNED";
 export type AnimalSort = "LATEST" | "OLDEST";
+/** The application types an animal accepts — 입양(permanent) / 임보(temporary). */
+export type PlacementType = "ADOPTION" | "FOSTER";
 
 /** The animal the UI renders — a flattened, display-ready view of the API model. */
 export interface Animal {
@@ -11,6 +13,7 @@ export interface Animal {
   name: string;
   species: AnimalSpecies;
   status: AnimalStatusCode;
+  eligiblePlacements: PlacementType[];
   sex: AnimalSex;
   size: AnimalSize;
   ageMonths: number | null;
@@ -18,6 +21,11 @@ export interface Animal {
   description: string;
   photoUrl?: string;
 }
+
+export const PLACEMENT_LABEL: Record<PlacementType, string> = {
+  ADOPTION: "입양",
+  FOSTER: "임보",
+};
 
 export const SPECIES_LABEL: Record<AnimalSpecies, string> = {
   DOG: "강아지",

--- a/apps/hobom-angel/src/features/animal-detail/lib/apply-cta.lib.spec.ts
+++ b/apps/hobom-angel/src/features/animal-detail/lib/apply-cta.lib.spec.ts
@@ -1,18 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { applyCta } from "./apply-cta.lib";
 
+const BOTH = ["ADOPTION", "FOSTER"] as const;
+
 describe("applyCta", () => {
-  it("lets an available animal be applied for, with a foster option", () => {
-    expect(applyCta("AVAILABLE")).toEqual({
+  it("offers 입양(primary) + 임보(secondary) when an available animal takes both", () => {
+    expect(applyCta("AVAILABLE", [...BOTH])).toEqual({
       primaryLabel: "입양 신청하기",
       primaryEnabled: true,
+      primaryKind: "ADOPTION",
       showFoster: true,
+    });
+  });
+
+  it("hides the foster option for an adoption-only animal", () => {
+    expect(applyCta("AVAILABLE", ["ADOPTION"])).toEqual({
+      primaryLabel: "입양 신청하기",
+      primaryEnabled: true,
+      primaryKind: "ADOPTION",
+      showFoster: false,
+    });
+  });
+
+  it("makes 임보 the primary action for a foster-only animal", () => {
+    expect(applyCta("AVAILABLE", ["FOSTER"])).toEqual({
+      primaryLabel: "임시보호 신청하기",
+      primaryEnabled: true,
+      primaryKind: "FOSTER",
+      showFoster: false,
     });
   });
 
   it("disables the CTA for every non-available status", () => {
     for (const status of ["RESERVED", "FOSTERED", "ADOPTED", "RETURNED"] as const) {
-      const cta = applyCta(status);
+      const cta = applyCta(status, [...BOTH]);
 
       expect(cta.primaryEnabled).toBe(false);
       expect(cta.showFoster).toBe(false);
@@ -20,8 +41,8 @@ describe("applyCta", () => {
   });
 
   it("labels the branch per the design", () => {
-    expect(applyCta("FOSTERED").primaryLabel).toBe("임시보호 중");
-    expect(applyCta("ADOPTED").primaryLabel).toBe("입양 완료");
-    expect(applyCta("RESERVED").primaryLabel).toBe("신청 마감");
+    expect(applyCta("FOSTERED", [...BOTH]).primaryLabel).toBe("임시보호 중");
+    expect(applyCta("ADOPTED", [...BOTH]).primaryLabel).toBe("입양 완료");
+    expect(applyCta("RESERVED", [...BOTH]).primaryLabel).toBe("신청 마감");
   });
 });

--- a/apps/hobom-angel/src/features/animal-detail/lib/apply-cta.lib.ts
+++ b/apps/hobom-angel/src/features/animal-detail/lib/apply-cta.lib.ts
@@ -1,28 +1,56 @@
-import type { AnimalStatusCode } from "@/entities/animal";
+import type { AnimalStatusCode, PlacementType } from "@/entities/animal";
 
 export interface ApplyCta {
   primaryLabel: string;
   /** Whether the primary action can be taken (design §02 status branch). */
   primaryEnabled: boolean;
-  /** Show the secondary "임시보호 신청" action. */
+  /** Which funnel the primary action opens (입양 vs 임보). */
+  primaryKind: PlacementType;
+  /** Show the secondary "임시보호 신청" action (only alongside a 입양 primary). */
   showFoster: boolean;
 }
 
 /**
- * Maps an animal's status to its detail-page CTA:
- * AVAILABLE → 입양/임보 신청, RESERVED → 신청 마감, FOSTERED → 임시보호 중,
- * ADOPTED → 입양 완료. Only AVAILABLE is actionable.
+ * Maps an animal's status and placement eligibility to its detail-page CTA.
+ * Only AVAILABLE is actionable; then the eligible placements decide the buttons:
+ * both → 입양(primary) + 임보(secondary), 입양-only → 입양, 임보-only → 임보 as the
+ * primary. RESERVED/FOSTERED/ADOPTED/RETURNED are shown but disabled.
  */
-export const applyCta = (status: AnimalStatusCode): ApplyCta => {
+export const applyCta = (
+  status: AnimalStatusCode,
+  eligiblePlacements: PlacementType[],
+): ApplyCta => {
+  if (status === "AVAILABLE") {
+    const canAdopt = eligiblePlacements.includes("ADOPTION");
+    const canFoster = eligiblePlacements.includes("FOSTER");
+
+    if (canAdopt) {
+      return {
+        primaryLabel: "입양 신청하기",
+        primaryEnabled: true,
+        primaryKind: "ADOPTION",
+        showFoster: canFoster,
+      };
+    }
+    if (canFoster) {
+      return {
+        primaryLabel: "임시보호 신청하기",
+        primaryEnabled: true,
+        primaryKind: "FOSTER",
+        showFoster: false,
+      };
+    }
+
+    return { primaryLabel: "신청 마감", primaryEnabled: false, primaryKind: "ADOPTION", showFoster: false };
+  }
+
   switch (status) {
-    case "AVAILABLE":
-      return { primaryLabel: "입양 신청하기", primaryEnabled: true, showFoster: true };
     case "FOSTERED":
-      return { primaryLabel: "임시보호 중", primaryEnabled: false, showFoster: false };
+      return { primaryLabel: "임시보호 중", primaryEnabled: false, primaryKind: "ADOPTION", showFoster: false };
     case "ADOPTED":
-      return { primaryLabel: "입양 완료", primaryEnabled: false, showFoster: false };
+      return { primaryLabel: "입양 완료", primaryEnabled: false, primaryKind: "ADOPTION", showFoster: false };
     case "RESERVED":
     case "RETURNED":
-      return { primaryLabel: "신청 마감", primaryEnabled: false, showFoster: false };
+      return { primaryLabel: "신청 마감", primaryEnabled: false, primaryKind: "ADOPTION", showFoster: false };
   }
 };

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
@@ -2,7 +2,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
-import type { AnimalDetail } from "@/entities/animal";
+import type { AnimalDetail, PlacementType } from "@/entities/animal";
 import { ApplyCard } from "./ApplyCard";
 
 const renderCard = (
@@ -16,12 +16,16 @@ const renderCard = (
     </MemoryRouter>,
   );
 
-const animal = (status: AnimalDetail["status"]): AnimalDetail => ({
+const animal = (
+  status: AnimalDetail["status"],
+  eligiblePlacements: PlacementType[] = ["ADOPTION", "FOSTER"],
+): AnimalDetail => ({
   id: "animal-1",
   shelterId: "shelter-1",
   name: "콩이",
   species: "DOG",
   status,
+  eligiblePlacements,
   sex: "FEMALE",
   size: "SMALL",
   ageMonths: 24,
@@ -51,6 +55,14 @@ describe("ApplyCard", () => {
     renderCard(animal("ADOPTED"));
 
     expect(button("입양 완료").hasAttribute("disabled")).toBe(true);
+    expect(screen.queryByRole("button", { name: "임시보호 신청" })).toBeNull();
+  });
+
+  it("makes 임보 the primary action for a foster-only animal", () => {
+    renderCard(animal("AVAILABLE", ["FOSTER"]));
+
+    expect(button("임시보호 신청하기").hasAttribute("disabled")).toBe(false);
+    expect(screen.queryByRole("button", { name: "입양 신청하기" })).toBeNull();
     expect(screen.queryByRole("button", { name: "임시보호 신청" })).toBeNull();
   });
 

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
@@ -32,7 +32,7 @@ export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProp
   const navigate = useNavigate();
   const { openWarnToast } = useToast();
 
-  const cta = applyCta(animal.status);
+  const cta = applyCta(animal.status, animal.eligiblePlacements);
   const statusLabel = STATUS_LABEL[animal.status];
   const age = animal.ageMonths != null ? `${formatAge(animal.ageMonths)}(추정)` : "나이 미상";
   const meta = [animal.breed, age, SIZE_LABEL[animal.size], SEX_LABEL[animal.sex]]
@@ -96,7 +96,11 @@ export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProp
           variant="primary"
           fullWidth
           disabled={!cta.primaryEnabled}
-          onClick={() => navigate(applyPath(animal.id))}
+          onClick={() =>
+            navigate(
+              cta.primaryKind === "FOSTER" ? fosterApplyPath(animal.id) : applyPath(animal.id),
+            )
+          }
         >
           {cta.primaryLabel}
         </Hb.Button>

--- a/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.spec.ts
+++ b/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.spec.ts
@@ -35,6 +35,12 @@ describe("filtersFromParams", () => {
     expect(filtersFromParams(new URLSearchParams("species=DINOSAUR")).species).toBeUndefined();
   });
 
+  it("reads a valid placement and ignores an unknown one", () => {
+    expect(filtersFromParams(new URLSearchParams("placement=FOSTER")).placement).toBe("FOSTER");
+    expect(filtersFromParams(new URLSearchParams("placement=ADOPTION")).placement).toBe("ADOPTION");
+    expect(filtersFromParams(new URLSearchParams("placement=RENT")).placement).toBeUndefined();
+  });
+
   it("treats a blank keyword as absent", () => {
     expect(filtersFromParams(new URLSearchParams("q=%20%20")).keyword).toBeUndefined();
   });
@@ -75,6 +81,14 @@ describe("paramsFromFilters", () => {
 
   it("marks the off state as status=all", () => {
     expect(paramsFromFilters({ limit: 20, view: "grid" }).get("status")).toBe("all");
+  });
+
+  it("serializes the placement filter", () => {
+    expect(
+      paramsFromFilters({ placement: "FOSTER", status: "AVAILABLE", limit: 20, view: "grid" }).get(
+        "placement",
+      ),
+    ).toBe("FOSTER");
   });
 
   it("serializes the map view and omits it for the grid", () => {

--- a/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.ts
+++ b/apps/hobom-angel/src/features/browse-animals/lib/animal-filter-params.lib.ts
@@ -1,7 +1,8 @@
-import type { AnimalFilters, AnimalSpecies } from "@/entities/animal";
+import type { AnimalFilters, AnimalSpecies, PlacementType } from "@/entities/animal";
 import type { SearchParamsCodec } from "@/shared/model";
 
 const SPECIES = new Set<AnimalSpecies>(["DOG", "CAT", "OTHER"]);
+const PLACEMENTS = new Set<PlacementType>(["ADOPTION", "FOSTER"]);
 const PAGE_SIZE = 20;
 
 export type AnimalView = "grid" | "map";
@@ -19,11 +20,16 @@ export type AnimalBrowseState = AnimalFilters & { view: AnimalView };
  */
 export const filtersFromParams = (params: URLSearchParams): AnimalBrowseState => {
   const species = params.get("species");
+  const placement = params.get("placement");
   const keyword = params.get("q")?.trim();
 
   return {
     species:
       species && SPECIES.has(species as AnimalSpecies) ? (species as AnimalSpecies) : undefined,
+    placement:
+      placement && PLACEMENTS.has(placement as PlacementType)
+        ? (placement as PlacementType)
+        : undefined,
     keyword: keyword || undefined,
     status: params.get("status") === "all" ? undefined : "AVAILABLE",
     sort: params.get("sort") === "OLDEST" ? "OLDEST" : "LATEST",
@@ -37,6 +43,7 @@ export const paramsFromFilters = (state: AnimalBrowseState): URLSearchParams => 
   const params = new URLSearchParams();
 
   if (state.species) params.set("species", state.species);
+  if (state.placement) params.set("placement", state.placement);
   if (state.keyword) params.set("q", state.keyword);
   if (!state.status) params.set("status", "all");
   if (state.sort === "OLDEST") params.set("sort", "OLDEST");

--- a/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.tsx
+++ b/apps/hobom-angel/src/features/browse-animals/ui/AnimalFilters.tsx
@@ -2,13 +2,14 @@ import { useState, type FormEvent } from "react";
 import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { SearchOutlined } from "hobom-design-system/icons";
-import { SPECIES_LABEL } from "@/entities/animal";
-import type { AnimalFilters as Filters, AnimalSpecies } from "@/entities/animal";
+import { PLACEMENT_LABEL, SPECIES_LABEL } from "@/entities/animal";
+import type { AnimalFilters as Filters, AnimalSpecies, PlacementType } from "@/entities/animal";
 import { SortSelect } from "./SortSelect";
 import { styles } from "./AnimalFilters.styles";
 import type { AnimalView } from "../lib/animal-filter-params.lib";
 
 const SPECIES: AnimalSpecies[] = ["DOG", "CAT", "OTHER"];
+const PLACEMENTS: PlacementType[] = ["ADOPTION", "FOSTER"];
 
 interface AnimalFiltersProps {
   filters: Filters;
@@ -61,6 +62,28 @@ export const AnimalFilters = ({ filters, onChange, view, onViewChange }: AnimalF
                 onChange={() => onChange({ ...filters, species: selected ? undefined : species })}
               >
                 {SPECIES_LABEL[species]}
+              </Hb.ToggleButton>
+            );
+          })}
+        </Hb.ToggleButtonGroup>
+
+        <Hb.Divider orientation="vertical" style={{ height: 24, alignSelf: "center" }} />
+
+        <Hb.ToggleButtonGroup variant="segmented" aria-label="신청 유형">
+          {PLACEMENTS.map((placement) => {
+            const selected = filters.placement === placement;
+
+            return (
+              <Hb.ToggleButton
+                key={placement}
+                variant="segmented"
+                value={placement}
+                selected={selected}
+                onChange={() =>
+                  onChange({ ...filters, placement: selected ? undefined : placement })
+                }
+              >
+                {PLACEMENT_LABEL[placement]}
               </Hb.ToggleButton>
             );
           })}

--- a/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
@@ -57,9 +57,10 @@ const SHELTERS = [
 ];
 
 // A mix across the roster: mostly both, with some foster-only and adoption-only.
+// animal-1 (i=0) stays "both" so it remains a valid adoption/foster fixture.
 const placementsFor = (i: number): string[] => {
-  if (i % 5 === 0) return ["FOSTER"];
-  if (i % 5 === 1) return ["ADOPTION"];
+  if (i % 5 === 2) return ["FOSTER"];
+  if (i % 5 === 3) return ["ADOPTION"];
 
   return ["ADOPTION", "FOSTER"];
 };

--- a/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/animal.handlers.ts
@@ -56,6 +56,14 @@ const SHELTERS = [
   },
 ];
 
+// A mix across the roster: mostly both, with some foster-only and adoption-only.
+const placementsFor = (i: number): string[] => {
+  if (i % 5 === 0) return ["FOSTER"];
+  if (i % 5 === 1) return ["ADOPTION"];
+
+  return ["ADOPTION", "FOSTER"];
+};
+
 const ANIMALS = Array.from({ length: 42 }, (_, i) => {
   const shelter = SHELTERS[i % SHELTERS.length] as (typeof SHELTERS)[number];
 
@@ -66,6 +74,7 @@ const ANIMALS = Array.from({ length: 42 }, (_, i) => {
     species: SPECIES[i % SPECIES.length],
     description: "사람을 좋아하고 산책을 즐기는 아이예요. 실내 배변 교육이 되어 있어요.",
     status: STATUSES[i % STATUSES.length],
+    eligiblePlacements: placementsFor(i),
     traits: {
       sex: SEXES[i % SEXES.length],
       size: SIZES[i % SIZES.length],
@@ -106,6 +115,7 @@ interface AnimalRow {
   species: string;
   description: string;
   status: string;
+  eligiblePlacements: string[];
   traits: {
     sex: string;
     size: string;
@@ -137,6 +147,7 @@ export const animalHandlers = [
     const url = new URL(request.url);
     const species = url.searchParams.get("species");
     const status = url.searchParams.get("status");
+    const placement = url.searchParams.get("placement");
     const keyword = url.searchParams.get("keyword");
     const sort = url.searchParams.get("sort");
     const limit = Number(url.searchParams.get("limit") ?? "20");
@@ -147,6 +158,7 @@ export const animalHandlers = [
 
     if (species) filtered = filtered.filter((a) => a.species === species);
     if (status) filtered = filtered.filter((a) => a.status === status);
+    if (placement) filtered = filtered.filter((a) => a.eligiblePlacements.includes(placement));
     if (keyword) filtered = filtered.filter((a) => a.name.includes(keyword));
 
     const page = filtered.slice(cursor, cursor + limit);

--- a/apps/hobom-angel/src/pages/foster/ui/FosterPage.tsx
+++ b/apps/hobom-angel/src/pages/foster/ui/FosterPage.tsx
@@ -98,7 +98,7 @@ export const FosterPage = () => {
           <p {...stylex.props(styles.ctaLead)}>{FOSTER_CTA.lead}</p>
           <Hb.Button
             style={{ backgroundColor: "#ffffff", color: "var(--hb-color-accent-dark)" }}
-            onClick={() => navigate(ROUTES.ANIMALS)}
+            onClick={() => navigate(`${ROUTES.ANIMALS}?placement=FOSTER`)}
           >
             {FOSTER_CTA.button}
           </Hb.Button>


### PR DESCRIPTION
## Why
`/animals` couldn't tell adoption and foster apart — the same list served both, and the detail page always offered both CTAs regardless of what the animal actually accepts. The backend now marks each animal with `eligiblePlacements` (`ADOPTION` / `FOSTER`, from #106), so the catalog can finally distinguish them.

## Changes
- **entity** — thread `eligiblePlacements` through the animal model, type, schema, and mapper; export `PlacementType` + `PLACEMENT_LABEL`.
- **catalog filter** — a 입양/임보 segmented control in the browse bar, URL-backed via `?placement=` (shareable / bookmarkable like the other filters).
- **detail CTA gating** — `applyCta` now takes eligibility: a foster-only animal makes 임보 its primary action, an adoption-only one hides the foster button, both keeps 입양 primary + 임보 secondary.
- **foster explainer** — '임보 가능한 친구 보기' now lands on `/animals?placement=FOSTER`.
- **mocks** — vary `eligiblePlacements` across the roster (animal-1 stays both so the funnels still open from it) and honor `?placement=`.

## Verify
typecheck, lint, unit (160), the full e2e suite (57), and the production build all pass. Adds unit coverage for the placement codec + CTA branching, and e2e for the filter and the foster CTA hand-off.

Note: the real backend needs a one-time backfill of `eligiblePlacements` on pre-existing animal docs — the read mapper defaults missing→both, but the query filter (`{eligiblePlacements: value}`) skips docs without the field, so `?placement=` returns empty until backfilled. Frontend is unaffected.