### PR TITLE
Let a shelter approve or reject its pending applications

### DIFF
--- a/apps/hobom-angel/e2e/console-applications.spec.ts
+++ b/apps/hobom-angel/e2e/console-applications.spec.ts
@@ -33,4 +33,26 @@ test.describe("§7.2 shelter console — applications", () => {
     await page.getByRole("button", { name: "임시보호", exact: true }).click();
     await expect(page.getByRole("button", { name: /단추/ })).toBeVisible();
   });
+
+  test("rejects a pending application with a reason", async ({ page }) => {
+    await login(page);
+    await page.goto("console/applications");
+
+    // Open a pending adoption application — the decision bar shows for PENDING.
+    await page.getByRole("button", { name: /콩이/ }).click();
+    await page.getByRole("button", { name: "반려하기" }).click();
+
+    // The dialog requires a reason before it can submit.
+    await page.getByLabel("반려 사유").fill("보호 환경 확인이 더 필요해요");
+    await page
+      .getByRole("button", { name: "반려하기" })
+      .last()
+      .click();
+
+    await expect(page.getByText("신청을 반려했어요.")).toBeVisible();
+
+    // The application now reads as 반려 with the reason, and the bar is gone.
+    await expect(page.getByText("보호 환경 확인이 더 필요해요")).toBeVisible();
+    await expect(page.getByRole("button", { name: "승인하기" })).toHaveCount(0);
+  });
 });

--- a/apps/hobom-angel/src/entities/application/api/application.api.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.api.ts
@@ -2,6 +2,7 @@ import { httpClient, parseResponse } from "@/shared/api";
 import { toQueryString } from "@/shared/lib";
 import { applicationDetailSchema, applicationsPageSchema } from "./application.schema";
 import { toDetail, toSummary } from "../lib/to-application.lib";
+import type { DecideApplicationInput } from "./application.type";
 import type { ApplicationDetail, ApplicationKind, ApplicationPage, ApplicationStatus } from "../model/application.model";
 
 const parsePage = parseResponse(applicationsPageSchema, "GET /shelters/:id/:kind-applications");
@@ -56,3 +57,11 @@ export const getApplicationDetail = (
     .get(`/${pathFor(kind)}/${id}`, { signal })
     .then(parseDetail)
     .then((raw) => toDetail(raw, kind));
+
+/** A shelter approves or rejects a pending application (§7.2 심사). */
+export const decideApplication = (
+  kind: ApplicationKind,
+  id: string,
+  input: DecideApplicationInput,
+): Promise<void> =>
+  httpClient.post(`/${pathFor(kind)}/${id}/decision`, input).then(() => undefined);

--- a/apps/hobom-angel/src/entities/application/api/application.mutations.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.mutations.ts
@@ -1,0 +1,12 @@
+import { mutationOptions } from "hobom-data";
+import { decideApplication } from "./application.api";
+import type { DecideApplicationInput } from "./application.type";
+import type { ApplicationKind } from "../model/application.model";
+
+export const applicationMutations = {
+  decide: () =>
+    mutationOptions({
+      mutationFn: (vars: { kind: ApplicationKind; id: string; input: DecideApplicationInput }) =>
+        decideApplication(vars.kind, vars.id, vars.input),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/application/api/application.schema.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.schema.ts
@@ -31,4 +31,5 @@ export const applicationDetailSchema: Schema<RawApplicationDetail> = HoBomSchema
       values: HoBomSchema.array(HoBomSchema.string()),
     }),
   ),
+  decidedReason: HoBomSchema.string().nullable().optional(),
 });

--- a/apps/hobom-angel/src/entities/application/api/application.type.ts
+++ b/apps/hobom-angel/src/entities/application/api/application.type.ts
@@ -24,4 +24,11 @@ export interface RawAnswer {
 
 export interface RawApplicationDetail extends RawApplicationSummary {
   answers: RawAnswer[];
+  decidedReason?: string | null;
+}
+
+/** `POST /:kind-applications/:id/decision` — a shelter's approve/reject. */
+export interface DecideApplicationInput {
+  decision: "APPROVE" | "REJECT";
+  reason?: string;
 }

--- a/apps/hobom-angel/src/entities/application/index.ts
+++ b/apps/hobom-angel/src/entities/application/index.ts
@@ -1,4 +1,5 @@
 export { applicationQueries } from "./api/application.queries";
+export { applicationMutations } from "./api/application.mutations";
 export { KIND_LABEL, STATUS_LABEL, STATUS_COLOR } from "./model/application.model";
 export type {
   ApplicationKind,
@@ -8,3 +9,4 @@ export type {
   ApplicationAnswer,
   ApplicationPage,
 } from "./model/application.model";
+export type { DecideApplicationInput } from "./api/application.type";

--- a/apps/hobom-angel/src/entities/application/lib/to-application.lib.ts
+++ b/apps/hobom-angel/src/entities/application/lib/to-application.lib.ts
@@ -21,4 +21,5 @@ export const toSummary = (raw: RawApplicationSummary, kind: ApplicationKind): Ap
 export const toDetail = (raw: RawApplicationDetail, kind: ApplicationKind): ApplicationDetail => ({
   ...toSummary(raw, kind),
   answers: raw.answers.map((answer) => ({ questionId: answer.questionId, values: answer.values })),
+  decidedReason: raw.decidedReason ?? null,
 });

--- a/apps/hobom-angel/src/entities/application/model/application.model.ts
+++ b/apps/hobom-angel/src/entities/application/model/application.model.ts
@@ -26,6 +26,8 @@ export interface ApplicationAnswer {
 /** Single-application projection: the summary plus the submitted answers. */
 export interface ApplicationDetail extends ApplicationSummary {
   answers: ApplicationAnswer[];
+  /** The shelter's reject reason, present once REJECTED. */
+  decidedReason: string | null;
 }
 
 /** A cursor page of a shelter's applications. */

--- a/apps/hobom-angel/src/features/console-applications/model/useApplicationDecision.ts
+++ b/apps/hobom-angel/src/features/console-applications/model/useApplicationDecision.ts
@@ -1,0 +1,29 @@
+import { useDataLot, useMutation } from "hobom-data";
+import { applicationMutations, applicationQueries } from "@/entities/application";
+import { useToast } from "@/shared/model";
+import type { ApplicationKind } from "@/entities/application";
+
+/** §7.2 심사 — approve or reject a pending application. A decision moves the row
+ *  between status filters and flips its detail, so it invalidates the whole
+ *  application cache for a fresh read. */
+export const useApplicationDecision = (kind: ApplicationKind, id: string) => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const decide = useMutation({
+    ...applicationMutations.decide(),
+    onSuccess: (_data, vars) => {
+      openSuccessToast({
+        message: vars.input.decision === "APPROVE" ? "신청을 승인했어요." : "신청을 반려했어요.",
+      });
+      void dataLot.invalidateQueries({ queryKey: applicationQueries.all() });
+    },
+    onError: (error: Error) => openErrorToast({ message: error.message || "처리에 실패했어요." }),
+  });
+
+  return {
+    approve: () => decide.mutate({ kind, id, input: { decision: "APPROVE" } }),
+    reject: (reason: string) => decide.mutate({ kind, id, input: { decision: "REJECT", reason } }),
+    deciding: decide.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/console-applications/ui/ApplicationDetailPanel.tsx
+++ b/apps/hobom-angel/src/features/console-applications/ui/ApplicationDetailPanel.tsx
@@ -2,9 +2,12 @@ import * as stylex from "@stylexjs/stylex";
 import { Hb } from "hobom-design-system";
 import { STATUS_COLOR, STATUS_LABEL } from "@/entities/application";
 import type { ApplicationKind } from "@/entities/application";
+import { useOverlay } from "@/shared/model";
 import { maskApplicant } from "../lib/application-format.lib";
 import { useAnimalNames } from "../model/useAnimalNames";
 import { useApplicationDetail } from "../model/useApplicationDetail";
+import { useApplicationDecision } from "../model/useApplicationDecision";
+import { ApplicationRejectDialog } from "./ApplicationRejectDialog";
 import { styles } from "./ConsoleApplications.styles";
 
 const formatDate = (iso: string): string =>
@@ -20,6 +23,13 @@ interface ApplicationDetailPanelProps {
 export const ApplicationDetailPanel = ({ shelterId, kind, id }: ApplicationDetailPanelProps) => {
   const animalName = useAnimalNames(shelterId);
   const { detail, rows } = useApplicationDetail(shelterId, kind, id);
+  const { approve, reject, deciding } = useApplicationDecision(kind, id);
+  const overlay = useOverlay();
+
+  const promptReject = () =>
+    overlay.open(({ close }) => (
+      <ApplicationRejectDialog onConfirm={reject} onClose={close} />
+    ));
 
   return (
     <div {...stylex.props(styles.detail)}>
@@ -40,6 +50,13 @@ export const ApplicationDetailPanel = ({ shelterId, kind, id }: ApplicationDetai
         <span>설문 v{detail.questionnaireVersion}</span>
       </div>
 
+      {detail.status === "REJECTED" && detail.decidedReason && (
+        <div {...stylex.props(styles.rejectReason)}>
+          <span {...stylex.props(styles.answerPrompt)}>반려 사유</span>
+          <span {...stylex.props(styles.answerText)}>{detail.decidedReason}</span>
+        </div>
+      )}
+
       <p {...stylex.props(styles.sectionLabel)}>제출한 답변</p>
       {rows.length === 0 ? (
         <span {...stylex.props(styles.answerText)}>제출한 답변이 없어요.</span>
@@ -51,6 +68,17 @@ export const ApplicationDetailPanel = ({ shelterId, kind, id }: ApplicationDetai
               <span {...stylex.props(styles.answerText)}>{row.text}</span>
             </div>
           ))}
+        </div>
+      )}
+
+      {detail.status === "PENDING" && (
+        <div {...stylex.props(styles.decisionBar)}>
+          <Hb.Button variant="primary" fullWidth disabled={deciding} onClick={approve}>
+            승인하기
+          </Hb.Button>
+          <Hb.Button variant="danger" fullWidth disabled={deciding} onClick={promptReject}>
+            반려하기
+          </Hb.Button>
         </div>
       )}
     </div>

--- a/apps/hobom-angel/src/features/console-applications/ui/ApplicationRejectDialog.tsx
+++ b/apps/hobom-angel/src/features/console-applications/ui/ApplicationRejectDialog.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Hb } from "hobom-design-system";
+
+interface ApplicationRejectDialogProps {
+  onConfirm: (reason: string) => void;
+  onClose: () => void;
+}
+
+/** Collect the required reason before rejecting an application. */
+export const ApplicationRejectDialog = ({ onConfirm, onClose }: ApplicationRejectDialogProps) => {
+  const [reason, setReason] = useState("");
+  const canSubmit = reason.trim().length > 0;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    onConfirm(reason.trim());
+    onClose();
+  };
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="xs">
+      <Hb.Dialog.Title>신청 반려</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <Hb.TextField
+          label="반려 사유"
+          placeholder="신청자에게 전달할 반려 사유를 입력하세요"
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          multiline
+          minRows={3}
+          fullWidth
+          autoFocus
+        />
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          취소
+        </Hb.Button>
+        <Hb.Button variant="danger" onClick={submit} disabled={!canSubmit}>
+          반려하기
+        </Hb.Button>
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/features/console-applications/ui/ConsoleApplications.styles.ts
+++ b/apps/hobom-angel/src/features/console-applications/ui/ConsoleApplications.styles.ts
@@ -190,4 +190,21 @@ export const styles = stylex.create({
     borderStyle: "dashed",
     borderColor: "var(--hb-color-border)",
   },
+  decisionBar: {
+    display: "flex",
+    gap: 8,
+    marginTop: 4,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopStyle: "solid",
+    borderTopColor: "var(--hb-color-border)",
+  },
+  rejectReason: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
 });

--- a/apps/hobom-angel/src/mocks/handlers/application.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/application.handlers.ts
@@ -17,6 +17,7 @@ interface ApplicationRow {
   questionnaireVersion: number;
   plannedEndDate?: string | null;
   createdAt: string | null;
+  decidedReason?: string | null;
   answers: AnswerRow[];
 }
 
@@ -120,6 +121,32 @@ const detail = (rows: ApplicationRow[], id: string | readonly string[] | undefin
   return ok(row);
 };
 
+/** Apply a shelter's decision to a pending row, mirroring the approval engine:
+ *  APPROVE → APPROVED, REJECT → REJECTED (with the reason). 404 when already
+ *  decided (no PENDING approval to resolve). */
+const decide = async (
+  rows: ApplicationRow[],
+  id: string | readonly string[] | undefined,
+  request: Request,
+) => {
+  if (!mockSession.isActive()) {
+    return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+  }
+
+  const row = rows.find((candidate) => candidate.id === id);
+
+  if (!row || row.status !== "PENDING") {
+    return HttpResponse.json({ message: "대기 중인 신청이 없어요." }, { status: 404 });
+  }
+
+  const body = (await request.json()) as { decision: "APPROVE" | "REJECT"; reason?: string };
+
+  row.status = body.decision === "APPROVE" ? "APPROVED" : "REJECTED";
+  row.decidedReason = body.decision === "REJECT" ? (body.reason ?? null) : null;
+
+  return new HttpResponse(null, { status: 204 });
+};
+
 /** §7.2 console — adoption / foster application read endpoints (queue + detail). */
 export const applicationHandlers = [
   http.get(mockUrl("/shelters/:shelterId/adoption-applications"), ({ request }) => {
@@ -170,4 +197,13 @@ export const applicationHandlers = [
 
     return detail(FOSTER_APPLICATIONS, params.id);
   }),
+
+  // §7.2 심사 — a shelter approves / rejects a pending application.
+  http.post(mockUrl("/adoption-applications/:id/decision"), ({ params, request }) =>
+    decide(ADOPTION_APPLICATIONS, params.id, request),
+  ),
+
+  http.post(mockUrl("/foster-applications/:id/decision"), ({ params, request }) =>
+    decide(FOSTER_APPLICATIONS, params.id, request),
+  ),
 ];


### PR DESCRIPTION
## What
The 신청 처리 console (§7.2) could **read** adoption/foster applications but had no way to decide them — the application contract never exposed the approval id, so the shelter had nothing to approve/reject with.

Backend #109 added application-scoped decision endpoints (`POST /{adoption|foster}-applications/:id/decision  { decision, reason? }`, resolving the approval server-side and reusing `canManageShelter` authz). This wires the frontend to them:

- **ApplicationDetailPanel** — a PENDING application now shows **승인하기 / 반려하기**. Reject opens a dialog that requires a reason; approve is one click.
- A decision invalidates the application cache, so the row moves into its new status filter and the detail flips.
- A **REJECTED** application shows its 반려 사유 (the new `decidedReason` field).

The action labels are 승인하기/반려하기 (distinct from the 승인/반려 status **filter** chips) to avoid ambiguity.

## Structure
- `entities/application` — `decideApplication(kind, id, input)` + `applicationMutations.decide()`, `DecideApplicationInput`, and `decidedReason` threaded through model/type/schema/mapper.
- `console-applications` — `useApplicationDecision` hook + `ApplicationRejectDialog`.
- MSW — the two decision endpoints mutate the seed row (PENDING→APPROVED/REJECTED, 404 when already decided).

## Verify
typecheck, lint, unit (160), the full e2e suite (58), and the build pass. Adds an e2e that rejects a pending application with a reason and confirms the 반려 state + reason render.