### PR TITLE
Add the shelter registration flow

### DIFF
--- a/apps/hobom-angel/e2e/register-shelter.spec.ts
+++ b/apps/hobom-angel/e2e/register-shelter.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("보호소 등록 신청", () => {
+  test("registers a shelter and returns to my page", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/register");
+
+    await expect(page.getByRole("heading", { name: "보호소 등록 신청" })).toBeVisible();
+
+    // Submit stays disabled until the required fields are valid.
+    const submit = page.getByRole("button", { name: "등록 신청하기" });
+    await expect(submit).toBeDisabled();
+
+    await page.getByLabel("보호소 이름").fill("햇살 보호소");
+    await page.getByLabel("보호소 프로필 주소").fill("haetsal-shelter");
+    await page.getByLabel("시·도").fill("서울");
+    await page.getByLabel("시·군·구").fill("마포구");
+    await page.getByLabel("도로명 주소").fill("월드컵로 100");
+
+    await page.screenshot({ path: "e2e-artifacts/register-shelter.png", fullPage: true });
+
+    await expect(submit).toBeEnabled();
+    await submit.click();
+
+    await expect(page.getByText("등록 신청이 접수됐어요.", { exact: false })).toBeVisible();
+    await expect(page).toHaveURL(/\/my$/);
+  });
+
+  test("blocks an invalid slug", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/register");
+
+    await page.getByLabel("보호소 이름").fill("햇살 보호소");
+    await page.getByLabel("보호소 프로필 주소").fill("Bad Slug!");
+
+    await expect(page.getByText("소문자·숫자·하이픈만", { exact: false })).toBeVisible();
+    await expect(page.getByRole("button", { name: "등록 신청하기" })).toBeDisabled();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -43,6 +43,9 @@ const ShelterDetailPage = lazy(() =>
 const ShelterListPage = lazy(() =>
   import("@/pages/shelters").then((module) => ({ default: module.ShelterListPage })),
 );
+const RegisterShelterPage = lazy(() =>
+  import("@/pages/register-shelter").then((module) => ({ default: module.RegisterShelterPage })),
+);
 const VolunteerPage = lazy(() =>
   import("@/pages/volunteer").then((module) => ({ default: module.VolunteerPage })),
 );
@@ -120,6 +123,7 @@ export const AppRouter = () => {
             <Route path={ROUTES.APPLY} element={<ApplyAdoptionPage />} />
             <Route path={ROUTES.FOSTER_APPLY} element={<ApplyFosterPage />} />
             <Route path={ROUTES.SHELTERS} element={<ShelterListPage />} />
+            <Route path={ROUTES.SHELTER_REGISTER} element={<RegisterShelterPage />} />
             <Route path={ROUTES.SHELTER_DETAIL} element={<ShelterDetailPage />} />
             <Route path={ROUTES.VOLUNTEER} element={<VolunteerPage />} />
             <Route path={ROUTES.VOLUNTEER_WRITE} element={<WriteReviewPage />} />

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.api.ts
@@ -5,6 +5,7 @@ import { toShelterListItem } from "../lib/to-shelter-list-item.lib";
 import { toShelterMarker } from "../lib/to-shelter-marker.lib";
 import {
   createdIdSchema,
+  registerShelterResultSchema,
   shelterAnnouncementsSchema,
   shelterDashboardSchema,
   shelterFaqsSchema,
@@ -32,6 +33,8 @@ import type {
   ApprovalDecisionInput,
   CreatedId,
   FaqInput,
+  RegisterShelterInput,
+  RegisterShelterResult,
   ShelterSearchParams,
   StaffPromotionResult,
 } from "./shelter.type";
@@ -87,6 +90,12 @@ export const getShelterMarkers = (
 /** Fetch a shelter's public microsite profile by slug (§04). */
 export const getShelterBySlug = (slug: string, signal?: AbortSignal): Promise<Shelter> =>
   httpClient.get(`/shelters/${slug}`, { signal }).then(parseShelter).then(toShelter);
+
+/** Register a shelter — the caller becomes 대표 and a verification opens. */
+export const registerShelter = (input: RegisterShelterInput): Promise<RegisterShelterResult> =>
+  httpClient
+    .post("/shelters", input)
+    .then(parseResponse(registerShelterResultSchema, "POST /shelters"));
 
 /** Fetch a shelter's notices/news, pinned first. */
 export const getShelterAnnouncements = (

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.mutations.ts
@@ -7,11 +7,22 @@ import {
   decideApproval,
   postAnnouncement,
   postFaq,
+  registerShelter,
   requestStaffPromotion,
 } from "./shelter.api";
-import type { AnnouncementInput, ApprovalDecisionInput, FaqInput } from "./shelter.type";
+import type {
+  AnnouncementInput,
+  ApprovalDecisionInput,
+  FaqInput,
+  RegisterShelterInput,
+} from "./shelter.type";
 
 export const shelterMutations = {
+  register: () =>
+    mutationOptions({
+      mutationFn: (input: RegisterShelterInput) => registerShelter(input),
+    }),
+
   createAnnouncement: (shelterId: string) =>
     mutationOptions({
       mutationFn: (input: AnnouncementInput) => postAnnouncement(shelterId, input),

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.schema.ts
@@ -10,6 +10,7 @@ import type {
   RawShelterStats,
   RawStaffMember,
   RawStaffPromotionRequest,
+  RegisterShelterResult,
   ShelterListPage,
   StaffPromotionResult,
 } from "./shelter.type";
@@ -147,4 +148,9 @@ export const staffPromotionsSchema: Schema<RawStaffPromotionRequest[]> = HoBomSc
 
 export const createdIdSchema: Schema<CreatedId> = HoBomSchema.object({
   id: HoBomSchema.string(),
+});
+
+export const registerShelterResultSchema: Schema<RegisterShelterResult> = HoBomSchema.object({
+  shelterId: HoBomSchema.string(),
+  approvalId: HoBomSchema.string(),
 });

--- a/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
+++ b/apps/hobom-angel/src/entities/shelter/api/shelter.type.ts
@@ -158,3 +158,24 @@ export interface FaqInput {
   answer: string;
   order: number;
 }
+
+/** `POST /shelters` request — the registrant becomes the 대표 and a
+ *  SHELTER_VERIFICATION approval opens for the operator to review. */
+export interface RegisterShelterInput {
+  name: string;
+  slug: string;
+  address: {
+    region: string;
+    city: string;
+    roadAddress: string;
+    visibility: AddressVisibility;
+  };
+  registrationNumber?: string;
+  businessNumber?: string;
+}
+
+/** `POST /shelters` response — the new shelter and its open verification. */
+export interface RegisterShelterResult {
+  shelterId: string;
+  approvalId: string;
+}

--- a/apps/hobom-angel/src/entities/shelter/index.ts
+++ b/apps/hobom-angel/src/entities/shelter/index.ts
@@ -1,7 +1,12 @@
 export { ShelterCard } from "./ui/ShelterCard";
 export { shelterQueries } from "./api/shelter.queries";
 export { shelterMutations } from "./api/shelter.mutations";
-export type { AnnouncementInput, FaqInput } from "./api/shelter.type";
+export type {
+  AnnouncementInput,
+  FaqInput,
+  RegisterShelterInput,
+  RegisterShelterResult,
+} from "./api/shelter.type";
 export { toShelter } from "./lib/to-shelter.lib";
 export { formatShelterAddress } from "./lib/format-shelter-address.lib";
 export { operatingYears } from "./lib/operating-years.lib";
@@ -11,6 +16,8 @@ export {
   isShelterAdmin,
   STAFF_ROLE_LABEL,
   TRUST_TIER_LABEL,
+  ADDRESS_VISIBILITY_LABEL,
+  ADDRESS_VISIBILITY_HINT,
 } from "./model/shelter.model";
 export type {
   Shelter,

--- a/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
+++ b/apps/hobom-angel/src/entities/shelter/model/shelter.model.ts
@@ -145,6 +145,19 @@ export const isShelterVerified = (status: ShelterStatus): boolean => status === 
 /** The precise road address is only shown when the policy is FULL. */
 export const isPreciseAddress = (visibility: AddressVisibility): boolean => visibility === "FULL";
 
+export const ADDRESS_VISIBILITY_LABEL: Record<AddressVisibility, string> = {
+  FULL: "전체 공개",
+  PARTIAL: "부분 공개",
+  HIDDEN: "비공개",
+};
+
+/** A one-line hint for what each disclosure level shows on the map/profile. */
+export const ADDRESS_VISIBILITY_HINT: Record<AddressVisibility, string> = {
+  FULL: "도로명 주소와 정확한 위치를 공개해요.",
+  PARTIAL: "시·군·구까지만, 지도에는 대략 위치로 표시돼요.",
+  HIDDEN: "지역만 공개하고 지도에는 표시하지 않아요.",
+};
+
 export const TRUST_TIER_LABEL: Record<TrustTier, string> = {
   A: "인증 단체",
   B: "인증 활동가",

--- a/apps/hobom-angel/src/features/register-shelter/index.ts
+++ b/apps/hobom-angel/src/features/register-shelter/index.ts
@@ -1,0 +1,1 @@
+export { RegisterShelter } from "./ui/RegisterShelter";

--- a/apps/hobom-angel/src/features/register-shelter/lib/register-shelter.lib.spec.ts
+++ b/apps/hobom-angel/src/features/register-shelter/lib/register-shelter.lib.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_FORM,
+  canSubmit,
+  isValidBusinessNumber,
+  isValidSlug,
+  toRegisterInput,
+} from "./register-shelter.lib";
+import type { RegisterShelterForm } from "./register-shelter.lib";
+
+const valid: RegisterShelterForm = {
+  name: "행복 보호소",
+  slug: "haengbok-shelter",
+  region: "서울",
+  city: "강남구",
+  roadAddress: "테헤란로 1",
+  visibility: "PARTIAL",
+  registrationNumber: "",
+  businessNumber: "",
+};
+
+describe("isValidSlug", () => {
+  it("accepts lowercase, digits, and hyphen-separated segments (3–40)", () => {
+    expect(isValidSlug("haengbok-shelter")).toBe(true);
+    expect(isValidSlug("abc")).toBe(true);
+    expect(isValidSlug("a1-b2-c3")).toBe(true);
+  });
+
+  it("rejects uppercase, spaces, edge hyphens, and too-short slugs", () => {
+    expect(isValidSlug("ab")).toBe(false);
+    expect(isValidSlug("Haengbok")).toBe(false);
+    expect(isValidSlug("has space")).toBe(false);
+    expect(isValidSlug("-lead")).toBe(false);
+    expect(isValidSlug("trail-")).toBe(false);
+    expect(isValidSlug("a".repeat(41))).toBe(false);
+  });
+});
+
+describe("isValidBusinessNumber", () => {
+  it("requires exactly 10 digits", () => {
+    expect(isValidBusinessNumber("1234567890")).toBe(true);
+    expect(isValidBusinessNumber("123-45-6789")).toBe(false);
+    expect(isValidBusinessNumber("123")).toBe(false);
+  });
+});
+
+describe("canSubmit", () => {
+  it("passes a complete valid form", () => {
+    expect(canSubmit(valid)).toBe(true);
+  });
+
+  it("fails on the empty form", () => {
+    expect(canSubmit(EMPTY_FORM)).toBe(false);
+  });
+
+  it("fails an invalid slug or missing required address parts", () => {
+    expect(canSubmit({ ...valid, slug: "Bad Slug" })).toBe(false);
+    expect(canSubmit({ ...valid, region: "" })).toBe(false);
+    expect(canSubmit({ ...valid, roadAddress: "  " })).toBe(false);
+  });
+
+  it("allows an empty business number but rejects a malformed one", () => {
+    expect(canSubmit({ ...valid, businessNumber: "" })).toBe(true);
+    expect(canSubmit({ ...valid, businessNumber: "12345" })).toBe(false);
+  });
+});
+
+describe("toRegisterInput", () => {
+  it("trims fields and omits blank optionals", () => {
+    const input = toRegisterInput({
+      ...valid,
+      name: "  행복 보호소  ",
+      registrationNumber: "  ",
+      businessNumber: "1234567890",
+    });
+
+    expect(input.name).toBe("행복 보호소");
+    expect(input.address).toEqual({
+      region: "서울",
+      city: "강남구",
+      roadAddress: "테헤란로 1",
+      visibility: "PARTIAL",
+    });
+    expect(input.registrationNumber).toBeUndefined();
+    expect(input.businessNumber).toBe("1234567890");
+  });
+});

--- a/apps/hobom-angel/src/features/register-shelter/lib/register-shelter.lib.ts
+++ b/apps/hobom-angel/src/features/register-shelter/lib/register-shelter.lib.ts
@@ -1,0 +1,58 @@
+import type { AddressVisibility } from "@/entities/shelter";
+
+/** The registration form's editable state (before it becomes the API input). */
+export interface RegisterShelterForm {
+  name: string;
+  slug: string;
+  region: string;
+  city: string;
+  roadAddress: string;
+  visibility: AddressVisibility;
+  registrationNumber: string;
+  businessNumber: string;
+}
+
+export const EMPTY_FORM: RegisterShelterForm = {
+  name: "",
+  slug: "",
+  region: "",
+  city: "",
+  roadAddress: "",
+  visibility: "PARTIAL",
+  registrationNumber: "",
+  businessNumber: "",
+};
+
+/** Backend contract: 3–40 chars, lowercase letters/digits, hyphen-separated. */
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SLUG_MIN = 3;
+const SLUG_MAX = 40;
+
+/** A stable public identifier check, mirrored server-side. */
+export const isValidSlug = (slug: string): boolean =>
+  slug.length >= SLUG_MIN && slug.length <= SLUG_MAX && SLUG_PATTERN.test(slug);
+
+/** The 10-digit 사업자/고유번호, when provided (optional field). */
+export const isValidBusinessNumber = (value: string): boolean => /^\d{10}$/.test(value);
+
+/** Whether the form can be submitted — all required fields valid. */
+export const canSubmit = (form: RegisterShelterForm): boolean =>
+  form.name.trim().length > 0 &&
+  isValidSlug(form.slug) &&
+  form.region.trim().length > 0 &&
+  form.roadAddress.trim().length > 0 &&
+  (form.businessNumber === "" || isValidBusinessNumber(form.businessNumber));
+
+/** Project the trimmed form into the `POST /shelters` request body. */
+export const toRegisterInput = (form: RegisterShelterForm) => ({
+  name: form.name.trim(),
+  slug: form.slug.trim(),
+  address: {
+    region: form.region.trim(),
+    city: form.city.trim(),
+    roadAddress: form.roadAddress.trim(),
+    visibility: form.visibility,
+  },
+  registrationNumber: form.registrationNumber.trim() || undefined,
+  businessNumber: form.businessNumber.trim() || undefined,
+});

--- a/apps/hobom-angel/src/features/register-shelter/model/useRegisterShelter.ts
+++ b/apps/hobom-angel/src/features/register-shelter/model/useRegisterShelter.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { useMutation } from "hobom-data";
+import { shelterMutations } from "@/entities/shelter";
+import { ROUTES } from "@/shared/config";
+import { useToast } from "@/shared/model";
+import { EMPTY_FORM, canSubmit, toRegisterInput } from "../lib/register-shelter.lib";
+import type { RegisterShelterForm } from "../lib/register-shelter.lib";
+
+/** Drives the shelter-registration form: local field state, validation, and the
+ *  submit that opens the verification and returns the applicant to their page. */
+export const useRegisterShelter = () => {
+  const navigate = useNavigate();
+  const { openSuccessToast, openErrorToast } = useToast();
+  const [form, setForm] = useState<RegisterShelterForm>(EMPTY_FORM);
+
+  const { mutate, isPending } = useMutation({
+    ...shelterMutations.register(),
+    onSuccess: () => {
+      openSuccessToast({ message: "등록 신청이 접수됐어요. 검증 결과를 기다려주세요." });
+      void navigate(ROUTES.MY, { replace: true });
+    },
+    onError: (error: Error) => openErrorToast({ message: error.message || "등록에 실패했어요." }),
+  });
+
+  const setField = <K extends keyof RegisterShelterForm>(key: K, value: RegisterShelterForm[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const submit = () => {
+    if (!canSubmit(form)) return;
+
+    mutate(toRegisterInput(form));
+  };
+
+  return { form, setField, submit, submitting: isPending, canSubmit: canSubmit(form) };
+};

--- a/apps/hobom-angel/src/features/register-shelter/ui/RegisterShelter.styles.ts
+++ b/apps/hobom-angel/src/features/register-shelter/ui/RegisterShelter.styles.ts
@@ -1,0 +1,110 @@
+import * as stylex from "@stylexjs/stylex";
+
+const TABLET = "@media (min-width: 640px)";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 560,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 24,
+    paddingBottom: 64,
+    display: "flex",
+    flexDirection: "column",
+    gap: 28,
+  },
+
+  // Header + "이렇게 진행돼요" timeline
+  header: { display: "flex", flexDirection: "column", gap: 10 },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 800,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: {
+    margin: 0,
+    fontSize: "0.9375rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-secondary)",
+  },
+  steps: {
+    display: "flex",
+    gap: 8,
+    padding: 14,
+    borderRadius: 14,
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  step: {
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+    textAlign: "center",
+  },
+  stepNum: {
+    alignSelf: "center",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 24,
+    height: 24,
+    borderRadius: "50%",
+    backgroundColor: "var(--hb-angel-green-tint)",
+    color: "var(--hb-color-accent-dark)",
+    fontSize: "0.75rem",
+    fontWeight: 800,
+  },
+  stepLabel: {
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-primary)",
+  },
+  stepDesc: { fontSize: "0.6875rem", color: "var(--hb-color-text-secondary)" },
+
+  // Light sections — no heavy card, just a heading and breathing room
+  section: { display: "flex", flexDirection: "column", gap: 16 },
+  sectionHead: { display: "flex", flexDirection: "column", gap: 2 },
+  sectionTitle: {
+    margin: 0,
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  sectionNote: { margin: 0, fontSize: "0.8125rem", color: "var(--hb-color-text-secondary)" },
+  divider: {
+    height: 1,
+    border: "none",
+    margin: 0,
+    backgroundColor: "var(--hb-color-border)",
+  },
+  row: {
+    display: "grid",
+    gridTemplateColumns: { default: "1fr", [TABLET]: "1fr 1fr" },
+    gap: 14,
+  },
+
+  // Slug field with a URL prefix + live preview
+  slugPreview: {
+    marginTop: 8,
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  slugValue: { color: "var(--hb-color-accent-dark)", fontWeight: 600 },
+
+  // Address visibility segmented choice
+  fieldLabel: {
+    display: "block",
+    marginBottom: 8,
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+  },
+  hint: {
+    margin: "8px 0 0",
+    fontSize: "0.8125rem",
+    lineHeight: 1.5,
+    color: "var(--hb-color-text-secondary)",
+  },
+});

--- a/apps/hobom-angel/src/features/register-shelter/ui/RegisterShelter.tsx
+++ b/apps/hobom-angel/src/features/register-shelter/ui/RegisterShelter.tsx
@@ -1,0 +1,153 @@
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { ADDRESS_VISIBILITY_HINT, ADDRESS_VISIBILITY_LABEL } from "@/entities/shelter";
+import type { AddressVisibility } from "@/entities/shelter";
+import { useRegisterShelter } from "../model/useRegisterShelter";
+import { isValidSlug } from "../lib/register-shelter.lib";
+import { styles } from "./RegisterShelter.styles";
+
+const VISIBILITIES: AddressVisibility[] = ["FULL", "PARTIAL", "HIDDEN"];
+
+const FLOW = [
+  { n: "1", label: "신청", desc: "정보 입력" },
+  { n: "2", label: "검증", desc: "운영자 확인" },
+  { n: "3", label: "승인", desc: "대표 권한" },
+];
+
+/** 보호소 등록 신청 — a light, guided form that opens a verification the operator
+ *  reviews. The registrant becomes the shelter's 대표 on approval. */
+export const RegisterShelter = () => {
+  const { form, setField, submit, submitting, canSubmit } = useRegisterShelter();
+  const slugInvalid = form.slug.length > 0 && !isValidSlug(form.slug);
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <h1 {...stylex.props(styles.title)}>보호소 등록 신청</h1>
+        <p {...stylex.props(styles.subtitle)}>
+          신청하면 운영자의 검증을 거쳐 승인돼요. 승인되면 신청자가 이 보호소 대표가 돼요.
+        </p>
+        <div {...stylex.props(styles.steps)}>
+          {FLOW.map((step) => (
+            <div key={step.n} {...stylex.props(styles.step)}>
+              <span {...stylex.props(styles.stepNum)}>{step.n}</span>
+              <span {...stylex.props(styles.stepLabel)}>{step.label}</span>
+              <span {...stylex.props(styles.stepDesc)}>{step.desc}</span>
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.sectionHead)}>
+          <h2 {...stylex.props(styles.sectionTitle)}>기본 정보</h2>
+        </div>
+        <Hb.TextField
+          label="보호소 이름"
+          placeholder="예: 행복 유기동물 보호소"
+          value={form.name}
+          onChange={(event) => setField("name", event.target.value)}
+          fullWidth
+        />
+        <div>
+          <Hb.TextField
+            label="보호소 프로필 주소"
+            placeholder="haengbok-shelter"
+            value={form.slug}
+            onChange={(event) => setField("slug", event.target.value)}
+            error={slugInvalid}
+            helperText={slugInvalid ? "소문자·숫자·하이픈만, 3~40자로 입력하세요." : undefined}
+            fullWidth
+          />
+          <p {...stylex.props(styles.slugPreview)}>
+            angel.hobom/shelters/
+            <span {...stylex.props(styles.slugValue)}>{form.slug || "haengbok-shelter"}</span>
+          </p>
+        </div>
+      </section>
+
+      <hr {...stylex.props(styles.divider)} />
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.sectionHead)}>
+          <h2 {...stylex.props(styles.sectionTitle)}>주소</h2>
+        </div>
+        <div {...stylex.props(styles.row)}>
+          <Hb.TextField
+            label="시·도"
+            placeholder="서울"
+            value={form.region}
+            onChange={(event) => setField("region", event.target.value)}
+            fullWidth
+          />
+          <Hb.TextField
+            label="시·군·구"
+            placeholder="강남구"
+            value={form.city}
+            onChange={(event) => setField("city", event.target.value)}
+            fullWidth
+          />
+        </div>
+        <Hb.TextField
+          label="도로명 주소"
+          placeholder="테헤란로 1"
+          value={form.roadAddress}
+          onChange={(event) => setField("roadAddress", event.target.value)}
+          fullWidth
+        />
+        <div>
+          <span {...stylex.props(styles.fieldLabel)}>주소 공개 범위</span>
+          <Hb.ToggleButtonGroup variant="segmented" aria-label="주소 공개 범위">
+            {VISIBILITIES.map((visibility) => (
+              <Hb.ToggleButton
+                key={visibility}
+                variant="segmented"
+                value={visibility}
+                selected={form.visibility === visibility}
+                onChange={() => setField("visibility", visibility)}
+              >
+                {ADDRESS_VISIBILITY_LABEL[visibility]}
+              </Hb.ToggleButton>
+            ))}
+          </Hb.ToggleButtonGroup>
+          <p {...stylex.props(styles.hint)}>{ADDRESS_VISIBILITY_HINT[form.visibility]}</p>
+        </div>
+      </section>
+
+      <hr {...stylex.props(styles.divider)} />
+
+      <section {...stylex.props(styles.section)}>
+        <div {...stylex.props(styles.sectionHead)}>
+          <h2 {...stylex.props(styles.sectionTitle)}>인증 정보</h2>
+          <p {...stylex.props(styles.sectionNote)}>
+            선택이지만, 입력하면 검증이 더 빠르게 진행돼요.
+          </p>
+        </div>
+        <Hb.TextField
+          label="동물보호센터 등록번호"
+          placeholder="예: 서울-2026-0001"
+          value={form.registrationNumber}
+          onChange={(event) => setField("registrationNumber", event.target.value)}
+          fullWidth
+        />
+        <Hb.TextField
+          label="사업자·고유번호 (숫자 10자리)"
+          placeholder="1234567890"
+          value={form.businessNumber}
+          onChange={(event) => setField("businessNumber", event.target.value.replace(/\D/g, ""))}
+          fullWidth
+        />
+      </section>
+
+      <Hb.Button
+        variant="primary"
+        fullWidth
+        onClick={submit}
+        disabled={!canSubmit}
+        loading={submitting}
+      >
+        등록 신청하기
+      </Hb.Button>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/shelter.handlers.ts
@@ -231,6 +231,19 @@ export const shelterHandlers = [
     return ok({ items: page, nextCursor: hasNext ? String(nextIndex) : null, hasNext });
   }),
 
+  http.post(mockUrl("/shelters"), async ({ request }) => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    const body = (await request.json()) as { slug: string };
+
+    // Slug is the public identifier — reject a collision with an existing one.
+    if (body.slug === SHELTER.slug || DIRECTORY.some((item) => item.slug === body.slug)) {
+      return HttpResponse.json({ message: "이미 사용 중인 주소예요." }, { status: 409 });
+    }
+
+    return ok({ shelterId: "shelter-new", approvalId: "approval-new" });
+  }),
+
   http.get(mockUrl("/shelters/:slug"), ({ params }) => {
     if (!mockSession.isActive()) return unauthorized();
 

--- a/apps/hobom-angel/src/pages/register-shelter/index.ts
+++ b/apps/hobom-angel/src/pages/register-shelter/index.ts
@@ -1,0 +1,1 @@
+export { RegisterShelterPage } from "./ui/RegisterShelterPage";

--- a/apps/hobom-angel/src/pages/register-shelter/ui/RegisterShelterPage.tsx
+++ b/apps/hobom-angel/src/pages/register-shelter/ui/RegisterShelterPage.tsx
@@ -1,0 +1,3 @@
+import { RegisterShelter } from "@/features/register-shelter";
+
+export const RegisterShelterPage = () => <RegisterShelter />;

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   VOLUNTEER: "/volunteer",
   VOLUNTEER_WRITE: "/volunteer/posts/new",
   SHELTERS: "/shelters",
+  SHELTER_REGISTER: "/shelters/register",
   SHELTER_DETAIL: "/shelters/:shelterSlug",
   FAVORITES: "/favorites",
   APPLICATIONS: "/applications",

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
@@ -33,7 +33,11 @@ const COLUMNS: { heading: string; links: FooterLink[] }[] = [
   },
   {
     heading: "보호소·기관",
-    links: [{ label: "보호소 등록 신청" }, { label: "관리 콘솔" }, { label: "운영 정책" }],
+    links: [
+      { label: "보호소 등록 신청", to: ROUTES.SHELTER_REGISTER },
+      { label: "관리 콘솔", to: ROUTES.CONSOLE },
+      { label: "운영 정책" },
+    ],
   },
 ];
 


### PR DESCRIPTION
## What
The footer's **보호소 등록 신청** and **관리 콘솔** links went nowhere. This builds the registration flow at `/shelters/register`:

- **기본 정보** — name + a profile slug with a **live URL preview** (`angel.hobom/shelters/[slug]`) and inline validation.
- **주소** — region / city / road address + a 3-level disclosure choice (전체/부분/비공개) with a hint for each.
- **인증 정보 (선택)** — 동물보호센터 등록번호 / 사업자·고유번호 (10 digits).

Submitting posts to `POST /shelters`, which opens a **SHELTER_VERIFICATION** approval — the same one the operator approval queue (#242/#248) reviews. On approval the registrant becomes the shelter's 대표. This closes the register → verify → approve loop end to end.

## UX
Reworked after review feedback (density / slug confusion / missing context):
- A **신청 → 검증 → 승인** timeline in the header sets expectations up front.
- **Light sections** (spacing + thin dividers) instead of heavy stacked cards, so the form scans easily.
- The slug field is labeled **보호소 프로필 주소** with the live URL preview, so it no longer reads like a second address.

## Structure
- `entities/shelter` — `registerShelter` + `shelterMutations.register`, `RegisterShelterInput/Result`, and `ADDRESS_VISIBILITY_LABEL/HINT`.
- `features/register-shelter` — `useRegisterShelter` hook + a pure, unit-tested validation lib (slug pattern 3–40, 10-digit business number).
- MSW `POST /shelters` (409 on a taken slug); footer links wired.

## Verify
typecheck, lint, unit (168, incl. the validation lib), the full e2e suite, and the build pass. e2e covers the happy path (fill → submit → toast → /my) and slug validation.

Note: facility-photo upload is intentionally out of scope for v1 (photos are optional in the contract; a reusable multi-image upload would be a separate change).