### PR TITLE
Add the volunteer activity certificate screen

### DIFF
--- a/apps/hobom-angel/e2e/volunteer-certificate.spec.ts
+++ b/apps/hobom-angel/e2e/volunteer-certificate.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§05 봉사 확인서", () => {
+  test("reachable from 마이페이지, lists certificates and issues a new one", async ({ page }) => {
+    await login(page);
+
+    // Reachable from the 내 활동 section.
+    await page.goto("my");
+    await page.getByRole("link", { name: "봉사 확인서" }).click();
+    await expect(page).toHaveURL(/\/volunteer\/certificates$/);
+
+    // The seeded certificate shows its number, totals, and participations.
+    await expect(page.getByRole("heading", { name: "봉사 확인서" })).toBeVisible();
+    await expect(page.getByText("HB-2026-000418")).toBeVisible();
+    await expect(page.getByText("주말 산책 봉사")).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/volunteer-certificate.png", fullPage: true });
+
+    // Issue a new one — it appears at the top with a success toast.
+    await page.getByRole("button", { name: "확인서 발급" }).click();
+    await expect(page.getByText("확인서를 발급했어요.")).toBeVisible();
+    await expect(page.getByText("급식소 청소 봉사")).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -55,6 +55,11 @@ const FavoritesPage = lazy(() =>
 const WriteReviewPage = lazy(() =>
   import("@/pages/volunteer-write").then((module) => ({ default: module.WriteReviewPage })),
 );
+const VolunteerCertificatesPage = lazy(() =>
+  import("@/pages/volunteer-certificates").then((module) => ({
+    default: module.VolunteerCertificatesPage,
+  })),
+);
 const MyPage = lazy(() => import("@/pages/my").then((module) => ({ default: module.MyPage })));
 const ApplicationsPage = lazy(() =>
   import("@/pages/applications").then((module) => ({ default: module.ApplicationsPage })),
@@ -127,6 +132,7 @@ export const AppRouter = () => {
             <Route path={ROUTES.SHELTER_DETAIL} element={<ShelterDetailPage />} />
             <Route path={ROUTES.VOLUNTEER} element={<VolunteerPage />} />
             <Route path={ROUTES.VOLUNTEER_WRITE} element={<WriteReviewPage />} />
+            <Route path={ROUTES.VOLUNTEER_CERTIFICATES} element={<VolunteerCertificatesPage />} />
             <Route path={ROUTES.FAVORITES} element={<FavoritesPage />} />
             <Route path={ROUTES.APPLICATIONS} element={<ApplicationsPage />} />
             <Route path={ROUTES.MY} element={<MyPage />} />

--- a/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.api.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.api.ts
@@ -1,0 +1,20 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { certificatesSchema, issuedCertificateSchema } from "./volunteer-certificate.schema";
+import type { VolunteerCertificate } from "../model/volunteer-certificate.model";
+
+const parseList = parseResponse(certificatesSchema, "GET /me/volunteer-certificates");
+const parseIssued = parseResponse(issuedCertificateSchema, "POST /me/volunteer-certificates");
+
+/** The signed-in volunteer's issued certificates (newest first). */
+export const getMyCertificates = (signal?: AbortSignal): Promise<VolunteerCertificate[]> =>
+  httpClient
+    .get("/me/volunteer-certificates", { signal })
+    .then(parseList)
+    .then((raw): VolunteerCertificate[] => raw);
+
+/** Issue a fresh certificate from the volunteer's completed participations. */
+export const issueCertificate = (): Promise<VolunteerCertificate> =>
+  httpClient
+    .post("/me/volunteer-certificates", {})
+    .then(parseIssued)
+    .then((raw): VolunteerCertificate => raw);

--- a/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.mutations.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.mutations.ts
@@ -1,0 +1,9 @@
+import { mutationOptions } from "hobom-data";
+import { issueCertificate } from "./volunteer-certificate.api";
+
+export const volunteerCertificateMutations = {
+  issue: () =>
+    mutationOptions({
+      mutationFn: () => issueCertificate(),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.queries.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.queries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from "hobom-data";
+import { getMyCertificates } from "./volunteer-certificate.api";
+
+export const volunteerCertificateQueries = {
+  all: () => ["volunteer-certificates"] as const,
+
+  mine: () =>
+    queryOptions({
+      queryKey: [...volunteerCertificateQueries.all(), "mine"] as const,
+      queryFn: ({ signal }) => getMyCertificates(signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.schema.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.schema.ts
@@ -1,0 +1,28 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { RawVolunteerCertificate } from "./volunteer-certificate.type";
+
+const certificateSchema = HoBomSchema.object({
+  certificateNo: HoBomSchema.string(),
+  volunteerNickname: HoBomSchema.string(),
+  issuedAt: HoBomSchema.string(),
+  totalCount: HoBomSchema.number(),
+  totalMinutes: HoBomSchema.number(),
+  totalHours: HoBomSchema.number(),
+  items: HoBomSchema.array(
+    HoBomSchema.object({
+      eventTitle: HoBomSchema.string(),
+      shelterName: HoBomSchema.string(),
+      startAt: HoBomSchema.string(),
+      endAt: HoBomSchema.string(),
+      minutes: HoBomSchema.number(),
+    }),
+  ),
+});
+
+/** `GET /me/volunteer-certificates` — a bare array of certificates. */
+export const certificatesSchema: Schema<RawVolunteerCertificate[]> =
+  HoBomSchema.array(certificateSchema);
+
+/** `POST /me/volunteer-certificates` — the newly issued certificate. */
+export const issuedCertificateSchema: Schema<RawVolunteerCertificate> = certificateSchema;

--- a/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.type.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/api/volunteer-certificate.type.ts
@@ -1,0 +1,17 @@
+export interface RawCertificateItem {
+  eventTitle: string;
+  shelterName: string;
+  startAt: string;
+  endAt: string;
+  minutes: number;
+}
+
+export interface RawVolunteerCertificate {
+  certificateNo: string;
+  volunteerNickname: string;
+  issuedAt: string;
+  totalCount: number;
+  totalMinutes: number;
+  totalHours: number;
+  items: RawCertificateItem[];
+}

--- a/apps/hobom-angel/src/entities/volunteer-certificate/index.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/index.ts
@@ -1,0 +1,6 @@
+export { volunteerCertificateQueries } from "./api/volunteer-certificate.queries";
+export { volunteerCertificateMutations } from "./api/volunteer-certificate.mutations";
+export type {
+  VolunteerCertificate,
+  CertificateItem,
+} from "./model/volunteer-certificate.model";

--- a/apps/hobom-angel/src/entities/volunteer-certificate/model/volunteer-certificate.model.ts
+++ b/apps/hobom-angel/src/entities/volunteer-certificate/model/volunteer-certificate.model.ts
@@ -1,0 +1,20 @@
+/** One participation line on a certificate. */
+export interface CertificateItem {
+  eventTitle: string;
+  shelterName: string;
+  startAt: string;
+  endAt: string;
+  minutes: number;
+}
+
+/** A volunteer's activity certificate (봉사활동 확인서), issued from completed
+ *  participations. `certificateNo` is the public verification handle. */
+export interface VolunteerCertificate {
+  certificateNo: string;
+  volunteerNickname: string;
+  issuedAt: string;
+  totalCount: number;
+  totalMinutes: number;
+  totalHours: number;
+  items: CertificateItem[];
+}

--- a/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
+++ b/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
@@ -86,6 +86,9 @@ export const MyProfile = ({ onLogout }: MyProfileProps) => {
           <Link to={ROUTES.FAVORITES} {...stylex.props(styles.actionRow)}>
             찜한 동물·팔로우
           </Link>
+          <Link to={ROUTES.VOLUNTEER_CERTIFICATES} {...stylex.props(styles.actionRow)}>
+            봉사 확인서
+          </Link>
           {isOperator(user) && (
             <Link to={ROUTES.OPERATOR_APPROVALS} {...stylex.props(styles.actionRow)}>
               승인 큐 (운영자)

--- a/apps/hobom-angel/src/features/volunteer-certificate/index.ts
+++ b/apps/hobom-angel/src/features/volunteer-certificate/index.ts
@@ -1,0 +1,1 @@
+export { VolunteerCertificates } from "./ui/VolunteerCertificates";

--- a/apps/hobom-angel/src/features/volunteer-certificate/lib/certificate-format.lib.spec.ts
+++ b/apps/hobom-angel/src/features/volunteer-certificate/lib/certificate-format.lib.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatCertDate, formatDay, formatMinutes } from "./certificate-format.lib";
+
+describe("formatMinutes", () => {
+  it("formats hours and minutes, dropping a zero part", () => {
+    expect(formatMinutes(150)).toBe("2시간 30분");
+    expect(formatMinutes(45)).toBe("45분");
+    expect(formatMinutes(180)).toBe("3시간");
+    expect(formatMinutes(0)).toBe("0분");
+  });
+});
+
+describe("formatCertDate", () => {
+  it("renders a full Korean date", () => {
+    expect(formatCertDate("2026-08-16T00:00:00Z")).toContain("2026년");
+    expect(formatCertDate("2026-08-16T00:00:00Z")).toContain("8월");
+  });
+});
+
+describe("formatDay", () => {
+  it("renders month and day only", () => {
+    const day = formatDay("2026-08-16T00:00:00Z");
+
+    expect(day).toContain("8월");
+    expect(day).not.toContain("2026");
+  });
+});

--- a/apps/hobom-angel/src/features/volunteer-certificate/lib/certificate-format.lib.ts
+++ b/apps/hobom-angel/src/features/volunteer-certificate/lib/certificate-format.lib.ts
@@ -1,0 +1,18 @@
+/** Minutes → "2시간 30분" / "45분" / "3시간". */
+export const formatMinutes = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+
+  if (hours === 0) return `${rest}분`;
+  if (rest === 0) return `${hours}시간`;
+
+  return `${hours}시간 ${rest}분`;
+};
+
+/** ISO date → "2026년 8월 16일". */
+export const formatCertDate = (iso: string): string =>
+  new Date(iso).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" });
+
+/** ISO date → "8월 16일" (participation day, year omitted). */
+export const formatDay = (iso: string): string =>
+  new Date(iso).toLocaleDateString("ko-KR", { month: "long", day: "numeric" });

--- a/apps/hobom-angel/src/features/volunteer-certificate/model/useVolunteerCertificates.ts
+++ b/apps/hobom-angel/src/features/volunteer-certificate/model/useVolunteerCertificates.ts
@@ -1,0 +1,33 @@
+import { useDataLot, useMutation, useSuspenseQuery } from "hobom-data";
+import {
+  volunteerCertificateMutations,
+  volunteerCertificateQueries,
+} from "@/entities/volunteer-certificate";
+import { useToast } from "@/shared/model";
+
+/** The volunteer's certificates plus the issue action, which reflects the new
+ *  one into the list. Issuing requires completed participations (server-checked;
+ *  a 4xx surfaces as a toast). */
+export const useVolunteerCertificates = () => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const options = volunteerCertificateQueries.mine();
+  const { data: certificates } = useSuspenseQuery(options);
+
+  const issue = useMutation({
+    ...volunteerCertificateMutations.issue(),
+    onSuccess: () => {
+      openSuccessToast({ message: "확인서를 발급했어요." });
+      void dataLot.invalidateQueries(options);
+    },
+    onError: (error: Error) =>
+      openErrorToast({ message: error.message || "발급할 수 있는 완료된 봉사가 없어요." }),
+  });
+
+  return {
+    certificates,
+    issue: () => issue.mutate(),
+    issuing: issue.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/volunteer-certificate/ui/CertificateCard.tsx
+++ b/apps/hobom-angel/src/features/volunteer-certificate/ui/CertificateCard.tsx
@@ -1,0 +1,39 @@
+import * as stylex from "@stylexjs/stylex";
+import type { VolunteerCertificate } from "@/entities/volunteer-certificate";
+import { formatCertDate, formatDay, formatMinutes } from "../lib/certificate-format.lib";
+import { styles } from "./VolunteerCertificates.styles";
+
+/** One issued certificate: its number, totals, and the participation lines. */
+export const CertificateCard = ({ certificate }: { certificate: VolunteerCertificate }) => (
+  <article {...stylex.props(styles.card)}>
+    <div {...stylex.props(styles.cardHead)}>
+      <span {...stylex.props(styles.certNo)}>{certificate.certificateNo}</span>
+      <span {...stylex.props(styles.spacer)} />
+      <span {...stylex.props(styles.issuedAt)}>{formatCertDate(certificate.issuedAt)} 발급</span>
+    </div>
+
+    <div {...stylex.props(styles.totals)}>
+      <div {...stylex.props(styles.total)}>
+        <span {...stylex.props(styles.totalValue)}>{certificate.totalCount}회</span>
+        <span {...stylex.props(styles.totalLabel)}>총 봉사</span>
+      </div>
+      <div {...stylex.props(styles.total)}>
+        <span {...stylex.props(styles.totalValue)}>{certificate.totalHours}시간</span>
+        <span {...stylex.props(styles.totalLabel)}>누적 시간</span>
+      </div>
+    </div>
+
+    <div {...stylex.props(styles.items)}>
+      {certificate.items.map((item, index) => (
+        <div key={`${item.eventTitle}-${index}`} {...stylex.props(styles.item)}>
+          <span {...stylex.props(styles.itemTitle)}>{item.eventTitle}</span>
+          <span {...stylex.props(styles.itemMeta)}>{item.shelterName}</span>
+          <span {...stylex.props(styles.itemSpacer)} />
+          <span {...stylex.props(styles.itemMeta)}>
+            {formatDay(item.startAt)} · {formatMinutes(item.minutes)}
+          </span>
+        </div>
+      ))}
+    </div>
+  </article>
+);

--- a/apps/hobom-angel/src/features/volunteer-certificate/ui/VolunteerCertificates.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer-certificate/ui/VolunteerCertificates.styles.ts
@@ -1,0 +1,88 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 720,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 16,
+    paddingBottom: 48,
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+  },
+  header: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  headings: { display: "flex", flexDirection: "column", gap: 6, flex: 1 },
+  title: {
+    margin: 0,
+    fontSize: "1.5rem",
+    fontWeight: 800,
+    letterSpacing: "-0.02em",
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: { margin: 0, fontSize: "0.9375rem", color: "var(--hb-color-text-secondary)" },
+  list: { display: "flex", flexDirection: "column", gap: 14 },
+
+  // Certificate card
+  card: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 14,
+    padding: 20,
+    borderRadius: "var(--hb-angel-radius-card)",
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+  },
+  cardHead: {
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    flexWrap: "wrap",
+  },
+  certNo: {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-accent-dark)",
+    backgroundColor: "var(--hb-angel-green-tint)",
+    paddingBlock: 4,
+    paddingInline: 10,
+    borderRadius: 8,
+  },
+  issuedAt: { fontSize: "0.8125rem", color: "var(--hb-color-text-secondary)" },
+  spacer: { flex: 1 },
+  totals: {
+    display: "flex",
+    gap: 20,
+    padding: 14,
+    borderRadius: 12,
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  total: { display: "flex", flexDirection: "column", gap: 2 },
+  totalValue: {
+    fontSize: "1.25rem",
+    fontWeight: 800,
+    color: "var(--hb-color-text-primary)",
+  },
+  totalLabel: { fontSize: "0.75rem", color: "var(--hb-color-text-secondary)" },
+  items: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+  },
+  item: {
+    display: "flex",
+    alignItems: "baseline",
+    gap: 8,
+    fontSize: "0.875rem",
+  },
+  itemTitle: { fontWeight: 600, color: "var(--hb-color-text-primary)" },
+  itemMeta: { color: "var(--hb-color-text-secondary)" },
+  itemSpacer: { flex: 1 },
+});

--- a/apps/hobom-angel/src/features/volunteer-certificate/ui/VolunteerCertificates.tsx
+++ b/apps/hobom-angel/src/features/volunteer-certificate/ui/VolunteerCertificates.tsx
@@ -1,0 +1,37 @@
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState, Hb } from "hobom-design-system";
+import { useVolunteerCertificates } from "../model/useVolunteerCertificates";
+import { CertificateCard } from "./CertificateCard";
+import { styles } from "./VolunteerCertificates.styles";
+
+/** §05 내 봉사 확인서 — the volunteer's issued certificates, plus issuing a new
+ *  one from completed participations. */
+export const VolunteerCertificates = () => {
+  const { certificates, issue, issuing } = useVolunteerCertificates();
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <div {...stylex.props(styles.headings)}>
+          <h1 {...stylex.props(styles.title)}>봉사 확인서</h1>
+          <p {...stylex.props(styles.subtitle)}>
+            완료한 봉사 이력으로 확인서를 발급하고, 확인서 번호로 인증할 수 있어요.
+          </p>
+        </div>
+        <Hb.Button variant="primary" onClick={issue} loading={issuing}>
+          확인서 발급
+        </Hb.Button>
+      </header>
+
+      {certificates.length === 0 ? (
+        <EmptyState message="아직 발급한 확인서가 없어요. 완료한 봉사가 있으면 발급할 수 있어요." />
+      ) : (
+        <div {...stylex.props(styles.list)}>
+          {certificates.map((certificate) => (
+            <CertificateCard key={certificate.certificateNo} certificate={certificate} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -13,6 +13,7 @@ import { adoptionHandlers } from "./adoption.handlers";
 import { fosterHandlers } from "./foster.handlers";
 import { applicationHandlers } from "./application.handlers";
 import { approvalHandlers } from "./approval.handlers";
+import { volunteerCertificateHandlers } from "./volunteer-certificate.handlers";
 
 /** All MSW request handlers, aggregated per domain. Add new domains here. */
 export const handlers = [
@@ -31,4 +32,5 @@ export const handlers = [
   ...fosterHandlers,
   ...applicationHandlers,
   ...approvalHandlers,
+  ...volunteerCertificateHandlers,
 ];

--- a/apps/hobom-angel/src/mocks/handlers/volunteer-certificate.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/volunteer-certificate.handlers.ts
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { mockSession } from "./mock-session";
+import { ok } from "./ok";
+
+interface CertificateRow {
+  certificateNo: string;
+  volunteerNickname: string;
+  issuedAt: string;
+  totalCount: number;
+  totalMinutes: number;
+  totalHours: number;
+  items: {
+    eventTitle: string;
+    shelterName: string;
+    startAt: string;
+    endAt: string;
+    minutes: number;
+  }[];
+}
+
+// The signed-in volunteer's issued certificates. Mutable so issuing appends one.
+const CERTIFICATES: CertificateRow[] = [
+  {
+    certificateNo: "HB-2026-000418",
+    volunteerNickname: "봄이네",
+    issuedAt: "2026-07-30T02:00:00.000Z",
+    totalCount: 3,
+    totalMinutes: 450,
+    totalHours: 7.5,
+    items: [
+      {
+        eventTitle: "주말 산책 봉사",
+        shelterName: "행복보호소",
+        startAt: "2026-07-12T00:00:00.000Z",
+        endAt: "2026-07-12T03:00:00.000Z",
+        minutes: 180,
+      },
+      {
+        eventTitle: "목욕·미용 봉사",
+        shelterName: "행복보호소",
+        startAt: "2026-07-19T00:00:00.000Z",
+        endAt: "2026-07-19T02:30:00.000Z",
+        minutes: 150,
+      },
+      {
+        eventTitle: "입양 홍보 부스",
+        shelterName: "인천반려동물보호소",
+        startAt: "2026-07-26T00:00:00.000Z",
+        endAt: "2026-07-26T02:00:00.000Z",
+        minutes: 120,
+      },
+    ],
+  },
+];
+
+const unauthorized = () => HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+
+let issued = 0;
+
+/** §05 내 봉사 확인서 — list and issue (from completed participations). */
+export const volunteerCertificateHandlers = [
+  http.get(mockUrl("/me/volunteer-certificates"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    return ok(CERTIFICATES);
+  }),
+
+  http.post(mockUrl("/me/volunteer-certificates"), () => {
+    if (!mockSession.isActive()) return unauthorized();
+
+    issued += 1;
+    const fresh: CertificateRow = {
+      certificateNo: `HB-2026-00050${issued}`,
+      volunteerNickname: "봄이네",
+      issuedAt: "2026-08-16T05:00:00.000Z",
+      totalCount: 1,
+      totalMinutes: 120,
+      totalHours: 2,
+      items: [
+        {
+          eventTitle: "급식소 청소 봉사",
+          shelterName: "부산해운대보호소",
+          startAt: "2026-08-09T00:00:00.000Z",
+          endAt: "2026-08-09T02:00:00.000Z",
+          minutes: 120,
+        },
+      ],
+    };
+
+    CERTIFICATES.unshift(fresh);
+
+    return ok(fresh);
+  }),
+];

--- a/apps/hobom-angel/src/pages/volunteer-certificates/index.ts
+++ b/apps/hobom-angel/src/pages/volunteer-certificates/index.ts
@@ -1,0 +1,1 @@
+export { VolunteerCertificatesPage } from "./ui/VolunteerCertificatesPage";

--- a/apps/hobom-angel/src/pages/volunteer-certificates/ui/VolunteerCertificatesPage.tsx
+++ b/apps/hobom-angel/src/pages/volunteer-certificates/ui/VolunteerCertificatesPage.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from "react";
+import { VolunteerCertificates } from "@/features/volunteer-certificate";
+import { LoadingState } from "@/shared/ui";
+
+export const VolunteerCertificatesPage = () => (
+  <Suspense fallback={<LoadingState />}>
+    <VolunteerCertificates />
+  </Suspense>
+);

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   FOSTER_APPLY: "/foster/apply/:animalId",
   VOLUNTEER: "/volunteer",
   VOLUNTEER_WRITE: "/volunteer/posts/new",
+  VOLUNTEER_CERTIFICATES: "/volunteer/certificates",
   SHELTERS: "/shelters",
   SHELTER_REGISTER: "/shelters/register",
   SHELTER_DETAIL: "/shelters/:shelterSlug",


### PR DESCRIPTION
## What
Completes the volunteer flow (feed · events · certificates) with **봉사 확인서** at `/volunteer/certificates`, reachable from 마이페이지 → 내 활동:

- Lists the signed-in volunteer's issued certificates.
- **확인서 발급** issues a fresh one from completed participations (server-checked; a 4xx surfaces as a toast).
- Each card shows the verification number, the totals (총 봉사 횟수 · 누적 시간), and the participation lines (event · shelter · day · duration).

Backed by the existing endpoints (`GET/POST /me/volunteer-certificates`) — fully me-scoped, no backend work needed.

## Structure
- `entities/volunteer-certificate` — model, api (list + issue), queries, mutations, schema.
- `features/volunteer-certificate` — `useVolunteerCertificates` hook, `CertificateCard`, and a pure, unit-tested duration/date format lib.
- MSW `GET/POST /me/volunteer-certificates` (issue appends); MyProfile link wired.

## Verify
typecheck, lint, unit (171), the full e2e suite (61), and the build pass. e2e reaches the screen from 마이페이지, reads the seeded certificate, and issues a new one.

Note: the public verification page (`GET /volunteer-certificates/:no`, anonymous) is out of scope here — the number is shown so it can be verified, and the standalone verify page can follow.