### PR TITLE
Let the author edit or delete their own reviews

### DIFF
--- a/apps/hobom-angel/e2e/shelter-microsite.spec.ts
+++ b/apps/hobom-angel/e2e/shelter-microsite.spec.ts
@@ -80,4 +80,30 @@ test.describe("§04 shelter microsite", () => {
     await expect(page.getByRole("tab", { name: "FAQ" })).toHaveAttribute("aria-selected", "true");
     await expect(page.getByText("임시보호도 신청할 수 있나요?")).toBeVisible();
   });
+
+  test("edits and deletes the viewer's own review", async ({ page }) => {
+    await login(page);
+    await page.goto("shelters/haengbok-shelter?tab=reviews");
+
+    // Only the viewer's own review card carries 수정 / 삭제.
+    const card = page.locator("article").filter({ hasText: "저희 아이 입양하면서" });
+    await expect(card).toBeVisible();
+
+    // Edit — the dialog is prefilled; change the body and save.
+    await card.getByRole("button", { name: "수정" }).click();
+    await expect(page.getByRole("heading", { name: "후기 수정" })).toBeVisible();
+    await page
+      .getByRole("textbox", { name: "후기" })
+      .fill("수정한 후기예요. 아이가 정말 잘 지내고 있어요.");
+    await page.getByRole("button", { name: "저장" }).click();
+    await expect(page.getByText("후기를 수정했어요.")).toBeVisible();
+    await expect(page.getByText("수정한 후기예요.", { exact: false })).toBeVisible();
+
+    // Delete — confirm removes it from the list.
+    const edited = page.locator("article").filter({ hasText: "수정한 후기예요." });
+    await edited.getByRole("button", { name: "삭제" }).click();
+    await page.getByRole("button", { name: "삭제하기" }).click();
+    await expect(page.getByText("후기를 삭제했어요.")).toBeVisible();
+    await expect(page.getByText("수정한 후기예요.", { exact: false })).toHaveCount(0);
+  });
 });

--- a/apps/hobom-angel/src/entities/review/api/review.api.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.api.ts
@@ -3,7 +3,7 @@ import { toQueryString } from "@/shared/lib";
 import { createdReviewSchema, reputationSchema, reviewsPageSchema } from "./review.schema";
 import { toReputation, toReview } from "../lib/to-review.lib";
 import type { ReviewPage, ShelterReputation } from "../model/review.model";
-import type { SubmitReviewInput } from "./review.type";
+import type { ReviseReviewInput, SubmitReviewInput } from "./review.type";
 
 const parsePage = parseResponse(reviewsPageSchema, "GET /shelters/:id/reviews");
 const parseReputation = parseResponse(reputationSchema, "GET /shelters/:id/reviews/reputation");
@@ -40,3 +40,11 @@ export const submitReview = (shelterId: string, input: SubmitReviewInput): Promi
     .post(`/shelters/${shelterId}/reviews`, input)
     .then(parseCreated)
     .then((created) => created.reviewId);
+
+/** Edit one of the viewer's own reviews (작성자만). */
+export const reviseReview = (reviewId: string, input: ReviseReviewInput): Promise<void> =>
+  httpClient.patch(`/reviews/${reviewId}`, input).then(() => undefined);
+
+/** Delete a review (작성자 또는 운영자). */
+export const deleteReview = (reviewId: string): Promise<void> =>
+  httpClient.delete(`/reviews/${reviewId}`).then(() => undefined);

--- a/apps/hobom-angel/src/entities/review/api/review.mutations.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.mutations.ts
@@ -1,6 +1,6 @@
 import { mutationOptions } from "hobom-data";
-import { submitReview } from "./review.api";
-import type { SubmitReviewInput } from "./review.type";
+import { deleteReview, reviseReview, submitReview } from "./review.api";
+import type { ReviseReviewInput, SubmitReviewInput } from "./review.type";
 
 export const reviewMutations = {
   // shelterId changes with the application under review, so it rides in the
@@ -9,5 +9,16 @@ export const reviewMutations = {
     mutationOptions({
       mutationFn: (vars: { shelterId: string; input: SubmitReviewInput }) =>
         submitReview(vars.shelterId, vars.input),
+    }),
+
+  revise: () =>
+    mutationOptions({
+      mutationFn: (vars: { reviewId: string; input: ReviseReviewInput }) =>
+        reviseReview(vars.reviewId, vars.input),
+    }),
+
+  remove: () =>
+    mutationOptions({
+      mutationFn: (reviewId: string) => deleteReview(reviewId),
     }),
 } as const;

--- a/apps/hobom-angel/src/entities/review/api/review.type.ts
+++ b/apps/hobom-angel/src/entities/review/api/review.type.ts
@@ -35,3 +35,9 @@ export interface SubmitReviewInput {
 export interface RawCreatedReview {
   reviewId: string;
 }
+
+/** `PATCH /reviews/:reviewId` request — the author edits rating + body. */
+export interface ReviseReviewInput {
+  rating: number;
+  body: string;
+}

--- a/apps/hobom-angel/src/entities/review/index.ts
+++ b/apps/hobom-angel/src/entities/review/index.ts
@@ -8,4 +8,4 @@ export type {
   PlacementType,
   StarRating,
 } from "./model/review.model";
-export type { SubmitReviewInput } from "./api/review.type";
+export type { SubmitReviewInput, ReviseReviewInput } from "./api/review.type";

--- a/apps/hobom-angel/src/features/shelter-microsite/model/useReviewActions.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/model/useReviewActions.ts
@@ -1,0 +1,40 @@
+import { useDataLot, useMutation } from "hobom-data";
+import { reviewMutations, reviewQueries } from "@/entities/review";
+import { useToast } from "@/shared/model";
+import type { ReviseReviewInput } from "@/entities/review";
+
+/** Edit / delete the viewer's own reviews. A change invalidates the shelter's
+ *  review list and reputation so the summary and cards refresh. */
+export const useReviewActions = () => {
+  const dataLot = useDataLot();
+  const { openSuccessToast, openErrorToast } = useToast();
+
+  const refresh = () => void dataLot.invalidateQueries({ queryKey: reviewQueries.all() });
+  const onError = (error: Error) =>
+    openErrorToast({ message: error.message || "처리에 실패했어요." });
+
+  const revise = useMutation({
+    ...reviewMutations.revise(),
+    onSuccess: () => {
+      openSuccessToast({ message: "후기를 수정했어요." });
+      refresh();
+    },
+    onError,
+  });
+
+  const remove = useMutation({
+    ...reviewMutations.remove(),
+    onSuccess: () => {
+      openSuccessToast({ message: "후기를 삭제했어요." });
+      refresh();
+    },
+    onError,
+  });
+
+  return {
+    revise: (reviewId: string, input: ReviseReviewInput) => revise.mutate({ reviewId, input }),
+    revising: revise.isPending,
+    remove: (reviewId: string) => remove.mutate(reviewId),
+    removing: remove.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewEditDialog.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewEditDialog.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import type { Review, ReviseReviewInput } from "@/entities/review";
+import { styles } from "./ReviewsTab.styles";
+
+interface ReviewEditDialogProps {
+  review: Review;
+  submitting: boolean;
+  onConfirm: (input: ReviseReviewInput) => void;
+  onClose: () => void;
+}
+
+/** Edit one of the viewer's own reviews — rating + body, prefilled. */
+export const ReviewEditDialog = ({
+  review,
+  submitting,
+  onConfirm,
+  onClose,
+}: ReviewEditDialogProps) => {
+  const [rating, setRating] = useState(review.rating);
+  const [body, setBody] = useState(review.body);
+  const canSubmit = rating >= 1 && body.trim().length > 0;
+
+  const submit = () => {
+    if (!canSubmit) return;
+
+    onConfirm({ rating, body: body.trim() });
+    onClose();
+  };
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="xs">
+      <Hb.Dialog.Title>후기 수정</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <div {...stylex.props(styles.editStars)} role="radiogroup" aria-label="별점">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button
+              key={n}
+              type="button"
+              {...stylex.props(styles.editStar, n <= rating && styles.editStarOn)}
+              onClick={() => setRating(n)}
+              role="radio"
+              aria-label={`${n}점`}
+              aria-checked={rating === n}
+            >
+              ★
+            </button>
+          ))}
+        </div>
+        <Hb.TextField
+          label="후기"
+          placeholder="보호소와의 경험, 아이의 근황을 자유롭게 남겨주세요"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+        />
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          취소
+        </Hb.Button>
+        <Hb.Button variant="primary" onClick={submit} disabled={!canSubmit} loading={submitting}>
+          저장
+        </Hb.Button>
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.styles.ts
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.styles.ts
@@ -127,6 +127,38 @@ export const styles = stylex.create({
     color: "var(--hb-color-text-primary)",
     whiteSpace: "pre-line",
   },
+  // Owner actions (수정 / 삭제) on the viewer's own review.
+  ownerActions: {
+    display: "flex",
+    gap: 4,
+    marginTop: 10,
+  },
+  ownerButton: {
+    appearance: "none",
+    border: "none",
+    background: "none",
+    cursor: "pointer",
+    padding: "4px 8px",
+    borderRadius: "var(--hb-angel-radius-sm)",
+    fontSize: "0.8125rem",
+    fontWeight: 600,
+    color: "var(--hb-color-text-secondary)",
+    backgroundColor: { default: "transparent", ":hover": "var(--hb-angel-surface-alt)" },
+  },
+  ownerDanger: { color: "var(--hb-angel-urgent)" },
+  // Edit-dialog star input.
+  editStars: { display: "flex", gap: 4, marginBottom: 16 },
+  editStar: {
+    appearance: "none",
+    border: "none",
+    background: "none",
+    cursor: "pointer",
+    padding: 0,
+    fontSize: "1.75rem",
+    lineHeight: 1,
+    color: "var(--hb-color-border)",
+  },
+  editStarOn: { color: "var(--hb-angel-accent-warm)" },
   more: {
     display: "flex",
     justifyContent: "center",

--- a/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.tsx
+++ b/apps/hobom-angel/src/features/shelter-microsite/ui/tabs/ReviewsTab.tsx
@@ -1,10 +1,14 @@
 import { useSuspenseQuery } from "hobom-data";
 import * as stylex from "@stylexjs/stylex";
-import { EmptyState, Hb } from "hobom-design-system";
+import { ConfirmDialog, EmptyState, Hb } from "hobom-design-system";
 import { PLACEMENT_LABEL, reviewQueries } from "@/entities/review";
+import { useCurrentUser } from "@/entities/user";
+import { useOverlay } from "@/shared/model";
 import type { Review, ShelterReputation } from "@/entities/review";
 import { distributionBars, filledStars, formatAverage } from "../../lib/reputation.lib";
+import { useReviewActions } from "../../model/useReviewActions";
 import { useShelterReviews } from "../../model/useShelterReviews";
+import { ReviewEditDialog } from "./ReviewEditDialog";
 import { styles } from "./ReviewsTab.styles";
 
 const formatDate = (iso: string): string =>
@@ -45,7 +49,14 @@ const ReputationSummary = ({ reputation }: { reputation: ShelterReputation }) =>
   </div>
 );
 
-const ReviewCard = ({ review }: { review: Review }) => (
+interface ReviewCardProps {
+  review: Review;
+  mine: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const ReviewCard = ({ review, mine, onEdit, onDelete }: ReviewCardProps) => (
   <article {...stylex.props(styles.card)}>
     <div {...stylex.props(styles.cardHead)}>
       <Hb.Chip
@@ -59,13 +70,54 @@ const ReviewCard = ({ review }: { review: Review }) => (
       {review.createdAt && <span {...stylex.props(styles.date)}>{formatDate(review.createdAt)}</span>}
     </div>
     <p {...stylex.props(styles.body)}>{review.body}</p>
+    {mine && (
+      <div {...stylex.props(styles.ownerActions)}>
+        <button type="button" {...stylex.props(styles.ownerButton)} onClick={onEdit}>
+          수정
+        </button>
+        <button
+          type="button"
+          {...stylex.props(styles.ownerButton, styles.ownerDanger)}
+          onClick={onDelete}
+        >
+          삭제
+        </button>
+      </div>
+    )}
   </article>
 );
 
-/** 후기 tab — the shelter's reputation summary plus its paginated reviews. */
+/** 후기 tab — the shelter's reputation summary plus its paginated reviews. The
+ *  viewer can edit or delete their own reviews inline. */
 export const ReviewsTab = ({ shelterId }: { shelterId: string }) => {
   const { data: reputation } = useSuspenseQuery(reviewQueries.reputation(shelterId));
   const { reviews, fetchNextPage, hasNextPage, isFetchingNextPage } = useShelterReviews(shelterId);
+  const { user } = useCurrentUser();
+  const { revise, revising, remove } = useReviewActions();
+  const overlay = useOverlay();
+
+  const editReview = (review: Review) =>
+    overlay.open(({ close }) => (
+      <ReviewEditDialog
+        review={review}
+        submitting={revising}
+        onConfirm={(input) => revise(review.id, input)}
+        onClose={close}
+      />
+    ));
+
+  const deleteReview = (review: Review) =>
+    overlay.open(({ close }) => (
+      <ConfirmDialog
+        open
+        onClose={close}
+        title="후기를 삭제할까요?"
+        description="삭제한 후기는 되돌릴 수 없어요."
+        confirmLabel="삭제하기"
+        confirmColor="error"
+        onConfirm={() => remove(review.id)}
+      />
+    ));
 
   return (
     <div {...stylex.props(styles.stack)}>
@@ -74,7 +126,15 @@ export const ReviewsTab = ({ shelterId }: { shelterId: string }) => {
       {reviews.length === 0 ? (
         <EmptyState message="아직 등록된 후기가 없어요." />
       ) : (
-        reviews.map((review) => <ReviewCard key={review.id} review={review} />)
+        reviews.map((review) => (
+          <ReviewCard
+            key={review.id}
+            review={review}
+            mine={review.authorId === user?.id}
+            onEdit={() => editReview(review)}
+            onDelete={() => deleteReview(review)}
+          />
+        ))
       )}
 
       {hasNextPage && (

--- a/apps/hobom-angel/src/features/volunteer-feed/ui/PostDetailModal.styles.ts
+++ b/apps/hobom-angel/src/features/volunteer-feed/ui/PostDetailModal.styles.ts
@@ -20,7 +20,8 @@ export const styles = stylex.create({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "var(--hb-angel-green-deep)",
+    // Black letterbox behind contained photos, like a standard image viewer.
+    backgroundColor: "#000000",
     minWidth: 0,
     minHeight: 0,
     overflow: "hidden",

--- a/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/review.handlers.ts
@@ -14,6 +14,14 @@ interface ReviewRow {
 
 const REVIEWS: ReviewRow[] = [
   {
+    id: "review-mine",
+    authorId: "mock-user-1",
+    placementType: "ADOPTION",
+    rating: 5,
+    body: "저희 아이 입양하면서 정말 큰 도움을 받았어요. 근황도 종종 여쭤봐 주셔서 감사했습니다.",
+    createdAt: "2026-07-02T05:00:00.000Z",
+  },
+  {
     id: "review-1",
     authorId: "user-11",
     placementType: "ADOPTION",
@@ -109,5 +117,35 @@ export const reviewHandlers = [
     await request.json();
 
     return ok({ reviewId: `review-${REVIEWS.length + 1}` });
+  }),
+
+  // §04 — the author edits their own review (rating + body).
+  http.patch(mockUrl("/reviews/:reviewId"), async ({ params, request }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    const row = REVIEWS.find((review) => review.id === params.reviewId);
+    const body = (await request.json()) as { rating: number; body: string };
+
+    if (row) {
+      row.rating = body.rating;
+      row.body = body.body;
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // §04 — delete a review (author or operator).
+  http.delete(mockUrl("/reviews/:reviewId"), ({ params }) => {
+    if (!mockSession.isActive()) {
+      return HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+    }
+
+    const index = REVIEWS.findIndex((review) => review.id === params.reviewId);
+
+    if (index >= 0) REVIEWS.splice(index, 1);
+
+    return new HttpResponse(null, { status: 204 });
   }),
 ];


### PR DESCRIPTION
## What
Reviews could be written but not managed. The shelter microsite **후기 tab** now shows **수정 / 삭제** on the viewer's own review cards (matched by `authorId`):
- **Edit** opens a prefilled rating + body dialog → `PATCH /reviews/:id`.
- **Delete** confirms first → `DELETE /reviews/:id`.
- Both invalidate the review list + reputation so the summary and cards refresh.

Also (per feedback) the **post-detail image pane** background is now **black**, so contained photos letterbox like a standard image viewer instead of sitting on green.

## Structure
- `entities/review` — `reviseReview` / `deleteReview` + `reviewMutations.revise/remove` + `ReviseReviewInput`.
- `shelter-microsite` — `useReviewActions` hook + `ReviewEditDialog`; owner actions wired into the review cards.
- MSW — `PATCH` / `DELETE /reviews/:id` handlers and a seeded own review.

## Verify
Backed by existing endpoints (no backend work). typecheck, lint, the full e2e suite (63), and the build pass. Adds an e2e that edits then deletes the viewer's own review.