### PR TITLE
Add animal 1:1 inquiries with a shelter message thread

### DIFF
--- a/apps/hobom-angel/e2e/inquiry.spec.ts
+++ b/apps/hobom-angel/e2e/inquiry.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const login = async (page: Page) => {
+  await page.goto("./");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await page.getByPlaceholder("hobom@example.com").fill("hobom@example.com");
+  await page.getByPlaceholder("••••••••").fill("secret123");
+  await page.getByRole("button", { name: "로그인" }).click();
+  await expect(page.getByText("봄이네님")).toBeVisible();
+};
+
+test.describe("§02 shelter inquiry", () => {
+  test("opens an inquiry from an animal and exchanges messages", async ({ page }) => {
+    await login(page);
+    await page.goto("animals/animal-1");
+
+    // Start an inquiry from the sticky apply panel.
+    await page.getByRole("button", { name: "보호소에 문의하기" }).click();
+    await expect(page.getByRole("heading", { name: "보호소에 문의하기" })).toBeVisible();
+
+    const first = "이 아이는 산책을 좋아하나요? 방문 상담도 가능할까요?";
+    await page
+      .getByPlaceholder("예: 이 아이는 아이들과 잘 지내나요? 방문 상담도 가능할까요?")
+      .fill(first);
+    await page.getByRole("button", { name: "문의 보내기" }).click();
+
+    // Lands in the new thread with the first message shown.
+    await expect(page).toHaveURL(/\/inquiries\/inquiry-\d+$/);
+    await expect(page.getByText(first)).toBeVisible();
+
+    // Post a follow-up; it appears in the thread.
+    const reply = "감사합니다. 이번 주말에 방문할게요.";
+    await page.getByPlaceholder("메시지를 입력하세요").fill(reply);
+    await page.getByRole("button", { name: "보내기" }).click();
+    await expect(page.getByText(reply)).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/inquiry-thread.png", fullPage: true });
+
+    // The inquiry surfaces in 내 문의.
+    await page.getByRole("link", { name: "문의 목록으로" }).click();
+    await expect(page).toHaveURL(/\/inquiries$/);
+    await expect(page.getByRole("heading", { name: "내 문의" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /문의/ }).first()).toBeVisible();
+
+    await page.screenshot({ path: "e2e-artifacts/my-inquiries.png", fullPage: true });
+  });
+
+  test("reaches 내 문의 from the my-page activity list", async ({ page }) => {
+    await login(page);
+    await page.goto("my");
+
+    await page.getByRole("link", { name: "내 문의" }).click();
+    await expect(page).toHaveURL(/\/inquiries$/);
+    await expect(page.getByRole("heading", { name: "내 문의" })).toBeVisible();
+  });
+});

--- a/apps/hobom-angel/src/apps/ui/AppRouter.tsx
+++ b/apps/hobom-angel/src/apps/ui/AppRouter.tsx
@@ -73,6 +73,12 @@ const MyPage = lazy(() => import("@/pages/my").then((module) => ({ default: modu
 const ApplicationsPage = lazy(() =>
   import("@/pages/applications").then((module) => ({ default: module.ApplicationsPage })),
 );
+const InquiriesPage = lazy(() =>
+  import("@/pages/inquiries").then((module) => ({ default: module.InquiriesPage })),
+);
+const InquiryThreadPage = lazy(() =>
+  import("@/pages/inquiry-thread").then((module) => ({ default: module.InquiryThreadPage })),
+);
 const ConsoleAnimalsPage = lazy(() =>
   import("@/pages/console-animals").then((module) => ({ default: module.ConsoleAnimalsPage })),
 );
@@ -143,6 +149,8 @@ export const AppRouter = () => {
             <Route path={ROUTES.VOLUNTEER_CERTIFICATES} element={<VolunteerCertificatesPage />} />
             <Route path={ROUTES.FAVORITES} element={<FavoritesPage />} />
             <Route path={ROUTES.APPLICATIONS} element={<ApplicationsPage />} />
+            <Route path={ROUTES.INQUIRIES} element={<InquiriesPage />} />
+            <Route path={ROUTES.INQUIRY_DETAIL} element={<InquiryThreadPage />} />
             <Route path={ROUTES.MY} element={<MyPage />} />
             </Route>
           </Route>

--- a/apps/hobom-angel/src/entities/conversation/api/conversation.api.ts
+++ b/apps/hobom-angel/src/entities/conversation/api/conversation.api.ts
@@ -1,0 +1,32 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { messagesSchema, postMessageResultSchema } from "./conversation.schema";
+import type { PostMessageResult } from "./conversation.type";
+import type { Message, MessageSubjectType } from "../model/conversation.model";
+
+const parseThread = parseResponse(
+  messagesSchema,
+  "GET /conversations/:subjectType/:subjectRef/messages",
+);
+const parsePosted = parseResponse(
+  postMessageResultSchema,
+  "POST /conversations/:subjectType/:subjectRef/messages",
+);
+
+const threadPath = (subjectType: MessageSubjectType, subjectRef: string) =>
+  `/conversations/${subjectType}/${subjectRef}/messages`;
+
+/** The messages of one conversation, oldest first. */
+export const getMessages = (
+  subjectType: MessageSubjectType,
+  subjectRef: string,
+  signal?: AbortSignal,
+): Promise<Message[]> =>
+  httpClient.get(threadPath(subjectType, subjectRef), { signal }).then(parseThread);
+
+/** Append a message to a conversation (applicant or shelter staff). */
+export const postMessage = (
+  subjectType: MessageSubjectType,
+  subjectRef: string,
+  body: string,
+): Promise<PostMessageResult> =>
+  httpClient.post(threadPath(subjectType, subjectRef), { body }).then(parsePosted);

--- a/apps/hobom-angel/src/entities/conversation/api/conversation.mutations.ts
+++ b/apps/hobom-angel/src/entities/conversation/api/conversation.mutations.ts
@@ -1,0 +1,11 @@
+import { mutationOptions } from "hobom-data";
+import { postMessage } from "./conversation.api";
+import type { MessageSubjectType } from "../model/conversation.model";
+
+export const conversationMutations = {
+  post: () =>
+    mutationOptions({
+      mutationFn: (vars: { subjectType: MessageSubjectType; subjectRef: string; body: string }) =>
+        postMessage(vars.subjectType, vars.subjectRef, vars.body),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/conversation/api/conversation.queries.ts
+++ b/apps/hobom-angel/src/entities/conversation/api/conversation.queries.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from "hobom-data";
+import { getMessages } from "./conversation.api";
+import type { MessageSubjectType } from "../model/conversation.model";
+
+export const conversationQueries = {
+  all: () => ["conversations"] as const,
+
+  thread: (subjectType: MessageSubjectType, subjectRef: string) =>
+    queryOptions({
+      queryKey: [...conversationQueries.all(), subjectType, subjectRef] as const,
+      queryFn: ({ signal }) => getMessages(subjectType, subjectRef, signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/conversation/api/conversation.schema.ts
+++ b/apps/hobom-angel/src/entities/conversation/api/conversation.schema.ts
@@ -1,0 +1,21 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { PostMessageResult, RawMessage } from "./conversation.type";
+
+const SENDER_ROLE = ["APPLICANT", "SHELTER"] as const;
+
+/** `GET /conversations/:subjectType/:subjectRef/messages` — the thread. */
+export const messagesSchema: Schema<RawMessage[]> = HoBomSchema.array(
+  HoBomSchema.object({
+    id: HoBomSchema.string(),
+    senderId: HoBomSchema.string(),
+    senderRole: HoBomSchema.enum(SENDER_ROLE),
+    body: HoBomSchema.string(),
+    sentAt: HoBomSchema.string().nullable(),
+  }),
+);
+
+/** `POST /conversations/:subjectType/:subjectRef/messages` — the new message id. */
+export const postMessageResultSchema: Schema<PostMessageResult> = HoBomSchema.object({
+  messageId: HoBomSchema.string(),
+});

--- a/apps/hobom-angel/src/entities/conversation/api/conversation.type.ts
+++ b/apps/hobom-angel/src/entities/conversation/api/conversation.type.ts
@@ -1,0 +1,15 @@
+import type { MessageSenderRole } from "../model/conversation.model";
+
+/** `GET /conversations/:subjectType/:subjectRef/messages` item. */
+export interface RawMessage {
+  id: string;
+  senderId: string;
+  senderRole: MessageSenderRole;
+  body: string;
+  sentAt: string | null;
+}
+
+/** `POST /conversations/:subjectType/:subjectRef/messages` response. */
+export interface PostMessageResult {
+  messageId: string;
+}

--- a/apps/hobom-angel/src/entities/conversation/index.ts
+++ b/apps/hobom-angel/src/entities/conversation/index.ts
@@ -1,0 +1,4 @@
+export { conversationQueries } from "./api/conversation.queries";
+export { conversationMutations } from "./api/conversation.mutations";
+export { SENDER_LABEL } from "./model/conversation.model";
+export type { Message, MessageSenderRole, MessageSubjectType } from "./model/conversation.model";

--- a/apps/hobom-angel/src/entities/conversation/model/conversation.model.ts
+++ b/apps/hobom-angel/src/entities/conversation/model/conversation.model.ts
@@ -1,0 +1,20 @@
+/** What a message thread is about. Each subject maps to its participants on the
+ *  backend, so messaging stays ignorant of inquiry/adoption/foster internals. */
+export type MessageSubjectType = "INQUIRY" | "ADOPTION" | "FOSTER";
+
+/** Which side of the conversation a message came from. */
+export type MessageSenderRole = "APPLICANT" | "SHELTER";
+
+/** One message in a thread. */
+export interface Message {
+  id: string;
+  senderId: string;
+  senderRole: MessageSenderRole;
+  body: string;
+  sentAt: string | null;
+}
+
+export const SENDER_LABEL: Record<MessageSenderRole, string> = {
+  APPLICANT: "나",
+  SHELTER: "보호소",
+};

--- a/apps/hobom-angel/src/entities/inquiry/api/inquiry.api.ts
+++ b/apps/hobom-angel/src/entities/inquiry/api/inquiry.api.ts
@@ -1,0 +1,26 @@
+import { httpClient, parseResponse } from "@/shared/api";
+import { toQueryString } from "@/shared/lib";
+import { inquiriesPageSchema, startInquiryResultSchema } from "./inquiry.schema";
+import type { StartInquiryInput, StartInquiryResult } from "./inquiry.type";
+import type { InquiryPage } from "../model/inquiry.model";
+
+const parsePage = parseResponse(inquiriesPageSchema, "GET /me/inquiries");
+const parseStarted = parseResponse(startInquiryResultSchema, "POST /animals/:animalId/inquiries");
+
+/** Open an inquiry about an animal, seeding it with the first message. */
+export const startInquiry = (
+  animalId: string,
+  input: StartInquiryInput,
+): Promise<StartInquiryResult> =>
+  httpClient.post(`/animals/${animalId}/inquiries`, input).then(parseStarted);
+
+/** The viewer's own inquiries, newest first (cursor page). */
+export const getMyInquiries = (cursor?: string, signal?: AbortSignal): Promise<InquiryPage> =>
+  httpClient
+    .get(`/me/inquiries${toQueryString({ cursor, limit: 20 })}`, { signal })
+    .then(parsePage)
+    .then((page) => ({
+      inquiries: page.items,
+      nextCursor: page.nextCursor,
+      hasNext: page.hasNext,
+    }));

--- a/apps/hobom-angel/src/entities/inquiry/api/inquiry.mutations.ts
+++ b/apps/hobom-angel/src/entities/inquiry/api/inquiry.mutations.ts
@@ -1,0 +1,11 @@
+import { mutationOptions } from "hobom-data";
+import { startInquiry } from "./inquiry.api";
+import type { StartInquiryInput } from "./inquiry.type";
+
+export const inquiryMutations = {
+  start: () =>
+    mutationOptions({
+      mutationFn: (vars: { animalId: string; input: StartInquiryInput }) =>
+        startInquiry(vars.animalId, vars.input),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/inquiry/api/inquiry.queries.ts
+++ b/apps/hobom-angel/src/entities/inquiry/api/inquiry.queries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from "hobom-data";
+import { getMyInquiries } from "./inquiry.api";
+
+export const inquiryQueries = {
+  all: () => ["inquiries"] as const,
+
+  mine: () =>
+    queryOptions({
+      queryKey: [...inquiryQueries.all(), "mine"] as const,
+      queryFn: ({ signal }) => getMyInquiries(undefined, signal),
+    }),
+} as const;

--- a/apps/hobom-angel/src/entities/inquiry/api/inquiry.schema.ts
+++ b/apps/hobom-angel/src/entities/inquiry/api/inquiry.schema.ts
@@ -1,0 +1,23 @@
+import { HoBomSchema } from "hobom-schema";
+import type { Schema } from "hobom-schema";
+import type { RawInquiriesPage, StartInquiryResult } from "./inquiry.type";
+
+const inquiryShape = {
+  inquiryId: HoBomSchema.string(),
+  shelterId: HoBomSchema.string(),
+  inquirerId: HoBomSchema.string(),
+  animalId: HoBomSchema.string().nullable(),
+  createdAt: HoBomSchema.string().nullable(),
+};
+
+/** `GET /me/inquiries` — a cursor page of the viewer's inquiries. */
+export const inquiriesPageSchema: Schema<RawInquiriesPage> = HoBomSchema.object({
+  items: HoBomSchema.array(HoBomSchema.object(inquiryShape)),
+  nextCursor: HoBomSchema.string().nullable(),
+  hasNext: HoBomSchema.boolean(),
+});
+
+/** `POST /animals/:animalId/inquiries` — the new inquiry id. */
+export const startInquiryResultSchema: Schema<StartInquiryResult> = HoBomSchema.object({
+  inquiryId: HoBomSchema.string(),
+});

--- a/apps/hobom-angel/src/entities/inquiry/api/inquiry.type.ts
+++ b/apps/hobom-angel/src/entities/inquiry/api/inquiry.type.ts
@@ -1,0 +1,23 @@
+export interface RawInquiry {
+  inquiryId: string;
+  shelterId: string;
+  inquirerId: string;
+  animalId: string | null;
+  createdAt: string | null;
+}
+
+export interface RawInquiriesPage {
+  items: RawInquiry[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+/** `POST /animals/:animalId/inquiries` request — the first message. */
+export interface StartInquiryInput {
+  message: string;
+}
+
+/** `POST /animals/:animalId/inquiries` response. */
+export interface StartInquiryResult {
+  inquiryId: string;
+}

--- a/apps/hobom-angel/src/entities/inquiry/index.ts
+++ b/apps/hobom-angel/src/entities/inquiry/index.ts
@@ -1,0 +1,4 @@
+export { inquiryQueries } from "./api/inquiry.queries";
+export { inquiryMutations } from "./api/inquiry.mutations";
+export type { Inquiry, InquiryPage } from "./model/inquiry.model";
+export type { StartInquiryInput } from "./api/inquiry.type";

--- a/apps/hobom-angel/src/entities/inquiry/model/inquiry.model.ts
+++ b/apps/hobom-angel/src/entities/inquiry/model/inquiry.model.ts
@@ -1,0 +1,17 @@
+/** A general shelter inquiry (문의) opened from an animal. The thread of messages
+ *  lives under the conversation entity (subjectType INQUIRY, subjectRef inquiryId). */
+export interface Inquiry {
+  inquiryId: string;
+  shelterId: string;
+  inquirerId: string;
+  /** The animal the inquiry is about — null for a shelter-level inquiry. */
+  animalId: string | null;
+  createdAt: string | null;
+}
+
+/** A cursor page of the viewer's inquiries. */
+export interface InquiryPage {
+  inquiries: Inquiry[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}

--- a/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
+++ b/apps/hobom-angel/src/features/account/ui/MyProfile.tsx
@@ -88,6 +88,10 @@ export const MyProfile = ({ onLogout }: MyProfileProps) => {
             찜한 동물·팔로우
             <ChevronRight fontSize="small" {...stylex.props(styles.chevron)} />
           </Link>
+          <Link to={ROUTES.INQUIRIES} {...stylex.props(styles.actionRow)}>
+            내 문의
+            <ChevronRight fontSize="small" {...stylex.props(styles.chevron)} />
+          </Link>
           <Link to={ROUTES.VOLUNTEER_CERTIFICATES} {...stylex.props(styles.actionRow)}>
             봉사 확인서
             <ChevronRight fontSize="small" {...stylex.props(styles.chevron)} />

--- a/apps/hobom-angel/src/features/animal-detail/model/useStartInquiry.ts
+++ b/apps/hobom-angel/src/features/animal-detail/model/useStartInquiry.ts
@@ -1,0 +1,29 @@
+import { useDataLot, useMutation } from "hobom-data";
+import { useNavigate } from "react-router";
+import { inquiryMutations, inquiryQueries } from "@/entities/inquiry";
+import { inquiryPath } from "@/shared/config";
+import { useToast } from "@/shared/model";
+
+/** Opens an inquiry about an animal and, on success, drops the viewer into the
+ *  new message thread. */
+export const useStartInquiry = (animalId: string, onDone: () => void) => {
+  const navigate = useNavigate();
+  const dataLot = useDataLot();
+  const { openErrorToast } = useToast();
+
+  const mutation = useMutation({
+    ...inquiryMutations.start(),
+    onSuccess: (result) => {
+      void dataLot.invalidateQueries({ queryKey: inquiryQueries.all() });
+      onDone();
+      void navigate(inquiryPath(result.inquiryId));
+    },
+    onError: (error: Error) =>
+      openErrorToast({ message: error.message || "문의 전송에 실패했어요." }),
+  });
+
+  return {
+    start: (message: string) => mutation.mutate({ animalId, input: { message } }),
+    starting: mutation.isPending,
+  };
+};

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.spec.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from "@testing-library/react";
+import { OverlayProvider } from "hobom-design-system";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import type { AnimalDetail, PlacementType } from "@/entities/animal";
@@ -12,7 +13,9 @@ const renderCard = (
 ) =>
   render(
     <MemoryRouter>
-      <ApplyCard animal={detail} favorited={favorited} onToggleFavorite={onToggleFavorite} />
+      <OverlayProvider>
+        <ApplyCard animal={detail} favorited={favorited} onToggleFavorite={onToggleFavorite} />
+      </OverlayProvider>
     </MemoryRouter>,
   );
 

--- a/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/ApplyCard.tsx
@@ -4,9 +4,10 @@ import { Hb } from "hobom-design-system";
 import { ChevronRight, Favorite, FavoriteBorder, LocationOnOutlined } from "hobom-design-system/icons";
 import { SEX_LABEL, SIZE_LABEL, STATUS_LABEL, formatAge } from "@/entities/animal";
 import { applyPath, fosterApplyPath, shelterPath } from "@/shared/config";
-import { useToast } from "@/shared/model";
+import { useOverlay } from "@/shared/model";
 import type { AnimalDetail } from "@/entities/animal";
 import { applyCta } from "../lib/apply-cta.lib";
+import { InquiryDialog } from "./InquiryDialog";
 import { styles } from "./ApplyCard.styles";
 
 interface ApplyCardProps {
@@ -24,13 +25,11 @@ const STATUS_COLOR = {
   반환: "default",
 } as const;
 
-const COMING_SOON = "곧 제공될 예정이에요.";
-
 /** Sticky application panel with status-branched CTAs (§02). Apply and foster
- *  open their funnels; inquiry is a placeholder until inquiry threads land. */
+ *  open their funnels; inquiry opens a shelter message thread. */
 export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProps) => {
   const navigate = useNavigate();
-  const { openWarnToast } = useToast();
+  const overlay = useOverlay();
 
   const cta = applyCta(animal.status, animal.eligiblePlacements);
   const statusLabel = STATUS_LABEL[animal.status];
@@ -45,7 +44,10 @@ export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProp
     animal.health.microchipId ? "마이크로칩" : null,
   ].filter((badge): badge is string => badge !== null);
 
-  const notReady = () => openWarnToast({ message: COMING_SOON });
+  const openInquiry = () =>
+    overlay.open(({ close }) => (
+      <InquiryDialog animalId={animal.id} animalName={animal.name} onClose={close} />
+    ));
 
   return (
     <aside {...stylex.props(styles.root)}>
@@ -113,7 +115,7 @@ export const ApplyCard = ({ animal, favorited, onToggleFavorite }: ApplyCardProp
             임시보호 신청
           </Hb.Button>
         )}
-        <button type="button" {...stylex.props(styles.inquiry)} onClick={notReady}>
+        <button type="button" {...stylex.props(styles.inquiry)} onClick={openInquiry}>
           보호소에 문의하기
           <ChevronRight fontSize="small" />
         </button>

--- a/apps/hobom-angel/src/features/animal-detail/ui/InquiryDialog.styles.ts
+++ b/apps/hobom-angel/src/features/animal-detail/ui/InquiryDialog.styles.ts
@@ -1,0 +1,11 @@
+import * as stylex from "@stylexjs/stylex";
+
+export const styles = stylex.create({
+  intro: {
+    margin: 0,
+    marginBottom: 12,
+    fontSize: "0.9375rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-secondary)",
+  },
+});

--- a/apps/hobom-angel/src/features/animal-detail/ui/InquiryDialog.tsx
+++ b/apps/hobom-angel/src/features/animal-detail/ui/InquiryDialog.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { useStartInquiry } from "../model/useStartInquiry";
+import { styles } from "./InquiryDialog.styles";
+
+interface InquiryDialogProps {
+  animalId: string;
+  animalName: string;
+  onClose: () => void;
+}
+
+/** Compose the first message of a shelter inquiry about an animal. Sending opens
+ *  the thread and navigates there. */
+export const InquiryDialog = ({ animalId, animalName, onClose }: InquiryDialogProps) => {
+  const [message, setMessage] = useState("");
+  const { start, starting } = useStartInquiry(animalId, onClose);
+
+  const canSubmit = message.trim().length > 0 && !starting;
+
+  const onSubmit = () => {
+    if (!canSubmit) return;
+
+    start(message.trim());
+  };
+
+  return (
+    <Hb.Dialog.Root open onClose={onClose} size="sm">
+      <Hb.Dialog.Title>보호소에 문의하기</Hb.Dialog.Title>
+      <Hb.Dialog.Content dividers>
+        <p {...stylex.props(styles.intro)}>
+          {animalName}에 대해 궁금한 점을 남겨주세요. 보호소가 확인 후 답변해요.
+        </p>
+        <Hb.TextField
+          placeholder="예: 이 아이는 아이들과 잘 지내나요? 방문 상담도 가능할까요?"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+          autoFocus
+        />
+      </Hb.Dialog.Content>
+      <Hb.Dialog.Actions>
+        <Hb.Button variant="ghost" onClick={onClose}>
+          취소
+        </Hb.Button>
+        <Hb.Button variant="primary" onClick={onSubmit} disabled={!canSubmit} loading={starting}>
+          문의 보내기
+        </Hb.Button>
+      </Hb.Dialog.Actions>
+    </Hb.Dialog.Root>
+  );
+};

--- a/apps/hobom-angel/src/features/inquiry-thread/index.ts
+++ b/apps/hobom-angel/src/features/inquiry-thread/index.ts
@@ -1,0 +1,1 @@
+export { InquiryThread } from "./ui/InquiryThread";

--- a/apps/hobom-angel/src/features/inquiry-thread/lib/format-message-time.lib.spec.ts
+++ b/apps/hobom-angel/src/features/inquiry-thread/lib/format-message-time.lib.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatMessageTime } from "./format-message-time.lib";
+
+describe("formatMessageTime", () => {
+  it("renders a Korean month/day and time", () => {
+    const out = formatMessageTime("2026-08-21T06:24:00.000Z");
+
+    // Locale output varies by runtime TZ, so assert on the stable pieces.
+    expect(out).toMatch(/8월/);
+    expect(out).toMatch(/\d/);
+  });
+
+  it("returns an empty string for a null timestamp", () => {
+    expect(formatMessageTime(null)).toBe("");
+  });
+});

--- a/apps/hobom-angel/src/features/inquiry-thread/lib/format-message-time.lib.ts
+++ b/apps/hobom-angel/src/features/inquiry-thread/lib/format-message-time.lib.ts
@@ -1,0 +1,11 @@
+/** Render a message timestamp as a short Korean date-time (빈 문자열 when unknown). */
+export const formatMessageTime = (iso: string | null): string => {
+  if (!iso) return "";
+
+  return new Date(iso).toLocaleString("ko-KR", {
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};

--- a/apps/hobom-angel/src/features/inquiry-thread/model/useInquiryThread.ts
+++ b/apps/hobom-angel/src/features/inquiry-thread/model/useInquiryThread.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { useDataLot, useMutation, useSuspenseQuery } from "hobom-data";
+import { conversationMutations, conversationQueries } from "@/entities/conversation";
+import { useToast } from "@/shared/model";
+
+/** Drives one inquiry's message thread: the loaded messages plus a draft the
+ *  viewer (the applicant) can send. Posting refreshes the thread in place. */
+export const useInquiryThread = (inquiryId: string) => {
+  const dataLot = useDataLot();
+  const { openErrorToast } = useToast();
+  const [draft, setDraft] = useState("");
+
+  const { data: messages } = useSuspenseQuery(conversationQueries.thread("INQUIRY", inquiryId));
+
+  const mutation = useMutation({
+    ...conversationMutations.post(),
+    onSuccess: () => {
+      setDraft("");
+      void dataLot.invalidateQueries({
+        queryKey: conversationQueries.thread("INQUIRY", inquiryId).queryKey,
+      });
+    },
+    onError: (error: Error) =>
+      openErrorToast({ message: error.message || "메시지 전송에 실패했어요." }),
+  });
+
+  const send = () => {
+    const body = draft.trim();
+
+    if (!body || mutation.isPending) return;
+
+    mutation.mutate({ subjectType: "INQUIRY", subjectRef: inquiryId, body });
+  };
+
+  return { messages, draft, setDraft, send, sending: mutation.isPending };
+};

--- a/apps/hobom-angel/src/features/inquiry-thread/ui/InquiryThread.styles.ts
+++ b/apps/hobom-angel/src/features/inquiry-thread/ui/InquiryThread.styles.ts
@@ -1,0 +1,128 @@
+import * as stylex from "@stylexjs/stylex";
+
+const REDUCE = "@media (prefers-reduced-motion: reduce)";
+
+const fadeUp = stylex.keyframes({
+  from: { opacity: 0, transform: "translateY(12px)" },
+  to: { opacity: 1, transform: "translateY(0)" },
+});
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 760,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 24,
+    paddingBottom: 32,
+    display: "flex",
+    flexDirection: "column",
+    gap: 20,
+    animationName: fadeUp,
+    animationDuration: "var(--hb-angel-dur-slow)",
+    animationTimingFunction: "var(--hb-angel-ease)",
+    animationFillMode: "both",
+    [REDUCE]: { animationName: "none" },
+  },
+  header: { display: "flex", alignItems: "center", gap: 12 },
+  back: {
+    flexShrink: 0,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 40,
+    height: 40,
+    borderRadius: "var(--hb-angel-radius-md)",
+    border: "1px solid var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    fontSize: "1.125rem",
+    textDecoration: "none",
+  },
+  titleBlock: { display: "flex", flexDirection: "column", gap: 4 },
+  kicker: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    fontSize: "0.6875rem",
+    fontWeight: 700,
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    color: "var(--hb-color-accent-dark)",
+  },
+  kickerDot: {
+    width: 6,
+    height: 6,
+    borderRadius: "50%",
+    backgroundColor: "var(--hb-angel-accent-warm)",
+  },
+  title: {
+    margin: 0,
+    fontSize: "1.375rem",
+    fontWeight: 700,
+    letterSpacing: "-0.015em",
+    color: "var(--hb-color-text-primary)",
+  },
+  // The scrollable message column.
+  thread: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 12,
+    minHeight: 320,
+    padding: "clamp(12px, 3vw, 20px)",
+    borderRadius: "var(--hb-angel-radius-card)",
+    border: "1px solid var(--hb-color-border)",
+    backgroundColor: "var(--hb-angel-surface-alt)",
+  },
+  empty: {
+    margin: "auto",
+    color: "var(--hb-color-text-secondary)",
+    fontSize: "0.9375rem",
+  },
+  row: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    maxWidth: "78%",
+  },
+  rowMine: { alignSelf: "flex-end", alignItems: "flex-end" },
+  rowTheirs: { alignSelf: "flex-start", alignItems: "flex-start" },
+  bubble: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    paddingInline: 14,
+    paddingBlock: 10,
+    borderRadius: "var(--hb-angel-radius-md)",
+    fontSize: "0.9375rem",
+    lineHeight: 1.5,
+    boxShadow: "var(--hb-angel-shadow-sm)",
+  },
+  bubbleMine: {
+    backgroundColor: "var(--hb-color-accent)",
+    color: "var(--hb-color-accent-contrast)",
+    borderEndEndRadius: 4,
+  },
+  bubbleTheirs: {
+    backgroundColor: "var(--hb-color-surface)",
+    color: "var(--hb-color-text-primary)",
+    border: "1px solid var(--hb-color-border)",
+    borderEndStartRadius: 4,
+  },
+  sender: {
+    fontSize: "0.75rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-secondary)",
+  },
+  body: { margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word" },
+  time: {
+    fontSize: "0.6875rem",
+    color: "var(--hb-color-text-disabled)",
+    paddingInline: 4,
+  },
+  // Composer pinned below the thread.
+  composer: {
+    display: "flex",
+    alignItems: "flex-end",
+    gap: 8,
+  },
+});

--- a/apps/hobom-angel/src/features/inquiry-thread/ui/InquiryThread.tsx
+++ b/apps/hobom-angel/src/features/inquiry-thread/ui/InquiryThread.tsx
@@ -1,0 +1,77 @@
+import { Link } from "react-router";
+import * as stylex from "@stylexjs/stylex";
+import { Hb } from "hobom-design-system";
+import { SENDER_LABEL } from "@/entities/conversation";
+import { ROUTES } from "@/shared/config";
+import { useInquiryThread } from "../model/useInquiryThread";
+import { formatMessageTime } from "../lib/format-message-time.lib";
+import { styles } from "./InquiryThread.styles";
+
+/** 보호소 문의 스레드 — the message conversation for one inquiry. The viewer is
+ *  the applicant, so their messages sit on the right; the shelter's on the left. */
+export const InquiryThread = ({ inquiryId }: { inquiryId: string }) => {
+  const { messages, draft, setDraft, send, sending } = useInquiryThread(inquiryId);
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <Link to={ROUTES.INQUIRIES} {...stylex.props(styles.back)} aria-label="문의 목록으로">
+          ←
+        </Link>
+        <div {...stylex.props(styles.titleBlock)}>
+          <span {...stylex.props(styles.kicker)}>
+            <span {...stylex.props(styles.kickerDot)} aria-hidden />
+            보호소 문의
+          </span>
+          <h1 {...stylex.props(styles.title)}>문의 대화</h1>
+        </div>
+      </header>
+
+      <div {...stylex.props(styles.thread)}>
+        {messages.length === 0 ? (
+          <p {...stylex.props(styles.empty)}>아직 주고받은 메시지가 없어요.</p>
+        ) : (
+          messages.map((message) => {
+            const mine = message.senderRole === "APPLICANT";
+
+            return (
+              <div
+                key={message.id}
+                {...stylex.props(styles.row, mine ? styles.rowMine : styles.rowTheirs)}
+              >
+                <div {...stylex.props(styles.bubble, mine ? styles.bubbleMine : styles.bubbleTheirs)}>
+                  {!mine && (
+                    <span {...stylex.props(styles.sender)}>{SENDER_LABEL[message.senderRole]}</span>
+                  )}
+                  <p {...stylex.props(styles.body)}>{message.body}</p>
+                </div>
+                <span {...stylex.props(styles.time)}>{formatMessageTime(message.sentAt)}</span>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <form
+        {...stylex.props(styles.composer)}
+        onSubmit={(event) => {
+          event.preventDefault();
+          send();
+        }}
+      >
+        <Hb.TextField
+          placeholder="메시지를 입력하세요"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          multiline
+          minRows={1}
+          maxRows={4}
+          fullWidth
+        />
+        <Hb.Button type="submit" variant="primary" disabled={!draft.trim()} loading={sending}>
+          보내기
+        </Hb.Button>
+      </form>
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/features/my-inquiries/index.ts
+++ b/apps/hobom-angel/src/features/my-inquiries/index.ts
@@ -1,0 +1,1 @@
+export { MyInquiries } from "./ui/MyInquiries";

--- a/apps/hobom-angel/src/features/my-inquiries/model/useMyInquiries.ts
+++ b/apps/hobom-angel/src/features/my-inquiries/model/useMyInquiries.ts
@@ -1,0 +1,26 @@
+import { useSuspenseQueries, useSuspenseQuery } from "hobom-data";
+import { animalQueries } from "@/entities/animal";
+import { inquiryQueries } from "@/entities/inquiry";
+import type { AnimalDetail } from "@/entities/animal";
+
+/** The viewer's inquiries, newest first, with each inquiry's animal hydrated for
+ *  its name and thumbnail. */
+export const useMyInquiries = () => {
+  const { data: page } = useSuspenseQuery(inquiryQueries.mine());
+  const inquiries = page.inquiries;
+
+  const animalIds = [
+    ...new Set(inquiries.map((inquiry) => inquiry.animalId).filter((id): id is string => id != null)),
+  ];
+  const animals = useSuspenseQueries({
+    queries: animalIds.map((id) => animalQueries.detail(id)),
+  });
+  const animalById = new Map<string, AnimalDetail>(
+    animals.map((result) => [result.data.id, result.data]),
+  );
+
+  return {
+    inquiries,
+    animal: (animalId: string | null) => (animalId ? animalById.get(animalId) : undefined),
+  };
+};

--- a/apps/hobom-angel/src/features/my-inquiries/ui/MyInquiries.styles.ts
+++ b/apps/hobom-angel/src/features/my-inquiries/ui/MyInquiries.styles.ts
@@ -1,0 +1,114 @@
+import * as stylex from "@stylexjs/stylex";
+
+const REDUCE = "@media (prefers-reduced-motion: reduce)";
+
+const fadeUp = stylex.keyframes({
+  from: { opacity: 0, transform: "translateY(12px)" },
+  to: { opacity: 1, transform: "translateY(0)" },
+});
+
+export const styles = stylex.create({
+  root: {
+    maxWidth: 760,
+    marginInline: "auto",
+    paddingInline: "clamp(16px, 4vw, 32px)",
+    paddingTop: 24,
+    paddingBottom: 48,
+    display: "flex",
+    flexDirection: "column",
+    gap: 20,
+    animationName: fadeUp,
+    animationDuration: "var(--hb-angel-dur-slow)",
+    animationTimingFunction: "var(--hb-angel-ease)",
+    animationFillMode: "both",
+    [REDUCE]: { animationName: "none" },
+  },
+  header: { display: "flex", flexDirection: "column", gap: 8 },
+  kicker: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    fontSize: "0.6875rem",
+    fontWeight: 700,
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    color: "var(--hb-color-accent-dark)",
+  },
+  kickerDot: {
+    width: 6,
+    height: 6,
+    borderRadius: "50%",
+    backgroundColor: "var(--hb-angel-accent-warm)",
+  },
+  title: {
+    margin: 0,
+    fontSize: "26px",
+    fontWeight: 700,
+    letterSpacing: "-0.015em",
+    color: "var(--hb-color-text-primary)",
+  },
+  subtitle: {
+    margin: 0,
+    fontSize: "1.0625rem",
+    lineHeight: 1.6,
+    color: "var(--hb-color-text-secondary)",
+  },
+  list: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  card: {
+    display: "flex",
+    alignItems: "center",
+    gap: 14,
+    padding: 12,
+    borderRadius: "var(--hb-angel-radius-card)",
+    border: "1px solid var(--hb-color-border)",
+    backgroundColor: "var(--hb-color-surface)",
+    textDecoration: "none",
+    transitionProperty: "transform, box-shadow",
+    transitionDuration: "var(--hb-angel-dur-fast)",
+    transitionTimingFunction: "var(--hb-angel-ease)",
+    transform: { default: "none", ":hover": "translateY(-2px)" },
+    boxShadow: { default: "var(--hb-angel-shadow-sm)", ":hover": "var(--hb-angel-shadow-md)" },
+    [REDUCE]: { transitionProperty: "none" },
+  },
+  thumb: {
+    flexShrink: 0,
+    width: 56,
+    height: 56,
+    borderRadius: "var(--hb-angel-radius-md)",
+    objectFit: "cover",
+  },
+  thumbFallback: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "var(--hb-angel-surface-alt)",
+    color: "var(--hb-color-text-disabled)",
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+  name: {
+    fontSize: "1rem",
+    fontWeight: 700,
+    color: "var(--hb-color-text-primary)",
+  },
+  date: {
+    fontSize: "0.8125rem",
+    color: "var(--hb-color-text-secondary)",
+  },
+  chevron: {
+    flexShrink: 0,
+    color: "var(--hb-color-text-disabled)",
+  },
+});

--- a/apps/hobom-angel/src/features/my-inquiries/ui/MyInquiries.tsx
+++ b/apps/hobom-angel/src/features/my-inquiries/ui/MyInquiries.tsx
@@ -1,0 +1,68 @@
+import { Link } from "react-router";
+import * as stylex from "@stylexjs/stylex";
+import { EmptyState } from "hobom-design-system";
+import { ChevronRight, MailOutline } from "hobom-design-system/icons";
+import { inquiryPath } from "@/shared/config";
+import { mediaUrl } from "@/shared/lib";
+import { useMyInquiries } from "../model/useMyInquiries";
+import { styles } from "./MyInquiries.styles";
+
+const formatDate = (iso: string | null) =>
+  iso ? new Date(iso).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" }) : "";
+
+/** 내 문의 — the viewer's shelter inquiries, each opening its message thread. */
+export const MyInquiries = () => {
+  const { inquiries, animal } = useMyInquiries();
+
+  return (
+    <div {...stylex.props(styles.root)}>
+      <header {...stylex.props(styles.header)}>
+        <span {...stylex.props(styles.kicker)}>
+          <span {...stylex.props(styles.kickerDot)} aria-hidden />
+          MY INQUIRIES
+        </span>
+        <h1 {...stylex.props(styles.title)}>내 문의</h1>
+        <p {...stylex.props(styles.subtitle)}>보호소에 남긴 문의와 답변을 확인해요.</p>
+      </header>
+
+      {inquiries.length === 0 ? (
+        <EmptyState
+          icon={
+            <MailOutline
+              style={{ fontSize: 40, color: "var(--hb-color-text-disabled)" }}
+            />
+          }
+          message="아직 문의한 내역이 없어요."
+        />
+      ) : (
+        <ul {...stylex.props(styles.list)}>
+          {inquiries.map((inquiry) => {
+            const pet = animal(inquiry.animalId);
+            const thumb = pet?.photos[0];
+
+            return (
+              <li key={inquiry.inquiryId}>
+                <Link to={inquiryPath(inquiry.inquiryId)} {...stylex.props(styles.card)}>
+                  {thumb ? (
+                    <img src={mediaUrl(thumb)} alt="" {...stylex.props(styles.thumb)} />
+                  ) : (
+                    <span {...stylex.props(styles.thumb, styles.thumbFallback)} aria-hidden>
+                      <MailOutline fontSize="small" />
+                    </span>
+                  )}
+                  <span {...stylex.props(styles.info)}>
+                    <span {...stylex.props(styles.name)}>
+                      {pet ? `${pet.name} 문의` : "보호소 문의"}
+                    </span>
+                    <span {...stylex.props(styles.date)}>{formatDate(inquiry.createdAt)}</span>
+                  </span>
+                  <ChevronRight fontSize="small" {...stylex.props(styles.chevron)} />
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/apps/hobom-angel/src/mocks/handlers/index.ts
+++ b/apps/hobom-angel/src/mocks/handlers/index.ts
@@ -14,6 +14,7 @@ import { fosterHandlers } from "./foster.handlers";
 import { applicationHandlers } from "./application.handlers";
 import { approvalHandlers } from "./approval.handlers";
 import { volunteerCertificateHandlers } from "./volunteer-certificate.handlers";
+import { inquiryHandlers } from "./inquiry.handlers";
 
 /** All MSW request handlers, aggregated per domain. Add new domains here. */
 export const handlers = [
@@ -33,4 +34,5 @@ export const handlers = [
   ...applicationHandlers,
   ...approvalHandlers,
   ...volunteerCertificateHandlers,
+  ...inquiryHandlers,
 ];

--- a/apps/hobom-angel/src/mocks/handlers/inquiry.handlers.ts
+++ b/apps/hobom-angel/src/mocks/handlers/inquiry.handlers.ts
@@ -1,0 +1,138 @@
+import { http, HttpResponse } from "msw";
+import { mockUrl } from "./mock-url";
+import { ok } from "./ok";
+import { mockSession } from "./mock-session";
+
+interface InquiryRow {
+  inquiryId: string;
+  shelterId: string;
+  inquirerId: string;
+  animalId: string | null;
+  createdAt: string | null;
+}
+
+interface MessageRow {
+  id: string;
+  senderId: string;
+  senderRole: "APPLICANT" | "SHELTER";
+  body: string;
+  sentAt: string | null;
+}
+
+const ME = "651f2a9c0b1d2e3f4a5b6c7d";
+const SHELTER_STAFF = "shelter-staff-1";
+
+// A seeded inquiry so the list and thread have content on first load.
+const INQUIRIES: InquiryRow[] = [
+  {
+    inquiryId: "inquiry-1",
+    shelterId: "shelter-1",
+    inquirerId: ME,
+    animalId: "animal-1",
+    createdAt: "2026-08-18T04:00:00.000Z",
+  },
+];
+
+const MESSAGES: Record<string, MessageRow[]> = {
+  "inquiry-1": [
+    {
+      id: "msg-1",
+      senderId: ME,
+      senderRole: "APPLICANT",
+      body: "이 아이는 아이들과 잘 지내나요? 방문 상담도 가능한지 궁금해요.",
+      sentAt: "2026-08-18T04:00:00.000Z",
+    },
+    {
+      id: "msg-2",
+      senderId: SHELTER_STAFF,
+      senderRole: "SHELTER",
+      body: "네, 아이들과도 잘 지내요. 주말 오후에 방문 상담 가능합니다.",
+      sentAt: "2026-08-18T05:12:00.000Z",
+    },
+  ],
+};
+
+let sequence = 100;
+const nextId = (prefix: string) => `${prefix}-${(sequence += 1)}`;
+
+const guard = () =>
+  mockSession.isActive() ? null : HttpResponse.json({ message: "인증이 필요해요." }, { status: 401 });
+
+/** §02/§05 consumer — animal inquiries and their message threads. */
+export const inquiryHandlers = [
+  // Open an inquiry from an animal, seeded with the first message.
+  http.post(mockUrl("/animals/:animalId/inquiries"), async ({ params, request }) => {
+    const denied = guard();
+
+    if (denied) return denied;
+
+    const body = (await request.json()) as { message: string };
+    const inquiryId = nextId("inquiry");
+
+    INQUIRIES.unshift({
+      inquiryId,
+      shelterId: "shelter-1",
+      inquirerId: ME,
+      animalId: typeof params.animalId === "string" ? params.animalId : null,
+      createdAt: "2026-08-19T00:00:00.000Z",
+    });
+    MESSAGES[inquiryId] = [
+      {
+        id: nextId("msg"),
+        senderId: ME,
+        senderRole: "APPLICANT",
+        body: body.message,
+        sentAt: "2026-08-19T00:00:00.000Z",
+      },
+    ];
+
+    return HttpResponse.json(
+      { success: true, items: { inquiryId }, message: "OK", timestamp: "2026-08-19T00:00:00.000Z" },
+      { status: 201 },
+    );
+  }),
+
+  // The viewer's inquiries (newest first).
+  http.get(mockUrl("/me/inquiries"), () => {
+    const denied = guard();
+
+    if (denied) return denied;
+
+    return ok({ items: INQUIRIES, nextCursor: null, hasNext: false });
+  }),
+
+  // One conversation's messages, oldest first.
+  http.get(mockUrl("/conversations/:subjectType/:subjectRef/messages"), ({ params }) => {
+    const denied = guard();
+
+    if (denied) return denied;
+
+    const ref = typeof params.subjectRef === "string" ? params.subjectRef : "";
+
+    return ok(MESSAGES[ref] ?? []);
+  }),
+
+  // Append a message to a conversation (the consumer is the applicant).
+  http.post(mockUrl("/conversations/:subjectType/:subjectRef/messages"), async ({ params, request }) => {
+    const denied = guard();
+
+    if (denied) return denied;
+
+    const ref = typeof params.subjectRef === "string" ? params.subjectRef : "";
+    const body = (await request.json()) as { body: string };
+    const messageId = nextId("msg");
+
+    (MESSAGES[ref] ??= []).push({
+      id: messageId,
+      senderId: ME,
+      senderRole: "APPLICANT",
+      body: body.body,
+      sentAt: "2026-08-19T01:00:00.000Z",
+    });
+
+    return HttpResponse.json(
+      { success: true, items: { messageId }, message: "OK", timestamp: "2026-08-19T01:00:00.000Z" },
+      { status: 201 },
+    );
+  }),
+];

--- a/apps/hobom-angel/src/pages/inquiries/index.ts
+++ b/apps/hobom-angel/src/pages/inquiries/index.ts
@@ -1,0 +1,1 @@
+export { InquiriesPage } from "./ui/InquiriesPage";

--- a/apps/hobom-angel/src/pages/inquiries/ui/InquiriesPage.tsx
+++ b/apps/hobom-angel/src/pages/inquiries/ui/InquiriesPage.tsx
@@ -1,0 +1,9 @@
+import { Suspense } from "react";
+import { MyInquiries } from "@/features/my-inquiries";
+import { LoadingState } from "@/shared/ui";
+
+export const InquiriesPage = () => (
+  <Suspense fallback={<LoadingState />}>
+    <MyInquiries />
+  </Suspense>
+);

--- a/apps/hobom-angel/src/pages/inquiry-thread/index.ts
+++ b/apps/hobom-angel/src/pages/inquiry-thread/index.ts
@@ -1,0 +1,1 @@
+export { InquiryThreadPage } from "./ui/InquiryThreadPage";

--- a/apps/hobom-angel/src/pages/inquiry-thread/ui/InquiryThreadPage.tsx
+++ b/apps/hobom-angel/src/pages/inquiry-thread/ui/InquiryThreadPage.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { useParams } from "react-router";
+import { InquiryThread } from "@/features/inquiry-thread";
+import { LoadingState, NotFoundState } from "@/shared/ui";
+
+export const InquiryThreadPage = () => {
+  const { inquiryId } = useParams<{ inquiryId: string }>();
+
+  if (!inquiryId) return <NotFoundState />;
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <InquiryThread inquiryId={inquiryId} />
+    </Suspense>
+  );
+};

--- a/apps/hobom-angel/src/shared/config/index.ts
+++ b/apps/hobom-angel/src/shared/config/index.ts
@@ -1,3 +1,10 @@
 export { env } from "./env";
-export { ROUTES, animalDetailPath, applyPath, fosterApplyPath, shelterPath } from "./routes";
+export {
+  ROUTES,
+  animalDetailPath,
+  applyPath,
+  fosterApplyPath,
+  shelterPath,
+  inquiryPath,
+} from "./routes";
 export { ROUTE_META, DEFAULT_META } from "./route-meta";

--- a/apps/hobom-angel/src/shared/config/routes.ts
+++ b/apps/hobom-angel/src/shared/config/routes.ts
@@ -16,6 +16,8 @@ export const ROUTES = {
   SHELTER_DETAIL: "/shelters/:shelterSlug",
   FAVORITES: "/favorites",
   APPLICATIONS: "/applications",
+  INQUIRIES: "/inquiries",
+  INQUIRY_DETAIL: "/inquiries/:inquiryId",
   MY: "/my",
 
   // Shelter staff console.
@@ -51,3 +53,6 @@ export const fosterApplyPath = (animalId: string): string => `/foster/apply/${an
 
 /** Build the concrete path to a shelter's microsite (by slug). */
 export const shelterPath = (shelterSlug: string): string => `/shelters/${shelterSlug}`;
+
+/** Build the concrete path to an inquiry's message thread. */
+export const inquiryPath = (inquiryId: string): string => `/inquiries/${inquiryId}`;

--- a/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
+++ b/apps/hobom-angel/src/widgets/global-nav/ui/GlobalFooter.tsx
@@ -28,7 +28,7 @@ const COLUMNS: { heading: string; links: FooterLink[] }[] = [
       { label: "공지사항" },
       { label: "자주 묻는 질문" },
       { label: "구조·학대 제보" },
-      { label: "1:1 문의" },
+      { label: "1:1 문의", to: ROUTES.INQUIRIES },
     ],
   },
   {


### PR DESCRIPTION
## What
Turn the animal detail 보호소에 문의하기 CTA into a real 1:1 inquiry backed by the new messaging APIs (previously a placeholder toast).

- **New `conversation` entity** — generic messaging over a subject (`GET`/`POST /conversations/:subjectType/:subjectRef/messages`). Kept subject-agnostic so ADOPTION/FOSTER threads can reuse it next.
- **New `inquiry` entity** — start an inquiry on an animal (`POST /animals/:animalId/inquiries`) and list your own (`GET /me/inquiries`).
- **Compose flow** — the CTA opens a dialog for the first message; sending starts the inquiry and navigates into its thread.
- **Thread view** (`/inquiries/:inquiryId`) — applicant/shelter message bubbles with a composer.
- **내 문의 list** (`/inquiries`) — the viewer's inquiries with the animal hydrated for name + thumbnail.
- **Entry points** — the dead footer `1:1 문의` link and a new my-page 내 문의 row now route here.
- MSW handlers cover the inquiry + messaging flow end-to-end.

## Verify
- `tsc` clean, `eslint --max-warnings=0` (incl. FSD boundaries), `build` clean.
- Unit: 169 passed (adds a `formatMessageTime` spec; `ApplyCard` spec now wraps `OverlayProvider`).
- e2e: 65 passed — new `inquiry.spec` starts an inquiry from an animal, exchanges messages, and reaches 내 문의 from both the thread back-link and the my-page row.